### PR TITLE
Aurora module tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - aws configure set aws_secret_access_key $CI2_AWS_SECRET_ACCESS_KEY --profile
       cztack-ci-2
     - aws --profile cztack-ci-2 sts get-caller-identity
-    script: make test
+    script: travis_wait 30m make test
 env:
   global:
   - secure: H6toE/cJTjXbp9QEONjA2wvWxIPIzPiX3VRY0r5C6YTYEMeujR/w8XW/HMrUFgK7DrD6td5vgpDVeoC84SmQ/KIyU/jEOJsjktxcsMK4Y/5Pbi5p9iK24ps7LUFLDGtYAnYiSOWd3lTDr1vRp/N1Es8VaSqyyRJwi5NwBFGjA0YoxiriIYe7WRCz9HRTiUSQ3PKZPJBLznqUrClvwVq9kZyI7zwyNmDYOrbXzKRPJfPCxHlWE/RsglXu0tSmuL6qxXVIhqp7ijRwJcCSMqpXYyYXPIHAm3b4dyXLSCzI3j+HwZqoTtnZFROMYrhVrgPlcntOe/NWMDu3UurE3ePEG6ghP/E5VD6xgcyiFDYvQV5f4ERPhmfurmOewESJdrtNQhepGutTaUX/gEzdu8rTaxc1fWFmOkscQOWCiPThqowdBP2kQtcrv660Z1PmtNuHmGyBS8j0hkkuyfWjX6YMf+egXpJSDT5kaEw+l6mn9yqL752hUdehKiBEroWqiv9eszFkFqPtBvNZO9vi+bRLeraq9lZJRHjS/T6LosfrLnXAo1X3Uqx79ruNFqLccADlsSqVMsSnyyIyv2d4uXvYTgPrqra1vbu7TQgjuMvwHXiLGt+h/ZLm8HFvSCFNAwzz3Ca+LxTN0TNpEHGmiqj0FoTfyuENvbAMkL4wyU7RprA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - aws configure set aws_secret_access_key $CI2_AWS_SECRET_ACCESS_KEY --profile
       cztack-ci-2
     - aws --profile cztack-ci-2 sts get-caller-identity
