### PR TITLE
move aurora modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Cztack (pronounced "stack") is CZI's collection of Terraform modules. We use the
 
 ## Design Principles
 
-TODO
+More TODO here
+
+### Consistent Tagging
+
+We tag all applicable resources with 'owner', 'project', 'env', 'service' and 'managedBy'.
 
 ## Modules
 

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -4,6 +4,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| apply_immediately |  | string | `false` | no |
+| backtrack_window |  | string | `0` | no |
 | database_name |  | string | - | yes |
 | database_password |  | string | - | yes |
 | database_subnet_group |  | string | - | yes |
@@ -11,12 +13,14 @@
 | db_parameters |  | list | `<list>` | no |
 | env |  | string | - | yes |
 | ingress_cidr_blocks |  | list | - | yes |
-| instance_class |  | string | - | yes |
+| instance_class |  | string | `db.t2.small` | no |
 | instance_count |  | string | - | yes |
 | owner |  | string | - | yes |
 | project |  | string | - | yes |
+| publicly_accessible |  | string | `false` | no |
 | rds_cluster_parameters |  | list | `<list>` | no |
 | service |  | string | - | yes |
+| skip_final_snapshot |  | string | `false` | no |
 | vpc_id |  | string | - | yes |
 
 ## Outputs

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -15,6 +15,7 @@
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | `db.t2.small` | no |
 | instance_count |  | string | - | yes |
