### PR TITLE
aws-iam-instance-profile Add option to disable attaching SSM policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - aws configure set aws_secret_access_key $CI2_AWS_SECRET_ACCESS_KEY --profile
       cztack-ci-2
     - aws --profile cztack-ci-2 sts get-caller-identity
-    script: travis_wait 30 make test
+    script: travis_wait 45 make test
 env:
   global:
   - secure: H6toE/cJTjXbp9QEONjA2wvWxIPIzPiX3VRY0r5C6YTYEMeujR/w8XW/HMrUFgK7DrD6td5vgpDVeoC84SmQ/KIyU/jEOJsjktxcsMK4Y/5Pbi5p9iK24ps7LUFLDGtYAnYiSOWd3lTDr1vRp/N1Es8VaSqyyRJwi5NwBFGjA0YoxiriIYe7WRCz9HRTiUSQ3PKZPJBLznqUrClvwVq9kZyI7zwyNmDYOrbXzKRPJfPCxHlWE/RsglXu0tSmuL6qxXVIhqp7ijRwJcCSMqpXYyYXPIHAm3b4dyXLSCzI3j+HwZqoTtnZFROMYrhVrgPlcntOe/NWMDu3UurE3ePEG6ghP/E5VD6xgcyiFDYvQV5f4ERPhmfurmOewESJdrtNQhepGutTaUX/gEzdu8rTaxc1fWFmOkscQOWCiPThqowdBP2kQtcrv660Z1PmtNuHmGyBS8j0hkkuyfWjX6YMf+egXpJSDT5kaEw+l6mn9yqL752hUdehKiBEroWqiv9eszFkFqPtBvNZO9vi+bRLeraq9lZJRHjS/T6LosfrLnXAo1X3Uqx79ruNFqLccADlsSqVMsSnyyIyv2d4uXvYTgPrqra1vbu7TQgjuMvwHXiLGt+h/ZLm8HFvSCFNAwzz3Ca+LxTN0TNpEHGmiqj0FoTfyuENvbAMkL4wyU7RprA=

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -10,7 +10,7 @@ For any other permissions that need to be attached to the role, this can be done
 
 ```hcl
 module "profile" {
-  source = "github.com/chanzuckerberg/cztack//aws-iam-instance_profile?ref=v0.14.0"
+  source = "github.com/chanzuckerberg/cztack//aws-iam-instance_profile?ref=v0.15.1"
 
   # The prefix of the name of the instance profile and role to create in this account.
   name_prefix = "..."
@@ -34,6 +34,7 @@ resource "aws_instance" "instance" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| enable_ssm | Attach the appropriate policies to allow the instance to integrate with AWS Systems Manager. | string | `true` | no |
 | iam_path | The IAM path to the role. | string | `/` | no |
 | name_prefix | Creates a unique name for both the role and instance profile beginning with the specified prefix. Max 32 characters long. | string | - | yes |
 | role_description | The description of the IAM role. | string | `` | no |

--- a/aws-iam-instance-profile/main.tf
+++ b/aws-iam-instance-profile/main.tf
@@ -22,6 +22,7 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
+  count      = "${var.enable_ssm ? 1 : 0}"
   role       = "${aws_iam_role.role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }

--- a/aws-iam-instance-profile/module_test.go
+++ b/aws-iam-instance-profile/module_test.go
@@ -22,3 +22,19 @@ func TestAWSIAMInstanceProfile(t *testing.T) {
 
 	testutil.Run(t, terraformOptions)
 }
+
+func TestAWSIAMInstanceProfileDisableSSM(t *testing.T) {
+	terraformOptions := testutil.Options(
+		testutil.IAMRegion,
+		map[string]interface{}{
+			"name_prefix":      random.UniqueId(),
+			"iam_path":         "/foo/",
+			"role_description": random.UniqueId(),
+			"enable_ssm":       "false",
+		},
+	)
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	testutil.Run(t, terraformOptions)
+}

--- a/aws-iam-instance-profile/variables.tf
+++ b/aws-iam-instance-profile/variables.tf
@@ -14,3 +14,9 @@ variable "role_description" {
   description = "The description of the IAM role."
   default     = ""
 }
+
+variable "enable_ssm" {
+  type        = "string"
+  description = "Attach the appropriate policies to allow the instance to integrate with AWS Systems Manager."
+  default     = "true"
+}


### PR DESCRIPTION
This PR adds the ability to disable attaching the SSM policy to the role created in aws-iam-instance-profile. It is believed this will disable the ssm-agent, and specifically prevent it from creating the ssm-user on the local machine, which has been messing up some pre-set UIDs.