-    script: travis_wait 30m make test
+    script: travis_wait 30 make test
 env:
   global:
   - secure: H6toE/cJTjXbp9QEONjA2wvWxIPIzPiX3VRY0r5C6YTYEMeujR/w8XW/HMrUFgK7DrD6td5vgpDVeoC84SmQ/KIyU/jEOJsjktxcsMK4Y/5Pbi5p9iK24ps7LUFLDGtYAnYiSOWd3lTDr1vRp/N1Es8VaSqyyRJwi5NwBFGjA0YoxiriIYe7WRCz9HRTiUSQ3PKZPJBLznqUrClvwVq9kZyI7zwyNmDYOrbXzKRPJfPCxHlWE/RsglXu0tSmuL6qxXVIhqp7ijRwJcCSMqpXYyYXPIHAm3b4dyXLSCzI3j+HwZqoTtnZFROMYrhVrgPlcntOe/NWMDu3UurE3ePEG6ghP/E5VD6xgcyiFDYvQV5f4ERPhmfurmOewESJdrtNQhepGutTaUX/gEzdu8rTaxc1fWFmOkscQOWCiPThqowdBP2kQtcrv660Z1PmtNuHmGyBS8j0hkkuyfWjX6YMf+egXpJSDT5kaEw+l6mn9yqL752hUdehKiBEroWqiv9eszFkFqPtBvNZO9vi+bRLeraq9lZJRHjS/T6LosfrLnXAo1X3Uqx79ruNFqLccADlsSqVMsSnyyIyv2d4uXvYTgPrqra1vbu7TQgjuMvwHXiLGt+h/ZLm8HFvSCFNAwzz3Ca+LxTN0TNpEHGmiqj0FoTfyuENvbAMkL4wyU7RprA=

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ MODULES=$(filter-out vendor/ module-template/ scripts/ testutil/,$(sort $(dir $(
 TEST :=./...
 export PRIVATE_SUBNETS :=subnet-0e74698925a68c650,subnet-0f6ea862112b067c8
 export VPC_ID :=vpc-0442f170b88f8eaf6
+export VPC_CIDR_BLOCK :=10.72.0.0/16
+export DATABASE_SUBNET_GROUP :=shared-infra-cztack-ci
 
 all: clean fmt docs lint test
 
@@ -38,4 +40,4 @@ clean:
 		rm **/*.tfstate*
 
 test: fmt
-	GOCACHE=off AWS_PROFILE=cztack-ci-1 go test $(TEST)
+	GOCACHE=off AWS_PROFILE=cztack-ci-1 go test -test.timeout 30m $(TEST)

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ clean:
 		rm **/*.tfstate*
 
 test: fmt
-	GOCACHE=off AWS_PROFILE=cztack-ci-1 go test -test.timeout 30m $(TEST)
+	GOCACHE=off AWS_PROFILE=cztack-ci-1 go test -parallel 10 -test.timeout 30m $(TEST)

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -43,6 +43,7 @@ module "db" {
 | database_username | Default user to be created. | string | - | yes |
 | db_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Instance) | list | `<list>` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| iam_database_authentication_enabled |  | string | `false` | no |
 | ingress_cidr_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | - | yes |
 | instance_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html) | string | `db.t2.small` | no |
 | instance_count | Number of instances to create in this cluster. | string | `1` | no |

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -48,6 +48,7 @@ module "db" {
 | instance_count | Number of instances to create in this cluster. | string | `1` | no |
 | kms_key_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| performance_insights_enabled |  | string | `false` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | publicly_accessible | Avoid doing this - it gives access to the open internet. | string | `false` | no |
 | rds_cluster_parameters | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Cluster) | list | `<list>` | no |

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -35,25 +35,25 @@ module "db" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| apply_immediately |  | string | `false` | no |
-| backtrack_window |  | string | `0` | no |
-| database_name |  | string | - | yes |
-| database_password |  | string | - | yes |
-| database_subnet_group |  | string | - | yes |
-| database_username |  | string | - | yes |
-| db_parameters |  | list | `<list>` | no |
+| apply_immediately | If false changes will not be applied until next maintenance window. | string | `false` | no |
+| backtrack_window | Turns on Backgrack for this many seconds. [Doc](https://aws.amazon.com/blogs/aws/amazon-aurora-backtrack-turn-back-time/) | string | `0` | no |
+| database_name | The name of the database to be created in the cluster. | string | - | yes |
+| database_password | Password for user that will be created. | string | - | yes |
+| database_subnet_group | The name of an existing database subnet group to use. | string | - | yes |
+| database_username | Default user to be created. | string | - | yes |
+| db_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Instance) | list | `<list>` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
-| ingress_cidr_blocks |  | list | - | yes |
-| instance_class |  | string | `db.t2.small` | no |
-| instance_count |  | string | `1` | no |
-| kms_key_id |  | string | `` | no |
+| ingress_cidr_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | - | yes |
+| instance_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html) | string | `db.t2.small` | no |
+| instance_count | Number of instances to create in this cluster. | string | `1` | no |
+| kms_key_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
-| publicly_accessible |  | string | `false` | no |
-| rds_cluster_parameters |  | list | `<list>` | no |
+| publicly_accessible | Avoid doing this - it gives access to the open internet. | string | `false` | no |
+| rds_cluster_parameters | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Cluster) | list | `<list>` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
-| skip_final_snapshot |  | string | `false` | no |
-| vpc_id |  | string | - | yes |
+| skip_final_snapshot | When you destroy a database RDS will, by default, take snapshot. Set this to skip that step. | string | `false` | no |
+| vpc_id | The id of the existing VPC in which this cluster should be created. | string | - | yes |
 
 ## Outputs
 

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,7 +1,7 @@
 module "aurora" {
-  source  = "../aws-aurora"
-  engine  = "aurora-mysql"
-  version = "5.7"
+  source         = "../aws-aurora"
+  engine         = "aurora-mysql"
+  engine_version = "5.7"
 
   project = "${var.project}"
   env     = "${var.env}"
@@ -15,6 +15,7 @@ module "aurora" {
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
   iam_database_authentication_enabled = false
+  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -15,6 +15,7 @@ module "aurora" {
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
   iam_database_authentication_enabled = false
+  performance_insights_enabled        = "${var.performance_insights_enabled}"
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,18 +1,20 @@
 module "aurora" {
-  source = "../aws-aurora"
-  engine = "aurora-mysql"
+  source  = "../aws-aurora"
+  engine  = "aurora-mysql"
+  version = "5.7"
 
   project = "${var.project}"
   env     = "${var.env}"
   service = "${var.service}"
   owner   = "${var.owner}"
 
-  database_name          = "${var.database_name}"
-  database_subnet_group  = "${var.database_subnet_group}"
-  database_password      = "${var.database_password}"
-  database_username      = "${var.database_username}"
-  db_parameters          = "${var.db_parameters}"
-  rds_cluster_parameters = "${var.rds_cluster_parameters}"
+  database_name                       = "${var.database_name}"
+  database_subnet_group               = "${var.database_subnet_group}"
+  database_password                   = "${var.database_password}"
+  database_username                   = "${var.database_username}"
+  db_parameters                       = "${var.db_parameters}"
+  rds_cluster_parameters              = "${var.rds_cluster_parameters}"
+  iam_database_authentication_enabled = false
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -14,7 +14,7 @@ module "aurora" {
   database_username                   = "${var.database_username}"
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
-  iam_database_authentication_enabled = false
+  iam_database_authentication_enabled = true
   performance_insights_enabled        = "${var.performance_insights_enabled}"
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -14,7 +14,7 @@ module "aurora" {
   database_username                   = "${var.database_username}"
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
-  iam_database_authentication_enabled = true
+  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
   performance_insights_enabled        = "${var.performance_insights_enabled}"
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -15,6 +15,7 @@ func TestAWSAuroraMysqlInit(t *testing.T) {
 }
 
 func TestAWSAuroraMysqlInitAndApply(t *testing.T) {
+	t.Parallel()
 	project := testutil.UniqueId()
 	env := testutil.UniqueId()
 	service := testutil.UniqueId()

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -3,12 +3,48 @@ package test
 import (
 	"testing"
 
+	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestAWSAuroraMysql(t *testing.T) {
+func TestAWSAuroraMysqlInit(t *testing.T) {
 	options := &terraform.Options{
 		TerraformDir: ".",
 	}
 	terraform.Init(t, options)
+}
+
+func TestAWSAuroraMysqlInitAndApply(t *testing.T) {
+	project := testutil.UniqueId()
+	env := testutil.UniqueId()
+	service := testutil.UniqueId()
+	owner := testutil.UniqueId()
+
+	vpc := testutil.EnvVar("VPC_ID")
+	database_subnet_group := testutil.EnvVar("DATABASE_SUBNET_GROUP")
+	ingress_cidr_blocks := testutil.EnvVar("VPC_CIDR_BLOCK")
+
+	database_password := testutil.RandomString(testutil.AlphaNum, 8)
+	database_username := testutil.RandomString(testutil.Alpha, 8)
+	database_name := testutil.UniqueId()
+
+	options := testutil.Options(
+		testutil.DefaultRegion,
+		map[string]interface{}{
+			"project": project,
+			"env":     env,
+			"service": service,
+			"owner":   owner,
+
+			"vpc_id":                vpc,
+			"database_subnet_group": database_subnet_group,
+			"database_password":     database_password,
+			"database_username":     database_username,
+			"ingress_cidr_blocks":   []string{ingress_cidr_blocks},
+			"database_name":         database_name,
+			"skip_final_snapshot":   true,
+		},
+	)
+	defer terraform.Destroy(t, options)
+	testutil.Run(t, options)
 }

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -140,3 +140,8 @@ variable "kms_key_id" {
   description = "If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on)."
   default     = ""
 }
+
+variable "performance_insights_enabled" {
+  type    = "string"
+  default = false
+}

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -1,17 +1,21 @@
 variable "database_name" {
-  type = "string"
+  type        = "string"
+  description = "The name of the database to be created in the cluster."
 }
 
 variable "database_subnet_group" {
-  type = "string"
+  type        = "string"
+  description = "The name of an existing database subnet group to use."
 }
 
 variable "database_password" {
-  type = "string"
+  type        = "string"
+  description = "Password for user that will be created."
 }
 
 variable "database_username" {
-  type = "string"
+  type        = "string"
+  description = "Default user to be created."
 }
 
 variable "env" {
@@ -20,17 +24,20 @@ variable "env" {
 }
 
 variable "ingress_cidr_blocks" {
-  type = "list"
+  type        = "list"
+  description = "A list of CIDR blocks that should be allowed to communicate with this Aurora cluster."
 }
 
 variable "instance_class" {
-  type    = "string"
-  default = "db.t2.small"
+  type        = "string"
+  description = "See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html)"
+  default     = "db.t2.small"
 }
 
 variable "instance_count" {
-  type    = "string"
-  default = 1
+  type        = "string"
+  description = "Number of instances to create in this cluster."
+  default     = 1
 }
 
 variable "owner" {
@@ -44,15 +51,21 @@ variable "project" {
 }
 
 variable "skip_final_snapshot" {
-  default = false
+  type        = "string"
+  description = "When you destroy a database RDS will, by default, take snapshot. Set this to skip that step."
+  default     = false
 }
 
 variable "backtrack_window" {
-  default = 0
+  type        = "string"
+  description = "Turns on Backgrack for this many seconds. [Doc](https://aws.amazon.com/blogs/aws/amazon-aurora-backtrack-turn-back-time/)"
+  default     = 0
 }
 
 variable "apply_immediately" {
-  default = false
+  type        = "string"
+  description = "If false changes will not be applied until next maintenance window."
+  default     = false
 }
 
 variable "service" {
@@ -61,15 +74,19 @@ variable "service" {
 }
 
 variable "vpc_id" {
-  type = "string"
+  type        = "string"
+  description = "The id of the existing VPC in which this cluster should be created."
 }
 
 variable "publicly_accessible" {
-  default = false
+  type        = "string"
+  description = "Avoid doing this - it gives access to the open internet."
+  default     = false
 }
 
 variable "rds_cluster_parameters" {
-  type = "list"
+  type        = "list"
+  description = "Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Cluster)"
 
   default = [
     {
@@ -86,7 +103,8 @@ variable "rds_cluster_parameters" {
 }
 
 variable "db_parameters" {
-  type = "list"
+  type        = "list"
+  description = "Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Instance)"
 
   default = [
     {
@@ -118,6 +136,7 @@ variable "db_parameters" {
 }
 
 variable "kms_key_id" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  description = "If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on)."
+  default     = ""
 }

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -145,3 +145,8 @@ variable "performance_insights_enabled" {
   type    = "string"
   default = false
 }
+
+variable "iam_database_authentication_enabled" {
+  type    = "string"
+  default = false
+}

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -43,6 +43,7 @@ module "db" {
 | db_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Instance) | list | `<list>` | no |
 | engine_version | The version of Postgres to use. | string | `9.6` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| iam_database_authentication_enabled |  | string | `false` | no |
 | ingress_cidr_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | - | yes |
 | instance_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html) | string | `db.r4.large` | no |
 | instance_count | Number of instances to create in this cluster. | string | `1` | no |

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -48,6 +48,7 @@ module "db" {
 | instance_count | Number of instances to create in this cluster. | string | `1` | no |
 | kms_key_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| performance_insights_enabled |  | string | `false` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | publicly_accessible | Avoid doing this - it gives access to the open internet. | string | `false` | no |
 | rds_cluster_parameters | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Cluster) | list | `<list>` | no |

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -35,25 +35,25 @@ module "db" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| apply_immediately |  | string | `false` | no |
-| backtrack_window |  | string | `0` | no |
-| database_name |  | string | - | yes |
-| database_password |  | string | - | yes |
-| database_subnet_group |  | string | - | yes |
-| database_username |  | string | - | yes |
-| db_parameters |  | list | `<list>` | no |
+| apply_immediately | If false changes will not be applied until next maintenance window. | string | `false` | no |
+| database_name | The name of the database to be created in the cluster. | string | - | yes |
+| database_password | Password for user that will be created. | string | - | yes |
+| database_subnet_group | The name of an existing database subnet group to use. | string | - | yes |
+| database_username | Default user to be created. | string | - | yes |
+| db_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Instance) | list | `<list>` | no |
+| engine_version | The version of Postgres to use. | string | `9.6` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
-| ingress_cidr_blocks |  | list | - | yes |
-| instance_class |  | string | - | yes |
-| instance_count |  | string | `1` | no |
-| kms_key_id |  | string | `` | no |
+| ingress_cidr_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | - | yes |
+| instance_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html) | string | `db.r4.large` | no |
+| instance_count | Number of instances to create in this cluster. | string | `1` | no |
+| kms_key_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
-| publicly_accessible |  | string | `false` | no |
-| rds_cluster_parameters |  | list | `<list>` | no |
+| publicly_accessible | Avoid doing this - it gives access to the open internet. | string | `false` | no |
+| rds_cluster_parameters | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Cluster) | list | `<list>` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
-| skip_final_snapshot |  | string | `false` | no |
-| vpc_id |  | string | - | yes |
+| skip_final_snapshot | When you destroy a database RDS will, by default, take snapshot. Set this to skip that step. | string | `false` | no |
+| vpc_id | The id of the existing VPC in which this cluster should be created. | string | - | yes |
 
 ## Outputs
 

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -15,7 +15,7 @@ module "aurora" {
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
   iam_database_authentication_enabled = false
-  performance_insights_enabled        = false
+  performance_insights_enabled        = "${var.performance_insights_enabled}"
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,7 +1,7 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-postgresql"
-  engine_version = "${var.version}"
+  engine_version = "${var.engin_version}"
 
   project = "${var.project}"
   env     = "${var.env}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,31 +1,29 @@
 module "aurora" {
-  source = "../aws-aurora"
-  engine = "aurora-postgresql"
+  source         = "../aws-aurora"
+  engine         = "aurora-postgresql"
+  engine_version = "${var.version}"
 
   project = "${var.project}"
   env     = "${var.env}"
   service = "${var.service}"
   owner   = "${var.owner}"
 
-  database_name          = "${var.database_name}"
-  database_subnet_group  = "${var.database_subnet_group}"
-  database_password      = "${var.database_password}"
-  database_username      = "${var.database_username}"
-  db_parameters          = "${var.db_parameters}"
-  rds_cluster_parameters = "${var.rds_cluster_parameters}"
+  database_name                       = "${var.database_name}"
+  database_subnet_group               = "${var.database_subnet_group}"
+  database_password                   = "${var.database_password}"
+  database_username                   = "${var.database_username}"
+  db_parameters                       = "${var.db_parameters}"
+  rds_cluster_parameters              = "${var.rds_cluster_parameters}"
+  iam_database_authentication_enabled = false
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"
   publicly_accessible = "${var.publicly_accessible}"
   port                = 5432
-
-  instance_class = "${var.instance_class}"
-  instance_count = "${var.instance_count}"
-
-  backtrack_window    = "${var.backtrack_window}"
+  instance_class      = "${var.instance_class}"
+  instance_count      = "${var.instance_count}"
+  backtrack_window    = 0                            # not supported yet
   skip_final_snapshot = "${var.skip_final_snapshot}"
-
-  kms_key_id = "${var.kms_key_id}"
-
-  apply_immediately = "${var.apply_immediately}"
+  kms_key_id          = "${var.kms_key_id}"
+  apply_immediately   = "${var.apply_immediately}"
 }

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,7 +1,7 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-postgresql"
-  engine_version = "${var.engin_version}"
+  engine_version = "${var.engine_version}"
 
   project = "${var.project}"
   env     = "${var.env}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -15,6 +15,7 @@ module "aurora" {
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
   iam_database_authentication_enabled = false
+  performance_insights_enabled        = false
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
   vpc_id              = "${var.vpc_id}"

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -14,7 +14,7 @@ module "aurora" {
   database_username                   = "${var.database_username}"
   db_parameters                       = "${var.db_parameters}"
   rds_cluster_parameters              = "${var.rds_cluster_parameters}"
-  iam_database_authentication_enabled = false
+  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
   performance_insights_enabled        = "${var.performance_insights_enabled}"
 
   ingress_cidr_blocks = "${var.ingress_cidr_blocks}"

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -3,12 +3,49 @@ package test
 import (
 	"testing"
 
+	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestAWSAuroraPostgres(t *testing.T) {
+func TestAWSAuroraPostgresInit(t *testing.T) {
 	options := &terraform.Options{
 		TerraformDir: ".",
 	}
 	terraform.Init(t, options)
+}
+
+func TestAWSAuroraPostgresInitAndApply(t *testing.T) {
+	t.Parallel()
+	project := testutil.UniqueId()
+	env := testutil.UniqueId()
+	service := testutil.UniqueId()
+	owner := testutil.UniqueId()
+
+	vpc := testutil.EnvVar("VPC_ID")
+	database_subnet_group := testutil.EnvVar("DATABASE_SUBNET_GROUP")
+	ingress_cidr_blocks := testutil.EnvVar("VPC_CIDR_BLOCK")
+
+	database_password := testutil.RandomString(testutil.AlphaNum, 8)
+	database_username := testutil.RandomString(testutil.Alpha, 8)
+	database_name := testutil.UniqueId()
+
+	options := testutil.Options(
+		testutil.DefaultRegion,
+		map[string]interface{}{
+			"project": project,
+			"env":     env,
+			"service": service,
+			"owner":   owner,
+
+			"vpc_id":                vpc,
+			"database_subnet_group": database_subnet_group,
+			"database_password":     database_password,
+			"database_username":     database_username,
+			"ingress_cidr_blocks":   []string{ingress_cidr_blocks},
+			"database_name":         database_name,
+			"skip_final_snapshot":   true,
+		},
+	)
+	defer terraform.Destroy(t, options)
+	testutil.Run(t, options)
 }

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -106,3 +106,8 @@ variable "performance_insights_enabled" {
   type    = "string"
   default = false
 }
+
+variable "iam_database_authentication_enabled" {
+  type    = "string"
+  default = false
+}

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -1,17 +1,21 @@
 variable "database_name" {
-  type = "string"
+  type        = "string"
+  description = "The name of the database to be created in the cluster."
 }
 
 variable "database_subnet_group" {
-  type = "string"
+  type        = "string"
+  description = "The name of an existing database subnet group to use."
 }
 
 variable "database_password" {
-  type = "string"
+  type        = "string"
+  description = "Password for user that will be created."
 }
 
 variable "database_username" {
-  type = "string"
+  type        = "string"
+  description = "Default user to be created."
 }
 
 variable "env" {
@@ -20,16 +24,20 @@ variable "env" {
 }
 
 variable "ingress_cidr_blocks" {
-  type = "list"
+  type        = "list"
+  description = "A list of CIDR blocks that should be allowed to communicate with this Aurora cluster."
 }
 
 variable "instance_class" {
-  type = "string"
+  type        = "string"
+  description = "See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html)"
+  default     = "db.r4.large"
 }
 
 variable "instance_count" {
-  type    = "string"
-  default = 1
+  type        = "string"
+  description = "Number of instances to create in this cluster."
+  default     = 1
 }
 
 variable "owner" {
@@ -48,38 +56,48 @@ variable "service" {
 }
 
 variable "vpc_id" {
-  type = "string"
+  type        = "string"
+  description = "The id of the existing VPC in which this cluster should be created."
 }
 
 variable "publicly_accessible" {
-  default = false
+  type        = "string"
+  description = "Avoid doing this - it gives access to the open internet."
+  default     = false
 }
 
 variable "skip_final_snapshot" {
-  default = false
-}
-
-variable "backtrack_window" {
-  default = 0
+  type        = "string"
+  description = "When you destroy a database RDS will, by default, take snapshot. Set this to skip that step."
+  default     = false
 }
 
 variable "apply_immediately" {
-  default = false
+  type        = "string"
+  description = "If false changes will not be applied until next maintenance window."
+  default     = false
 }
 
 variable "rds_cluster_parameters" {
-  type = "list"
-
-  default = []
+  type        = "list"
+  description = "Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Cluster)"
+  default     = []
 }
 
 variable "db_parameters" {
-  type = "list"
-
-  default = []
+  type        = "list"
+  description = "Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Instance)"
+  default     = []
 }
 
 variable "kms_key_id" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  description = "If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on)."
+  default     = ""
+}
+
+variable "engine_version" {
+  type        = "string"
+  description = "The version of Postgres to use."
+  default     = "9.6"
 }

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -101,3 +101,8 @@ variable "engine_version" {
   description = "The version of Postgres to use."
   default     = "9.6"
 }
+
+variable "performance_insights_enabled" {
+  type    = "string"
+  default = false
+}

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -15,8 +15,11 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | database_subnet_group |  | string | - | yes |
 | database_username |  | string | - | yes |
 | db_parameters |  | list | `<list>` | no |
+| enabled_cloudwatch_logs_exports |  | list | `<list>` | no |
 | engine |  | string | - | yes |
+| engine_version |  | string | - | yes |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| iam_database_authentication_enabled |  | string | `true` | no |
 | ingress_cidr_blocks |  | list | - | yes |
 | instance_class |  | string | `db.t2.small` | no |
 | instance_count |  | string | `1` | no |

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -25,6 +25,7 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | instance_count |  | string | `1` | no |
 | kms_key_id | If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module. | string | `` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | - | yes |
+| performance_insights_enabled |  | string | `true` | no |
 | port |  | string | - | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | - | yes |
 | publicly_accessible |  | string | `false` | no |

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -42,7 +42,7 @@ resource "aws_rds_cluster" "db" {
   vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
   db_subnet_group_name                = "${var.database_subnet_group}"
   storage_encrypted                   = true
-  iam_database_authentication_enabled = true
+  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
   backup_retention_period             = 28
   final_snapshot_identifier           = "${local.name}-snapshot"
   skip_final_snapshot                 = "${var.skip_final_snapshot}"
@@ -77,7 +77,7 @@ resource "aws_rds_cluster_instance" "db" {
 
 resource "aws_rds_cluster_parameter_group" "db" {
   name        = "${local.name}"
-  family      = "${local.name}"
+  family      = "${var.engine}${var.version}"
   description = "RDS default cluster parameter group"
 
   parameter = ["${var.rds_cluster_parameters}"]
@@ -91,7 +91,7 @@ resource "aws_rds_cluster_parameter_group" "db" {
 
 resource "aws_db_parameter_group" "db" {
   name   = "${local.name}"
-  family = "${local.name}"
+  family = "${var.engine}${var.version}"
 
   parameter = ["${var.db_parameters}"]
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -68,7 +68,7 @@ resource "aws_rds_cluster_instance" "db" {
   db_parameter_group_name = "${aws_db_parameter_group.db.name}"
 
   publicly_accessible          = "${var.publicly_accessible}"
-  performance_insights_enabled = true
+  performance_insights_enabled = "${var.performance_insights_enabled}"
 
   apply_immediately = "${var.apply_immediately}"
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -50,7 +50,7 @@ resource "aws_rds_cluster" "db" {
   kms_key_id                          = "${var.kms_key_id}"
   port                                = "${var.port}"
 
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
 
   apply_immediately = "${var.apply_immediately}"
 
@@ -77,7 +77,7 @@ resource "aws_rds_cluster_instance" "db" {
 
 resource "aws_rds_cluster_parameter_group" "db" {
   name        = "${local.name}"
-  family      = "${var.engine}${var.version}"
+  family      = "${var.engine}${var.engine_version}"
   description = "RDS default cluster parameter group"
 
   parameter = ["${var.rds_cluster_parameters}"]
@@ -91,7 +91,7 @@ resource "aws_rds_cluster_parameter_group" "db" {
 
 resource "aws_db_parameter_group" "db" {
   name   = "${local.name}"
-  family = "${var.engine}${var.version}"
+  family = "${var.engine}${var.engine_version}"
 
   parameter = ["${var.db_parameters}"]
 

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -107,3 +107,8 @@ variable "enabled_cloudwatch_logs_exports" {
   type    = "list"
   default = []
 }
+
+variable "performance_insights_enabled" {
+  type    = "string"
+  default = true
+}

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -94,12 +94,16 @@ variable "port" {
   type = "string"
 }
 
-variable "version" {
-  type    = "string"
-  default = "5.7"
+variable "engine_version" {
+  type = "string"
 }
 
 variable "iam_database_authentication_enabled" {
   type    = "string"
   default = true
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  type    = "list"
+  default = []
 }

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -93,3 +93,13 @@ variable "kms_key_id" {
 variable "port" {
   type = "string"
 }
+
+variable "version" {
+  type    = "string"
+  default = "5.7"
+}
+
+variable "iam_database_authentication_enabled" {
+  type    = "string"
+  default = true
+}

--- a/aws-cloudwatch-log-group/module_test.go
+++ b/aws-cloudwatch-log-group/module_test.go
@@ -9,19 +9,16 @@ import (
 )
 
 func TestAWSCloudWatchLogGroup(t *testing.T) {
-	options := &terraform.Options{
-		TerraformDir: ".",
-		Vars: map[string]interface{}{
+	options := testutil.Options(
+		testutil.DefaultRegion,
+		map[string]interface{}{
 			"project":        random.UniqueId(),
 			"env":            random.UniqueId(),
 			"service":        random.UniqueId(),
 			"owner":          random.UniqueId(),
 			"log_group_name": random.UniqueId(),
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.DefaultRegion,
-		},
-	}
+	)
 	defer terraform.Destroy(t, options)
 	testutil.Run(t, options)
 }

--- a/aws-iam-group-console-login/module_test.go
+++ b/aws-iam-group-console-login/module_test.go
@@ -6,23 +6,18 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMGroupConsoleLogin(t *testing.T) {
 
-	terraformOptions := &terraform.Options{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
 
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+		map[string]interface{}{
 			"group_name": random.UniqueId(),
 			"iam_path":   fmt.Sprintf("/%s/", random.UniqueId()),
 		},
-
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		}}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-policy-cwlogs/module_test.go
+++ b/aws-iam-policy-cwlogs/module_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMPolicyCwlogs(t *testing.T) {
@@ -14,17 +13,13 @@ func TestAWSIAMPolicyCwlogs(t *testing.T) {
 	roleName := testutil.CreateRole(t)
 	defer testutil.DeleteRole(t, roleName)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"role_name": roleName,
 			"iam_path":  fmt.Sprintf("/%s/", random.UniqueId()),
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-bless/module_test.go
+++ b/aws-iam-role-bless/module_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestIAMRoleBless(t *testing.T) {
-	t.Parallel()
 
 	region := testutil.IAMRegion
 	curAcct := testutil.AWSCurrentAccountId(t)

--- a/aws-iam-role-cloudfront-poweruser/module_test.go
+++ b/aws-iam-role-cloudfront-poweruser/module_test.go
@@ -6,25 +6,22 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
 
-		Vars: map[string]interface{}{
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 			"source_account_id": curAcct,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
+
 	defer testutil.Cleanup(t, terraformOptions)
 
 	testutil.Run(t, terraformOptions)

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -5,24 +5,20 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleCrossAcct(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
 
-		Vars: map[string]interface{}{
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-ec2-poweruser/module_test.go
+++ b/aws-iam-role-ec2-poweruser/module_test.go
@@ -9,22 +9,16 @@ import (
 )
 
 func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
-	t.Parallel()
 
-	region := "us-west-1"
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": region,
-		},
-	}
+	)
 
 	defer terraform.Destroy(t, terraformOptions)
 

--- a/aws-iam-role-ecs-poweruser/module_test.go
+++ b/aws-iam-role-ecs-poweruser/module_test.go
@@ -5,24 +5,20 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
 
-		Vars: map[string]interface{}{
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-infraci/module_test.go
+++ b/aws-iam-role-infraci/module_test.go
@@ -6,25 +6,20 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleInfraCI(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-poweruser/module_test.go
+++ b/aws-iam-role-poweruser/module_test.go
@@ -5,24 +5,19 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRolePowerUser(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-readonly/module_test.go
+++ b/aws-iam-role-readonly/module_test.go
@@ -6,25 +6,21 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleReadOnly(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
 
-		Vars: map[string]interface{}{
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-iam-role-security-audit/module_test.go
+++ b/aws-iam-role-security-audit/module_test.go
@@ -6,25 +6,20 @@ import (
 
 	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSIAMRoleReadOnly(t *testing.T) {
 
 	curAcct := testutil.AWSCurrentAccountId(t)
 
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-params-reader-policy/module_test.go
+++ b/aws-params-reader-policy/module_test.go
@@ -53,20 +53,16 @@ func TestAWSParamsSecretReaderPolicy(t *testing.T) {
 	testutil.Run(t, keyTerraformOptions)
 
 	// Actual test
-	terraformOptions := &terraform.Options{
-		TerraformDir: ".",
-
-		Vars: map[string]interface{}{
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
 			"project":                   random.UniqueId(),
 			"env":                       random.UniqueId(),
 			"service":                   random.UniqueId(),
 			"role_name":                 roleName,
 			"parameter_store_key_alias": keyAlias,
 		},
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.IAMRegion,
-		},
-	}
+	)
 
 	defer testutil.Cleanup(t, terraformOptions)
 

--- a/aws-redis-node/module_test.go
+++ b/aws-redis-node/module_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/cztack/testutil"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestAWSRedisNode(t *testing.T) {
@@ -27,14 +26,8 @@ func TestAWSRedisNode(t *testing.T) {
 
 	az := fmt.Sprintf("%sa", testutil.DefaultRegion)
 
-	options := &terraform.Options{
-		TerraformDir: ".",
-
-		EnvVars: map[string]string{
-			"AWS_DEFAULT_REGION": testutil.DefaultRegion,
-		},
-
-		Vars: map[string]interface{}{
+	options := testutil.Options(testutil.DefaultRegion,
+		map[string]interface{}{
 			"project": project,
 			"env":     env,
 			"service": service,
@@ -44,7 +37,7 @@ func TestAWSRedisNode(t *testing.T) {
 			"subnets":                    private_subnets,
 			"ingress_security_group_ids": []string{sg},
 		},
-	}
+	)
 
 	defer testutil.Cleanup(t, options)
 

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -135,23 +135,29 @@ func Options(region string, vars map[string]interface{}) *terraform.Options {
 // to do lowercase only.
 // TODO fork terratest and write a method for random strings that takes a list of acceptable characters.
 const base62chars = "abcdefghijklmnopqrstuvwxyz"
+const AlphaNum = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+const Alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 const uniqueIDLength = 6 // Should be good for 62^6 = 56+ billion combinations
 
 // UniqueId returns a unique (ish) id we can attach to resources and tfstate files so they don't conflict with each other
 // Uses base 62 to generate a 6 character string that's unlikely to collide with the handful of tests we run in
 // parallel. Based on code here: http://stackoverflow.com/a/9543797/483528
 func UniqueId() string {
-	var out bytes.Buffer
-
-	generator := newRand()
-	for i := 0; i < uniqueIDLength; i++ {
-		out.WriteByte(base62chars[generator.Intn(len(base62chars))])
-	}
-
-	return out.String()
+	return RandomString(base62chars, uniqueIDLength)
 }
 
 // newRand creates a new random number generator, seeding it with the current system time.
 func newRand() *rand.Rand {
 	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func RandomString(chars string, length int) string {
+	var out bytes.Buffer
+
+	generator := newRand()
+	for i := 0; i < length; i++ {
+		out.WriteByte(chars[generator.Intn(len(chars))])
+	}
+
+	return out.String()
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -119,6 +119,18 @@ func EnvVar(name string) string {
 	return os.Getenv(name)
 }
 
+func Options(region string, vars map[string]interface{}) *terraform.Options {
+	return &terraform.Options{
+		TerraformDir: ".",
+
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+
+		Vars: vars,
+	}
+}
+
 // Lifted from https://github.com/gruntwork-io/terratest/blob/master/modules/random/random.go and modified
 // to do lowercase only.
 // TODO fork terratest and write a method for random strings that takes a list of acceptable characters.


### PR DESCRIPTION
I set out on this change to write some full `apply` tests for the aurora modules. Along the way I had to made a bunch of small fixes to get things green.

Note that these are the first tests that use our CI VPC. I've decided, for  now, to just bake the relevant IDs into the Makefile in such a way that others an override them.

In theory the aurora tests should run in paralle (`t.Parallel`) but in practice that does not appear to be working and I don't know why.

Fixes #53 and #54 