### PR TITLE
[breaking] Turn params reader policy into inline policy to avoid collision

### DIFF
--- a/aws-params-reader-policy/README.md
+++ b/aws-params-reader-policy/README.md
@@ -9,17 +9,10 @@ Creates a policy to access encrypted parameters in Parameter Store for a given s
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
-| iam_path |  | string | `/` | no |
 | parameter_store_key_alias | Alias of the encryption key used to encrypt parameter store values. | string | `parameter_store_key` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | region | Region the parameter store values can be read from. Defaults to all. | string | `*` | no |
 | role_name | Name of the role to assign the policy to. | string | - | yes |
 | service | Name of the service to load secrets for. | string | - | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| policy_arn |  |
 
 <!-- END -->

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -8,10 +8,9 @@ data "aws_kms_alias" "parameter_store_key" {
   name = "alias/${var.parameter_store_key_alias}"
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "${local.resource_name}-parameter-policy"
-  description = "Provide access to the parameters of service ${local.resource_name}"
-  path        = "${var.iam_path}"
+resource "aws_iam_role_policy" "policy" {
+  name = "${local.resource_name}-parameter-policy"
+  role = "${var.role_name}"
 
   policy = <<EOF
 {
@@ -40,13 +39,4 @@ resource "aws_iam_policy" "policy" {
   ]
 }
 EOF
-
-  lifecycle {
-    ignore_changes = ["name"]
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "policy_attachment" {
-  role       = "${var.role_name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
 }

--- a/aws-params-reader-policy/outputs.tf
+++ b/aws-params-reader-policy/outputs.tf
@@ -1,3 +1,1 @@
-output "policy_arn" {
-  value = "${aws_iam_policy.policy.arn}"
-}
+

--- a/aws-params-reader-policy/variables.tf
+++ b/aws-params-reader-policy/variables.tf
@@ -19,11 +19,6 @@ variable "parameter_store_key_alias" {
   type        = "string"
 }
 
-variable "iam_path" {
-  type    = "string"
-  default = "/"
-}
-
 variable "role_name" {
   description = "Name of the role to assign the policy to."
   type        = "string"


### PR DESCRIPTION
This PR moves the params reader policy from being a global policy to direct inline attachment to a role. This is for the special case where multiple different deployments of a service (e.g. cellxgene-rest-api-kidney and cellxgene-rest-api-mouse) both intentionally use the same hard coded service name because they want access to parameters that are common across multiple deployments. In that case, you would do something like <https://github.com/chanzuckerberg/stp-infra/blob/master/terraform/modules/cellxgene-rest-api/main.tf#L60> where the service name is hard coded so that all such services pick up the param path "/stp-staging-cellxgene/*".

However, since the name of the policy matches this path, multiple different deployments will try to create a policy with the same name. This is disallowed by AWS and causes runtime errors.

This PR moves the policy to be inline to the role, removing the collision. This will unfortunately cause existing uses of aws-params-reader-policy to recreate new policies the next time it is run, but this shouldn't affect run time, given that the most common use case the policy only comes into play at startup when running chamber.