### PR TITLE
Output Readonly role ARN, fix bool

### DIFF
--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -34,6 +34,7 @@ output "role_name" {
 
 | Name | Description |
 |------|-------------|
+| arn |  |
 | role_name |  |
 
 <!-- END -->

--- a/aws-iam-role-readonly/outputs.tf
+++ b/aws-iam-role-readonly/outputs.tf
@@ -1,3 +1,7 @@
 output "role_name" {
   value = "${aws_iam_role.readonly.name}"
 }
+
+output "arn" {
+  value = "${aws_iam_role.readonly.arn}"
+}

--- a/aws-param/main.tf
+++ b/aws-param/main.tf
@@ -3,5 +3,5 @@ locals {
 }
 
 data "aws_ssm_parameter" "secret" {
-  name = "${var.use_paths == "true" ? "/" : ""}${local.service_name}${var.use_paths == "true" ? "/" : "."}${var.name}"
+  name = "${var.use_paths ? "/" : ""}${local.service_name}${var.use_paths ? "/" : "."}${var.name}"
 }


### PR DESCRIPTION
This PR contains 2 separate small fixes:
1) Adds readonly role's ARN as output of the module. Getting the role ARNs is useful in some ECR IAM permission experiments.
2) Fixes the usage of boolean comparison in aws-param, to properly support both bool true and string "true".