### PR TITLE
Add iam_path to ec2 poweruser role

### DIFF
--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "assume-role" {
 
 resource "aws_iam_role" "ec2-poweruser" {
   name               = "${var.role_name}"
+  path               = "${var.iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
 }
 


### PR DESCRIPTION
This PR bring the aws-iam-role-ec2-poweruser module in line with the other aws-iam-role-* modules by actually using the iam_path variable for the IAM role it generates. This can affect the role's ARN, and all the other modules do set the path based on the user's input (defaulting to '/', so this should be backwards compatible)