### PR TITLE
Add iam:TagRole to poweruser

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -67,6 +67,7 @@ data "aws_iam_policy_document" "misc" {
       "iam:PutRole",
       "iam:PutRolePolicy",
       "iam:RemoveRoleFromInstanceProfile",
+      "iam:TagRole",
       "iam:UpdateRole",
     ]
 


### PR DESCRIPTION
This PR adds the new iam:TagRole permission to the IAM poweruser module.