### PR TITLE
Add iam_path to aws-iam-ecs-task-role

### DIFF
--- a/aws-iam-ecs-task-role/README.md
+++ b/aws-iam-ecs-task-role/README.md
@@ -27,6 +27,7 @@ output "ecs-role-arn" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | env | Environment name. For example– dev, staging or prod. | string | - | yes |
+| iam_path | IAM path for the role. | string | `/` | no |
 | owner | Email address of the owner. Can be a group address. | string | - | yes |
 | project | High-level project, should be unique across the organization. | string | - | yes |
 | service | Name of this thing we're running. | string | - | yes |

--- a/aws-iam-ecs-task-role/main.tf
+++ b/aws-iam-ecs-task-role/main.tf
@@ -13,4 +13,5 @@ resource "aws_iam_role" "role" {
   name               = "${var.project}-${var.env}-${var.service}"
   description        = "Task role for ${var.service} task in ${var.project}-${var.env}. Owned by ${var.owner}."
   assume_role_policy = "${data.aws_iam_policy_document.role.json}"
+  path               = "${var.iam_path}"
 }

--- a/aws-iam-ecs-task-role/variables.tf
+++ b/aws-iam-ecs-task-role/variables.tf
@@ -1,23 +1,25 @@
 variable "project" {
-  type = "string"
-
+  type        = "string"
   description = "High-level project, should be unique across the organization."
 }
 
 variable "env" {
-  type = "string"
-
+  type        = "string"
   description = "Environment name. For example– dev, staging or prod."
 }
 
 variable "service" {
-  type = "string"
-
+  type        = "string"
   description = "Name of this thing we're running."
 }
 
 variable "owner" {
-  type = "string"
-
+  type        = "string"
   description = "Email address of the owner. Can be a group address."
+}
+
+variable "iam_path" {
+  type        = "string"
+  default     = "/"
+  description = "IAM path for the role."
 }


### PR DESCRIPTION
This PR adds an optional iam_path argument to aws-iam-ecs-task-role, bringing it in line with our other aws-iam-*-role modules and allowing people to place the role in a specific path.