### PR TITLE
aws-iam-instance-profile ignore name_prefix

### DIFF
--- a/aws-iam-instance-profile/main.tf
+++ b/aws-iam-instance-profile/main.tf
@@ -15,6 +15,10 @@ resource "aws_iam_role" "role" {
   description        = "${var.role_description}"
   path               = "${var.iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+
+  lifecycle {
+    ignore_changes = ["name", "name_prefix", "path"]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
@@ -31,4 +35,8 @@ resource "aws_iam_instance_profile" "profile" {
   name_prefix = "${var.name_prefix}"
   path        = "${var.iam_path}"
   role        = "${aws_iam_role.role.name}"
+
+  lifecycle {
+    ignore_changes = ["name", "name_prefix", "path"]
+  }
 }


### PR DESCRIPTION
This PR makes the new aws-iam-instance-profile module temporarily ignore name/name_prefix/path changes to ease the Terraform migrations of existing resources.