### PR TITLE
Bugfix on aws-iam-ecs-task-role policy doc

### DIFF
--- a/aws-iam-ecs-task-role/main.tf
+++ b/aws-iam-ecs-task-role/main.tf
@@ -2,7 +2,7 @@ data "aws_iam_policy_document" "role" {
   statement {
     principals {
       type        = "Service"
-      identifiers = "ecs-tasks.amazonaws.com"
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
 
     actions = ["sts:AssumeRole"]


### PR DESCRIPTION
Fixes issue mentioned in meta-infra channel. However, cztack should be stable enough for meta's purposes that it can be on v0.14.0 and not master, which would not have pulled this bug in.