### PR TITLE
Add allowCI tagged secretsmanager read access to aws-iam-role-infraci

### DIFF
--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -51,6 +51,18 @@ data "aws_iam_policy_document" "secrets" {
 
     resources = ["*"]
   }
+
+  statement {
+    sid       = "secretsmanager"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "secretsmanager:ResourceTag/allowCI"
+      values   = ["true"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "secrets" {


### PR DESCRIPTION
This PR allows any infraci role that uses the module to read all secretsmanager secrets only if the secret has a tag called "allowCI" with a value of the string "true". By default, secretsmanager secrets will not be readable by roles created by this module, but if that tag is added, it is visible. Note that this tag permissioning is allowed cross account too, as long as the account with the secretsmanager is allowing access cross account as well and the secret in the other account also has this allowCI tag.