### PR TITLE
Remove owner from aws-param

### DIFF
--- a/aws-param/README.md
+++ b/aws-param/README.md
@@ -31,7 +31,6 @@ output "secret" {
 |------|-------------|:----:|:-----:|:-----:|
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | name | The name of the secret. | string | - | yes |
-| owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | use_paths | This exists to support data written by Chamber before version 2.0.0, which used '.' instead of '/' as a separator. | string | `true` | no |

--- a/aws-param/variables.tf
+++ b/aws-param/variables.tf
@@ -8,11 +8,6 @@ variable "project" {
   description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }
 
-variable "owner" {
-  type        = "string"
-  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)."
-}
-
 variable "service" {
   type        = "string"
   description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"


### PR DESCRIPTION
aws-param does nothing with the owner variable; it's read only and does no modification of tags. This removes it from the list of variables needed.