+| kms_key_id |  | string | `` | no |
 | owner |  | string | - | yes |
 | project |  | string | - | yes |
 | publicly_accessible |  | string | `false` | no |

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -1,0 +1,29 @@
+<!-- START -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| database_name |  | string | - | yes |
+| database_password |  | string | - | yes |
+| database_subnet_group |  | string | - | yes |
+| database_username |  | string | - | yes |
+| db_parameters |  | list | `<list>` | no |
+| env |  | string | - | yes |
+| ingress_cidr_blocks |  | list | - | yes |
+| instance_class |  | string | - | yes |
+| instance_count |  | string | - | yes |
+| owner |  | string | - | yes |
+| project |  | string | - | yes |
+| rds_cluster_parameters |  | list | `<list>` | no |
+| service |  | string | - | yes |
+| vpc_id |  | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| database_name |  |
+| endpoint |  |
+
+<!-- END -->

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -1,3 +1,34 @@
+# AWS Aurora MySQL
+
+This module will created a robust and secure [AWS Aurora](https://aws.amazon.com/rds/aurora/) MySQL cluster.
+
+A few things this module does for you–
+
+* ensures that data is encrypted at rest, either via an AWS managed key or if you supply `kms_key_id` a key that you control (via KMS).
+* tags all resources with our [consistent tags](../README.md#Consistent%20Tagging)
+* sets some sane defaults for database and cluster parameters
+
+A simple example:
+
+```hcl
+module "db" {
+  source = "github.com/chanzuckerberg/cztack//aws-aurora-mysql?ref=v0.12.0"
+
+  database_name         = "..."
+  database_subnet_group = "..."
+  database_password     = "..."
+  database_password     = "..."
+  
+  vpc_id = "..."
+
+  # Variables used for tagging
+  env     = "..."
+  project = "..."
+  service = "..."
+  owner   = "..."
+}
+```
+
 <!-- START -->
 
 ## Inputs
@@ -14,7 +45,7 @@
 | env |  | string | - | yes |
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | `db.t2.small` | no |
-| instance_count |  | string | - | yes |
+| instance_count |  | string | `1` | no |
 | kms_key_id |  | string | `` | no |
 | owner |  | string | - | yes |
 | project |  | string | - | yes |

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -24,5 +24,7 @@ module "aurora" {
   backtrack_window    = "${var.backtrack_window}"
   skip_final_snapshot = "${var.skip_final_snapshot}"
 
+  kms_key_id = "${var.kms_key_id}"
+
   apply_immediately = "${var.apply_immediately}"
 }

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,0 +1,91 @@
+locals {
+  name = "${var.project}-${var.env}-${var.service}"
+
+  tags = {
+    managedBy = "terraform"
+    Name      = "${local.name}"
+    project   = "${var.project}"
+    env       = "${var.env}"
+    service   = "${var.service}"
+    owner     = "${var.owner}"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.name}"
+  description = "Allow mysql inbound"
+
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["${var.ingress_cidr_blocks}"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = "${local.tags}"
+}
+
+# engine aurora-mysql means mysql 5.7 compat
+resource "aws_rds_cluster" "db" {
+  cluster_identifier                  = "${local.name}"
+  engine                              = "aurora-mysql"
+  database_name                       = "${var.database_name}"
+  master_username                     = "${var.database_username}"
+  master_password                     = "${var.database_password}"
+  vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
+  db_subnet_group_name                = "${var.database_subnet_group}"
+  storage_encrypted                   = true
+  iam_database_authentication_enabled = true
+  backup_retention_period             = 28
+  final_snapshot_identifier           = "${local.name}-snapshot"
+  skip_final_snapshot                 = "${var.skip_final_snapshot}"
+  backtrack_window                    = "${var.backtrack_window}"
+
+  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+
+  apply_immediately = "${var.apply_immediately}"
+
+  tags = "${local.tags}"
+}
+
+resource "aws_rds_cluster_instance" "db" {
+  count                   = "${var.instance_count}"
+  engine                  = "aurora-mysql"
+  identifier              = "${local.name}-${count.index}"
+  cluster_identifier      = "${aws_rds_cluster.db.id}"
+  instance_class          = "${var.instance_class}"
+  db_subnet_group_name    = "${var.database_subnet_group}"
+  db_parameter_group_name = "${aws_db_parameter_group.db.name}"
+
+  publicly_accessible          = "${var.publicly_accessible}"
+  performance_insights_enabled = true
+
+  apply_immediately = "${var.apply_immediately}"
+
+  tags = "${local.tags}"
+}
+
+resource "aws_rds_cluster_parameter_group" "db" {
+  name        = "${local.name}"
+  family      = "aurora-mysql5.7"
+  description = "RDS default cluster parameter group"
+
+  parameter = ["${var.rds_cluster_parameters}"]
+
+  tags = "${local.tags}"
+}
+
+resource "aws_db_parameter_group" "db" {
+  name   = "${local.name}"
+  family = "aurora-mysql5.7"
+
+  parameter = ["${var.db_parameters}"]
+
+  tags = "${local.tags}"
+}

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -17,6 +17,7 @@ module "aurora" {
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"
   publicly_accessible = "${var.publicly_accessible}"
+  port = 3306
 
   instance_class = "${var.instance_class}"
   instance_count = "${var.instance_count}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -17,7 +17,7 @@ module "aurora" {
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"
   publicly_accessible = "${var.publicly_accessible}"
-  port = 3306
+  port                = 3306
 
   instance_class = "${var.instance_class}"
   instance_count = "${var.instance_count}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -26,6 +26,7 @@ resource "aws_security_group" "rds" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["name"]
   }
 
   tags = "${local.tags}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,94 +1,28 @@
-locals {
-  name = "${var.project}-${var.env}-${var.service}"
-
-  tags = {
-    managedBy = "terraform"
-    Name      = "${local.name}"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
-  }
-}
-
-resource "aws_security_group" "rds" {
-  name        = "${local.name}"
-  description = "Allow mysql inbound"
-
-  vpc_id = "${var.vpc_id}"
-
-  ingress {
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    cidr_blocks = ["${var.ingress_cidr_blocks}"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-    ignore_changes = ["name"]
-  }
-
-  tags = "${local.tags}"
-}
-
-# engine aurora-mysql means mysql 5.7 compat
-resource "aws_rds_cluster" "db" {
+module "aurora" {
+  source = "../aws-aurora"
   engine = "aurora-mysql"
 
-  cluster_identifier                  = "${local.name}"
-  database_name                       = "${var.database_name}"
-  master_username                     = "${var.database_username}"
-  master_password                     = "${var.database_password}"
-  vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
-  db_subnet_group_name                = "${var.database_subnet_group}"
-  storage_encrypted                   = true
-  iam_database_authentication_enabled = true
-  backup_retention_period             = 28
-  final_snapshot_identifier           = "${local.name}-snapshot"
-  skip_final_snapshot                 = "${var.skip_final_snapshot}"
-  backtrack_window                    = "${var.backtrack_window}"
+  project = "${var.project}"
+  env     = "${var.env}"
+  service = "${var.service}"
+  owner   = "${var.owner}"
 
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  database_name          = "${var.database_name}"
+  database_subnet_group  = "${var.database_subnet_group}"
+  database_password      = "${var.database_password}"
+  database_username      = "${var.database_username}"
+  db_parameters          = "${var.db_parameters}"
+  rds_cluster_parameters = "${var.rds_cluster_parameters}"
 
-  apply_immediately = "${var.apply_immediately}"
+  ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
+  vpc_id              = "${var.vpc_id}"
+  publicly_accessible = "${var.publicly_accessible}"
 
-  tags = "${local.tags}"
-}
+  instance_class = "${var.instance_class}"
+  instance_count = "${var.instance_count}"
 
-resource "aws_rds_cluster_instance" "db" {
-  engine = "aurora-mysql"
-
-  count                   = "${var.instance_count}"
-  identifier              = "${local.name}-${count.index}"
-  cluster_identifier      = "${aws_rds_cluster.db.id}"
-  instance_class          = "${var.instance_class}"
-  db_subnet_group_name    = "${var.database_subnet_group}"
-  db_parameter_group_name = "${aws_db_parameter_group.db.name}"
-
-  publicly_accessible          = "${var.publicly_accessible}"
-  performance_insights_enabled = true
+  backtrack_window    = "${var.backtrack_window}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
 
   apply_immediately = "${var.apply_immediately}"
-
-  tags = "${local.tags}"
-}
-
-resource "aws_rds_cluster_parameter_group" "db" {
-  name        = "${local.name}"
-  family      = "aurora-mysql5.7"
-  description = "RDS default cluster parameter group"
-
-  parameter = ["${var.rds_cluster_parameters}"]
-
-  tags = "${local.tags}"
-}
-
-resource "aws_db_parameter_group" "db" {
-  name   = "${local.name}"
-  family = "aurora-mysql5.7"
-
-  parameter = ["${var.db_parameters}"]
-
-  tags = "${local.tags}"
 }

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestAWSAuroraMysql(t *testing.T) {
+	options := &terraform.Options{
+		TerraformDir: ".",
+	}
+	terraform.Init(t, options)
+}

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -1,7 +1,7 @@
 output "database_name" {
-  value = "${aws_rds_cluster.db.database_name}"
+  value = "${module.aurora.database_name}"
 }
 
 output "endpoint" {
-  value = "${aws_rds_cluster.db.endpoint}"
+  value = "${module.aurora.endpoint}"
 }

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -1,0 +1,7 @@
+output "database_name" {
+  value = "${aws_rds_cluster.db.database_name}"
+}
+
+output "endpoint" {
+  value = "${aws_rds_cluster.db.endpoint}"
+}

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -68,13 +68,13 @@ variable "rds_cluster_parameters" {
 
   default = [
     {
-      name  = "character_set_server"
-      value = "utf8"
+      name         = "character_set_server"
+      value        = "utf8"
       apply_method = "pending-reboot"
     },
     {
-      name  = "character_set_client"
-      value = "utf8"
+      name         = "character_set_client"
+      value        = "utf8"
       apply_method = "pending-reboot"
     },
   ]
@@ -85,28 +85,28 @@ variable "db_parameters" {
 
   default = [
     {
-      name  = "general_log"
-      value = 1
+      name         = "general_log"
+      value        = 1
       apply_method = "pending-reboot"
     },
     {
-      name  = "slow_query_log"
-      value = "1"
+      name         = "slow_query_log"
+      value        = "1"
       apply_method = "pending-reboot"
     },
     {
-      name  = "long_query_time"
-      value = "0"
+      name         = "long_query_time"
+      value        = "0"
       apply_method = "pending-reboot"
     },
     {
-      name  = "log_output"
-      value = "file"
+      name         = "log_output"
+      value        = "file"
       apply_method = "pending-reboot"
     },
     {
-      name  = "log_queries_not_using_indexes"
-      value = "1"
+      name         = "log_queries_not_using_indexes"
+      value        = "1"
       apply_method = "pending-reboot"
     },
   ]

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -29,6 +29,7 @@ variable "instance_class" {
 
 variable "instance_count" {
   type = "string"
+  default = 1
 }
 
 variable "owner" {

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -70,10 +70,12 @@ variable "rds_cluster_parameters" {
     {
       name  = "character_set_server"
       value = "utf8"
+      apply_method = "pending-reboot"
     },
     {
       name  = "character_set_client"
       value = "utf8"
+      apply_method = "pending-reboot"
     },
   ]
 }

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -96,7 +96,7 @@ variable "db_parameters" {
     },
     {
       name  = "log_output"
-      value = "FILE"
+      value = "file"
     },
     {
       name  = "log_queries_not_using_indexes"

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -1,0 +1,106 @@
+variable "database_name" {
+  type = "string"
+}
+
+variable "database_subnet_group" {
+  type = "string"
+}
+
+variable "database_password" {
+  type = "string"
+}
+
+variable "database_username" {
+  type = "string"
+}
+
+variable "env" {
+  type = "string"
+}
+
+variable "ingress_cidr_blocks" {
+  type = "list"
+}
+
+variable "instance_class" {
+  type    = "string"
+  default = "db.t2.small"
+}
+
+variable "instance_count" {
+  type = "string"
+}
+
+variable "owner" {
+  type = "string"
+}
+
+variable "project" {
+  type = "string"
+}
+
+variable "skip_final_snapshot" {
+  default = false
+}
+
+variable "backtrack_window" {
+  default = 0
+}
+
+variable "apply_immediately" {
+  default = false
+}
+
+variable "service" {
+  type = "string"
+}
+
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "publicly_accessible" {
+  default = false
+}
+
+variable "rds_cluster_parameters" {
+  type = "list"
+
+  default = [
+    {
+      name  = "character_set_server"
+      value = "utf8"
+    },
+    {
+      name  = "character_set_client"
+      value = "utf8"
+    },
+  ]
+}
+
+variable "db_parameters" {
+  type = "list"
+
+  default = [
+    {
+      name  = "general_log"
+      value = 1
+    },
+    {
+      name  = "slow_query_log"
+      value = "1"
+    },
+    {
+      name  = "long_query_time"
+      value = "0"
+    },
+    {
+      name  = "log_output"
+      value = "FILE"
+    },
+    {
+      name  = "log_queries_not_using_indexes"
+      value = "1"
+    },
+  ]
+}

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -28,7 +28,7 @@ variable "instance_class" {
 }
 
 variable "instance_count" {
-  type = "string"
+  type    = "string"
   default = 1
 }
 

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -85,22 +85,27 @@ variable "db_parameters" {
     {
       name  = "general_log"
       value = 1
+      apply_method = "pending-reboot"
     },
     {
       name  = "slow_query_log"
       value = "1"
+      apply_method = "pending-reboot"
     },
     {
       name  = "long_query_time"
       value = "0"
+      apply_method = "pending-reboot"
     },
     {
       name  = "log_output"
       value = "file"
+      apply_method = "pending-reboot"
     },
     {
       name  = "log_queries_not_using_indexes"
       value = "1"
+      apply_method = "pending-reboot"
     },
   ]
 }

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -104,3 +104,8 @@ variable "db_parameters" {
     },
   ]
 }
+
+variable "kms_key_id" {
+  type    = "string"
+  default = ""
+}

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -1,3 +1,34 @@
+# AWS Aurora Postgres
+
+This module will created a robust and secure [AWS Aurora](https://aws.amazon.com/rds/aurora/) Postgres cluster.
+
+A few things this module does for you–
+
+* ensures that data is encrypted at rest, either via an AWS managed key or if you supply `kms_key_id` a key that you control (via KMS).
+* tags all resources with our [consistent tags](../README.md#Consistent%20Tagging)
+* sets some sane defaults for database and cluster parameters
+
+A simple example:
+
+```hcl
+module "db" {
+  source = "github.com/chanzuckerberg/cztack//aws-aurora-postgres?ref=v0.12.0"
+
+  database_name         = "..."
+  database_subnet_group = "..."
+  database_password     = "..."
+  database_password     = "..."
+  
+  vpc_id = "..."
+
+  # Variables used for tagging
+  env     = "..."
+  project = "..."
+  service = "..."
+  owner   = "..."
+}
+```
+
 <!-- START -->
 
 ## Inputs
@@ -14,7 +45,7 @@
 | env |  | string | - | yes |
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | - | yes |
-| instance_count |  | string | - | yes |
+| instance_count |  | string | `1` | no |
 | kms_key_id |  | string | `` | no |
 | owner |  | string | - | yes |
 | project |  | string | - | yes |

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -4,6 +4,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| apply_immediately |  | string | `false` | no |
+| backtrack_window |  | string | `0` | no |
 | database_name |  | string | - | yes |
 | database_password |  | string | - | yes |
 | database_port |  | string | `5432` | no |
@@ -17,8 +19,10 @@
 | kms_key_id |  | string | `` | no |
 | owner |  | string | - | yes |
 | project |  | string | - | yes |
+| publicly_accessible |  | string | `false` | no |
 | rds_cluster_parameters |  | list | `<list>` | no |
 | service |  | string | - | yes |
+| skip_final_snapshot |  | string | `false` | no |
 | vpc_id |  | string | - | yes |
 
 ## Outputs

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -8,7 +8,6 @@
 | backtrack_window |  | string | `0` | no |
 | database_name |  | string | - | yes |
 | database_password |  | string | - | yes |
-| database_port |  | string | `5432` | no |
 | database_subnet_group |  | string | - | yes |
 | database_username |  | string | - | yes |
 | db_parameters |  | list | `<list>` | no |
@@ -30,9 +29,7 @@
 | Name | Description |
 |------|-------------|
 | database_name |  |
-| database_password |  |
-| database_port |  |
-| database_username |  |
 | endpoint |  |
+| port |  |
 
 <!-- END -->

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -1,0 +1,34 @@
+<!-- START -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| database_name |  | string | - | yes |
+| database_password |  | string | - | yes |
+| database_port |  | string | `5432` | no |
+| database_subnet_group |  | string | - | yes |
+| database_username |  | string | - | yes |
+| db_parameters |  | list | `<list>` | no |
+| env |  | string | - | yes |
+| ingress_cidr_blocks |  | list | - | yes |
+| instance_class |  | string | - | yes |
+| instance_count |  | string | - | yes |
+| kms_key_id |  | string | `` | no |
+| owner |  | string | - | yes |
+| project |  | string | - | yes |
+| rds_cluster_parameters |  | list | `<list>` | no |
+| service |  | string | - | yes |
+| vpc_id |  | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| database_name |  |
+| database_password |  |
+| database_port |  |
+| database_username |  |
+| endpoint |  |
+
+<!-- END -->

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -24,5 +24,7 @@ module "aurora" {
   backtrack_window    = "${var.backtrack_window}"
   skip_final_snapshot = "${var.skip_final_snapshot}"
 
+  kms_key_id = "${var.kms_key_id}"
+
   apply_immediately = "${var.apply_immediately}"
 }

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -17,6 +17,7 @@ module "aurora" {
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"
   publicly_accessible = "${var.publicly_accessible}"
+  port = 5432
 
   instance_class = "${var.instance_class}"
   instance_count = "${var.instance_count}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,88 +1,28 @@
-locals {
-  name = "${var.project}-${var.env}-${var.service}"
-
-  tags = {
-    managedBy = "terraform"
-    Name      = "${var.project}-${var.env}-${var.service}"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
-  }
-}
-
-resource "aws_security_group" "rds" {
-  name        = "${local.name}"
-  description = "Allow postgres inbound"
-
-  vpc_id = "${var.vpc_id}"
-
-  ingress {
-    from_port   = "${var.database_port}"
-    to_port     = "${var.database_port}"
-    protocol    = "tcp"
-    cidr_blocks = ["${var.ingress_cidr_blocks}"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-    ignore_changes = ["name"]
-  }
-
-  tags = "${local.tags}"
-}
-
-resource "aws_rds_cluster" "db" {
-  engine = "aurora-mysql"
-
-  cluster_identifier                  = "${local.name}"
-  database_name                       = "${var.database_name}"
-  master_username                     = "${var.database_username}"
-  master_password                     = "${var.database_password}"
-  vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
-  db_subnet_group_name                = "${var.database_subnet_group}"
-  storage_encrypted                   = true
-  iam_database_authentication_enabled = true
-  backup_retention_period             = 28
-  final_snapshot_identifier           = "${local.name}-snapshot"
-  skip_final_snapshot                 = "${var.skip_final_snapshot}"
-  backtrack_window                    = "${var.backtrack_window}"
-
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-
-  apply_immediately = "${var.apply_immediately}"
-
-  tags = "${local.tags}"
-}
-
-resource "aws_rds_cluster_instance" "db" {
+module "aurora" {
+  source = "../aws-aurora"
   engine = "aurora-postgresql"
 
-  count                   = "${var.instance_count}"
-  identifier              = "${local.name}-${count.index}"
-  cluster_identifier      = "${aws_rds_cluster.db.id}"
-  instance_class          = "${var.instance_class}"
-  db_subnet_group_name    = "${var.database_subnet_group}"
-  db_parameter_group_name = "${aws_db_parameter_group.db.name}"
+  project = "${var.project}"
+  env     = "${var.env}"
+  service = "${var.service}"
+  owner   = "${var.owner}"
 
-  tags = "${local.tags}"
-}
+  database_name          = "${var.database_name}"
+  database_subnet_group  = "${var.database_subnet_group}"
+  database_password      = "${var.database_password}"
+  database_username      = "${var.database_username}"
+  db_parameters          = "${var.db_parameters}"
+  rds_cluster_parameters = "${var.rds_cluster_parameters}"
 
-resource "aws_rds_cluster_parameter_group" "db" {
-  name        = "${local.name}"
-  family      = "aurora-postgresql9.6"
-  description = "RDS default cluster parameter group"
+  ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
+  vpc_id              = "${var.vpc_id}"
+  publicly_accessible = "${var.publicly_accessible}"
 
-  parameter = ["${var.rds_cluster_parameters}"]
+  instance_class = "${var.instance_class}"
+  instance_count = "${var.instance_count}"
 
-  tags = "${local.tags}"
-}
+  backtrack_window    = "${var.backtrack_window}"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
 
-resource "aws_db_parameter_group" "db" {
-  name   = "${local.name}"
-  family = "aurora-postgresql9.6"
-
-  parameter = ["${var.db_parameters}"]
-
-  tags = "${local.tags}"
+  apply_immediately = "${var.apply_immediately}"
 }

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -17,7 +17,7 @@ module "aurora" {
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"
   publicly_accessible = "${var.publicly_accessible}"
-  port = 5432
+  port                = 5432
 
   instance_class = "${var.instance_class}"
   instance_count = "${var.instance_count}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -26,6 +26,7 @@ resource "aws_security_group" "rds" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["name"]
   }
 
   tags = "${local.tags}"

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestAWSAuroraPostgres(t *testing.T) {
+	options := &terraform.Options{
+		TerraformDir: ".",
+	}
+	terraform.Init(t, options)
+}

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -5,3 +5,7 @@ output "database_name" {
 output "endpoint" {
   value = "${module.aurora.endpoint}"
 }
+
+output "port" {
+  value = "${module.aurora.port}"
+}

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -1,19 +1,7 @@
 output "database_name" {
-  value = "${aws_rds_cluster.db.database_name}"
-}
-
-output "database_username" {
-  value = "${var.database_username}"
-}
-
-output "database_password" {
-  value = "${var.database_password}"
-}
-
-output "database_port" {
-  value = "${var.database_port}"
+  value = "${module.aurora.database_name}"
 }
 
 output "endpoint" {
-  value = "${aws_rds_cluster.db.endpoint}"
+  value = "${module.aurora.endpoint}"
 }

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -1,0 +1,19 @@
+output "database_name" {
+  value = "${aws_rds_cluster.db.database_name}"
+}
+
+output "database_username" {
+  value = "${var.database_username}"
+}
+
+output "database_password" {
+  value = "${var.database_password}"
+}
+
+output "database_port" {
+  value = "${var.database_port}"
+}
+
+output "endpoint" {
+  value = "${aws_rds_cluster.db.endpoint}"
+}

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -1,0 +1,85 @@
+variable "database_name" {
+  type = "string"
+}
+
+variable "database_subnet_group" {
+  type = "string"
+}
+
+variable "database_password" {
+  type = "string"
+}
+
+variable "database_username" {
+  type = "string"
+}
+
+variable "database_port" {
+  type    = "string"
+  default = "5432"
+}
+
+variable "env" {
+  type = "string"
+}
+
+variable "ingress_cidr_blocks" {
+  type = "list"
+}
+
+variable "instance_class" {
+  type = "string"
+}
+
+variable "instance_count" {
+  type = "string"
+}
+
+variable "owner" {
+  type = "string"
+}
+
+variable "project" {
+  type = "string"
+}
+
+variable "service" {
+  type = "string"
+}
+
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "publicly_accessible" {
+  default = false
+}
+
+variable "skip_final_snapshot" {
+  default = false
+}
+
+variable "backtrack_window" {
+  default = 0
+}
+
+variable "apply_immediately" {
+  default = false
+}
+
+variable "rds_cluster_parameters" {
+  type = "list"
+
+  default = []
+}
+
+variable "db_parameters" {
+  type = "list"
+
+  default = []
+}
+
+variable "kms_key_id" {
+  type    = "string"
+  default = ""
+}

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -28,6 +28,7 @@ variable "instance_class" {
 
 variable "instance_count" {
   type = "string"
+  default = 1
 }
 
 variable "owner" {

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -27,7 +27,7 @@ variable "instance_class" {
 }
 
 variable "instance_count" {
-  type = "string"
+  type    = "string"
   default = 1
 }
 

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -14,11 +14,6 @@ variable "database_username" {
   type = "string"
 }
 
-variable "database_port" {
-  type    = "string"
-  default = "5432"
-}
-
 variable "env" {
   type = "string"
 }

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -1,3 +1,7 @@
+# AWS Aurora Module
+
+This is a low-level module for creating AWS Aurora clusters. We strongly reccomend you use one of the higher-level, opinionated modules for [mysql](../aws-aurora-mysql/README.md) or [postgres](../aws-aurora-postgres/README.md).
+
 <!-- START -->
 
 ## Inputs
@@ -15,7 +19,7 @@
 | env |  | string | - | yes |
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | `db.t2.small` | no |
-| instance_count |  | string | - | yes |
+| instance_count |  | string | `1` | no |
 | kms_key_id | If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module. | string | `` | no |
 | owner |  | string | - | yes |
 | port |  | string | - | yes |

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -1,0 +1,33 @@
+<!-- START -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| apply_immediately |  | string | `false` | no |
+| backtrack_window |  | string | `0` | no |
+| database_name |  | string | - | yes |
+| database_password |  | string | - | yes |
+| database_subnet_group |  | string | - | yes |
+| database_username |  | string | - | yes |
+| db_parameters |  | list | `<list>` | no |
+| env |  | string | - | yes |
+| ingress_cidr_blocks |  | list | - | yes |
+| instance_class |  | string | `db.t2.small` | no |
+| instance_count |  | string | - | yes |
+| owner |  | string | - | yes |
+| project |  | string | - | yes |
+| publicly_accessible |  | string | `false` | no |
+| rds_cluster_parameters |  | list | `<list>` | no |
+| service |  | string | - | yes |
+| skip_final_snapshot |  | string | `false` | no |
+| vpc_id |  | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| database_name |  |
+| endpoint |  |
+
+<!-- END -->

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -11,11 +11,14 @@
 | database_subnet_group |  | string | - | yes |
 | database_username |  | string | - | yes |
 | db_parameters |  | list | `<list>` | no |
+| engine |  | string | - | yes |
 | env |  | string | - | yes |
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | `db.t2.small` | no |
 | instance_count |  | string | - | yes |
+| kms_key_id | If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module. | string | `` | no |
 | owner |  | string | - | yes |
+| port |  | string | - | yes |
 | project |  | string | - | yes |
 | publicly_accessible |  | string | `false` | no |
 | rds_cluster_parameters |  | list | `<list>` | no |
@@ -29,5 +32,6 @@
 |------|-------------|
 | database_name |  |
 | endpoint |  |
+| port |  |
 
 <!-- END -->

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -32,7 +32,6 @@ resource "aws_security_group" "rds" {
   tags = "${local.tags}"
 }
 
-# engine aurora-mysql means mysql 5.7 compat
 resource "aws_rds_cluster" "db" {
   engine = "${var.engine}"
 
@@ -58,7 +57,7 @@ resource "aws_rds_cluster" "db" {
 }
 
 resource "aws_rds_cluster_instance" "db" {
-  engine = "aurora-mysql"
+  engine = "${var.engine}"
 
   count                   = "${var.instance_count}"
   identifier              = "${local.name}-${count.index}"
@@ -77,19 +76,27 @@ resource "aws_rds_cluster_instance" "db" {
 
 resource "aws_rds_cluster_parameter_group" "db" {
   name        = "${local.name}"
-  family      = "aurora-mysql5.7"
+  family      = "${local.name}"
   description = "RDS default cluster parameter group"
 
   parameter = ["${var.rds_cluster_parameters}"]
+
+  lifecycle {
+    ignore_changes = ["family"]
+  }
 
   tags = "${local.tags}"
 }
 
 resource "aws_db_parameter_group" "db" {
   name   = "${local.name}"
-  family = "aurora-mysql5.7"
+  family = "${local.name}"
 
   parameter = ["${var.db_parameters}"]
+
+  lifecycle {
+    ignore_changes = ["family"]
+  }
 
   tags = "${local.tags}"
 }

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -48,7 +48,7 @@ resource "aws_rds_cluster" "db" {
   skip_final_snapshot                 = "${var.skip_final_snapshot}"
   backtrack_window                    = "${var.backtrack_window}"
   kms_key_id                          = "${var.kms_key_id}"
-  port = "${var.port}"
+  port                                = "${var.port}"
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -48,6 +48,7 @@ resource "aws_rds_cluster" "db" {
   final_snapshot_identifier           = "${local.name}-snapshot"
   skip_final_snapshot                 = "${var.skip_final_snapshot}"
   backtrack_window                    = "${var.backtrack_window}"
+  kms_key_id                          = "${var.kms_key_id}"
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -18,8 +18,8 @@ resource "aws_security_group" "rds" {
   vpc_id = "${var.vpc_id}"
 
   ingress {
-    from_port   = 3306
-    to_port     = 3306
+    from_port   = "${var.port}"
+    to_port     = "${var.port}"
     protocol    = "tcp"
     cidr_blocks = ["${var.ingress_cidr_blocks}"]
   }
@@ -48,6 +48,7 @@ resource "aws_rds_cluster" "db" {
   skip_final_snapshot                 = "${var.skip_final_snapshot}"
   backtrack_window                    = "${var.backtrack_window}"
   kms_key_id                          = "${var.kms_key_id}"
+  port = "${var.port}"
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -13,7 +13,7 @@ locals {
 
 resource "aws_security_group" "rds" {
   name        = "${local.name}"
-  description = "Allow mysql inbound"
+  description = "Allow db traffic."
 
   vpc_id = "${var.vpc_id}"
 
@@ -26,7 +26,7 @@ resource "aws_security_group" "rds" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["name"]
+    ignore_changes        = ["name", "description"]
   }
 
   tags = "${local.tags}"

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -1,0 +1,94 @@
+locals {
+  name = "${var.project}-${var.env}-${var.service}"
+
+  tags = {
+    managedBy = "terraform"
+    Name      = "${local.name}"
+    project   = "${var.project}"
+    env       = "${var.env}"
+    service   = "${var.service}"
+    owner     = "${var.owner}"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.name}"
+  description = "Allow mysql inbound"
+
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["${var.ingress_cidr_blocks}"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = ["name"]
+  }
+
+  tags = "${local.tags}"
+}
+
+# engine aurora-mysql means mysql 5.7 compat
+resource "aws_rds_cluster" "db" {
+  engine = "${var.engine}"
+
+  cluster_identifier                  = "${local.name}"
+  database_name                       = "${var.database_name}"
+  master_username                     = "${var.database_username}"
+  master_password                     = "${var.database_password}"
+  vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
+  db_subnet_group_name                = "${var.database_subnet_group}"
+  storage_encrypted                   = true
+  iam_database_authentication_enabled = true
+  backup_retention_period             = 28
+  final_snapshot_identifier           = "${local.name}-snapshot"
+  skip_final_snapshot                 = "${var.skip_final_snapshot}"
+  backtrack_window                    = "${var.backtrack_window}"
+
+  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+
+  apply_immediately = "${var.apply_immediately}"
+
+  tags = "${local.tags}"
+}
+
+resource "aws_rds_cluster_instance" "db" {
+  engine = "aurora-mysql"
+
+  count                   = "${var.instance_count}"
+  identifier              = "${local.name}-${count.index}"
+  cluster_identifier      = "${aws_rds_cluster.db.id}"
+  instance_class          = "${var.instance_class}"
+  db_subnet_group_name    = "${var.database_subnet_group}"
+  db_parameter_group_name = "${aws_db_parameter_group.db.name}"
+
+  publicly_accessible          = "${var.publicly_accessible}"
+  performance_insights_enabled = true
+
+  apply_immediately = "${var.apply_immediately}"
+
+  tags = "${local.tags}"
+}
+
+resource "aws_rds_cluster_parameter_group" "db" {
+  name        = "${local.name}"
+  family      = "aurora-mysql5.7"
+  description = "RDS default cluster parameter group"
+
+  parameter = ["${var.rds_cluster_parameters}"]
+
+  tags = "${local.tags}"
+}
+
+resource "aws_db_parameter_group" "db" {
+  name   = "${local.name}"
+  family = "aurora-mysql5.7"
+
+  parameter = ["${var.db_parameters}"]
+
+  tags = "${local.tags}"
+}

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestAWSAurora(t *testing.T) {
+	options := &terraform.Options{
+		TerraformDir: ".",
+	}
+	terraform.Init(t, options)
+}

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -5,3 +5,7 @@ output "database_name" {
 output "endpoint" {
   value = "${aws_rds_cluster.db.endpoint}"
 }
+
+output "port" {
+  value = "${var.port}"
+}

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -1,0 +1,7 @@
+output "database_name" {
+  value = "${aws_rds_cluster.db.database_name}"
+}
+
+output "endpoint" {
+  value = "${aws_rds_cluster.db.endpoint}"
+}

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -1,0 +1,80 @@
+variable "database_name" {
+  type = "string"
+}
+
+variable "database_subnet_group" {
+  type = "string"
+}
+
+variable "database_password" {
+  type = "string"
+}
+
+variable "database_username" {
+  type = "string"
+}
+
+variable "env" {
+  type = "string"
+}
+
+variable "ingress_cidr_blocks" {
+  type = "list"
+}
+
+variable "instance_class" {
+  type    = "string"
+  default = "db.t2.small"
+}
+
+variable "instance_count" {
+  type = "string"
+}
+
+variable "owner" {
+  type = "string"
+}
+
+variable "project" {
+  type = "string"
+}
+
+variable "skip_final_snapshot" {
+  default = false
+}
+
+variable "backtrack_window" {
+  default = 0
+}
+
+variable "apply_immediately" {
+  default = false
+}
+
+variable "service" {
+  type = "string"
+}
+
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "publicly_accessible" {
+  default = false
+}
+
+variable "rds_cluster_parameters" {
+  type = "list"
+
+  default = []
+}
+
+variable "db_parameters" {
+  type = "list"
+
+  default = []
+}
+
+variable "engine" {
+  type = "string"
+}

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -29,6 +29,7 @@ variable "instance_class" {
 
 variable "instance_count" {
   type = "string"
+  default = 1
 }
 
 variable "owner" {

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -28,7 +28,7 @@ variable "instance_class" {
 }
 
 variable "instance_count" {
-  type = "string"
+  type    = "string"
   default = 1
 }
 

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -84,3 +84,7 @@ variable "kms_key_id" {
   description = "If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module."
   default     = ""
 }
+
+variable "port" {
+  type = "string"
+}

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -78,3 +78,9 @@ variable "db_parameters" {
 variable "engine" {
   type = "string"
 }
+
+variable "kms_key_id" {
+  type        = "string"
+  description = "If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module."
+  default     = ""
+}


### PR DESCRIPTION
As part of this move, the modules have been refactored to have a common module. The -mysql and -postgres modules are still useful for setting appropriate defaults for each engine.

Fixes #24 #23