### PR TITLE
Add aws-iam-instance-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This module will create a good password policy for your AWS account.
 
 [Read More](aws-iam-password-policy/README.md)
 
+### AWS IAM instance profile
+
+This module will create an EC2 instance profile, attaching to it a new IAM role with permissions to run standard system agents (Systems Manager Agent and Cloudwatch Logs Agent).
+
+[Read More](aws-iam-instance-profile/README.md)
+
 ### AWS IAM cloudwatch logs policy
 
 This will create a policy that allow writing to cloudwatch logs.

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -1,0 +1,50 @@
+# AWS IAM Instance Profile
+
+This module will create an EC2 instance profile, attaching to it a new IAM role with permissions to run standard system agents (Systems Manager Agent and Cloudwatch Logs Agent).
+
+The IAM role has policies attached to allow it to integrate with AWS reporting agents to track systems configuration and for remote maintenance through Systems Manager. It also allows reporting logs of the agents through Cloudwatch Logs Agent.
+
+For any other permissions that need to be attached to the role, this can be done by using the role name/ARN returned as an output.
+
+## Example
+
+```hcl
+module "profile" {
+  source = "github.com/chanzuckerberg/cztack//aws-iam-instance_profile?ref=v0.14.0"
+
+  # The prefix of the name of the instance profile and role to create in this account.
+  name_prefix = "..."
+}
+
+resource "aws_iam_role_policy_attachment" {
+  role       = "${module.profile.role_arn}"
+  policy_arn = "arn:aws:iam::aws:policy/AnyPolicyARNGoesHere"
+}
+
+resource "aws_instance" "instance" {
+  # ...
+  iam_instance_profile = "${module.profile.profile_arn}"
+  # ...
+}
+```
+
+<!-- START -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| iam_path | The IAM path to the role. | string | `/` | no |
+| name_prefix | Creates a unique name for both the role and instance profile beginning with the specified prefix. Max 32 characters long. | string | - | yes |
+| role_description | The description of the IAM role. | string | `` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| profile_arn | The ARN assigned by AWS to the instance profile. |
+| profile_name | The instance profile's name. |
+| role_arn | The Amazon Resource Name (ARN) specifying the role. |
+| role_name | The name of the role. |
+
+<!-- END -->

--- a/aws-iam-instance-profile/main.tf
+++ b/aws-iam-instance-profile/main.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "assume-role" {
+  statement {
+    sid     = "AssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name_prefix        = "${var.name_prefix}"
+  description        = "${var.role_description}"
+  path               = "${var.iam_path}"
+  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "profile" {
+  name_prefix = "${var.name_prefix}"
+  path        = "${var.iam_path}"
+  role        = "${aws_iam_role.role.name}"
+}

--- a/aws-iam-instance-profile/module_test.go
+++ b/aws-iam-instance-profile/module_test.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/chanzuckerberg/cztack/testutil"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestAWSIAMInstanceProfile(t *testing.T) {
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
+			"name_prefix":      random.UniqueId(),
+			"iam_path":         "/foo/",
+			"role_description": random.UniqueId(),
+		},
+	)
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	testutil.Run(t, terraformOptions)
+}

--- a/aws-iam-instance-profile/outputs.tf
+++ b/aws-iam-instance-profile/outputs.tf
@@ -1,0 +1,19 @@
+output "role_arn" {
+  value       = "${aws_iam_role.role.arn}"
+  description = "The Amazon Resource Name (ARN) specifying the role."
+}
+
+output "role_name" {
+  value       = "${aws_iam_role.role.name}"
+  description = "The name of the role."
+}
+
+output "profile_arn" {
+  value       = "${aws_iam_instance_profile.profile.arn}"
+  description = "The ARN assigned by AWS to the instance profile."
+}
+
+output "profile_name" {
+  value       = "${aws_iam_instance_profile.profile.name}"
+  description = "The instance profile's name."
+}

--- a/aws-iam-instance-profile/variables.tf
+++ b/aws-iam-instance-profile/variables.tf
@@ -1,0 +1,16 @@
+variable "name_prefix" {
+  type        = "string"
+  description = "Creates a unique name for both the role and instance profile beginning with the specified prefix. Max 32 characters long."
+}
+
+variable "iam_path" {
+  type        = "string"
+  default     = "/"
+  description = "The IAM path to the role."
+}
+
+variable "role_description" {
+  type        = "string"
+  description = "The description of the IAM role."
+  default     = ""
+}


### PR DESCRIPTION
This PR adds a new aws-iam-instance-profile module that creates both an IAM role and an EC2 instance profile. The IAM role has policies attached to allow Systems Manager Agent and Cloudwatch Logs Agent to interact with AWS servers. This also allows us to change the permissions for the EC2 agent in the future if we find other agents or permissions that we want to be opinionated about being the base.

The intent is that we will replace existing AWS roles and instance profiles created in individual modules with the ones created here. This will either require Terraform state migrations or brief downtimes when the roles are recreated. This may also require rotating out existing instances that have different instance profiles from the one created by the original autoscaling group. This may also force some changes when replacing instance profiles whose names mismatch the role, or when the role used a specific name instead of a name prefix.