### PR TITLE
Remove policy argument from aws-iam-ecs-task-role

### DIFF
--- a/aws-iam-ecs-task-role/README.md
+++ b/aws-iam-ecs-task-role/README.md
@@ -7,9 +7,6 @@ This will create a role for attaching to an ECS task, using `policy`.
 ```hcl
 module "ecs-role" {
   source = "github.com/chanzuckerberg/cztack/aws-iam-ecs-task-role?ref=v0.14.0"
-  
-  # IAM policy
-  policy = "..."
 
   # Variables used for tagging.
   project = "..."
@@ -31,7 +28,6 @@ output "ecs-role-arn" {
 |------|-------------|:----:|:-----:|:-----:|
 | env | Environment name. For example– dev, staging or prod. | string | - | yes |
 | owner | Email address of the owner. Can be a group address. | string | - | yes |
-| policy | IAM policy to grant to this role. | string | - | yes |
 | project | High-level project, should be unique across the organization. | string | - | yes |
 | service | Name of this thing we're running. | string | - | yes |
 

--- a/aws-iam-ecs-task-role/main.tf
+++ b/aws-iam-ecs-task-role/main.tf
@@ -14,10 +14,3 @@ resource "aws_iam_role" "role" {
   description        = "Task role for ${var.service} task in ${var.project}-${var.env}. Owned by ${var.owner}."
   assume_role_policy = "${data.aws_iam_policy_document.role.json}"
 }
-
-resource "aws_iam_role_policy" "policy" {
-  name = "${var.project}-${var.env}-${var.service}"
-  role = "${aws_iam_role.role.id}"
-
-  policy = "${var.policy}"
-}

--- a/aws-iam-ecs-task-role/variables.tf
+++ b/aws-iam-ecs-task-role/variables.tf
@@ -21,9 +21,3 @@ variable "owner" {
 
   description = "Email address of the owner. Can be a group address."
 }
-
-variable "policy" {
-  type = "string"
-
-  description = "IAM policy to grant to this role."
-}


### PR DESCRIPTION
This PR removes the policy argument from `aws-iam-ecs-task-role`. Users are expected to use the role name as the output of the module, and attach policies or role policies manually instead like so:

```
module "role" {
    source = "github.com/chanzuckerberg/cztack//aws-iam-ecs-task-role"
    ... project/env/service/owner ...
}

module "policy" {
    source    = "github.com/chanzuckerberg/cztack//aws-params-reader-policy"
    ... project/env/service ...
    role_name = "${module.role.name}"
}

resource "aws_iam_role_policy" "own-policy" {
    role = "${module.role.name}"
    policy = "${insert_policy_arn_here}"
}
```

We do this instead of passing in the text or ARNs of existing policies as an argument because of the problems we've had in the past of making those ARNs unique.

* In the past, we had used a pattern of creating a standalone `aws_iam_policy`, then attaching it to the role via an `aws_iam_role_policy_attachment`, passing it the ARN of the `aws_iam_policy`. However, when we create the policy, since its name must be unique, that means that we actually have to customize the policy name to include the role name as part of its name so that it doesn't conflict when we reuse the same module. This breaks our naming scheme. At that point, the realization is that we are truly making a role specific policy, so we might as well use an `aws_iam_role_policy` instead of trying to uniquify the name of the `aws_iam_policy`, since aws_iam_role_policy doesn't have its own proper name (and thus will not name conflict). But in that case, the `aws_iam_role_policy` has no ARN to pass in as an argument to `aws-iam-ecs-task-role`.

* So in that case, one way around this is to actually have an `aws_iam_policy` that is reusable across multiple roles, and thus has no need to have a role name embedded in it. This would have an ARN we could pass as an argument. However, since this policy is shared, it can't really live in any of the user's components specific to their feature; it has to be created in some other component that lives outside of their feature components, e.g. a component called "iam-common", and referred to in the feature components via `"${data.terraform_remote_state.iam-common.aws_iam_policy.policy.arn}"`. But this just adds more layers of indirection for the Terraform user to write/maintain.

If you truly think having common components for IAM policies as in #2, I can provide that kind of PR instead. However, if we go with #1, we either have to provide the text of the policy document (but in the case of multiple policies we then have to figure out how to merge documents, or make them provide a list of policy texts), or just go with the model where the policies are attached external to the module by passing the role's ARN around. This last model is what I propose going with for all future cztack modules, and doesn't preclude the user from being able to attach the shared modules.