### PR TITLE
[breaking] Removing ability of powerusers to register domains via route53

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "misc" {
       "iam:DeleteUser",
       "iam:CreateGroup",
       "iam:DeleteGroup",
+      "route53domains:RegisterDomain",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Deny power users ability to register domains in Route53. 

Next step: create new user to specifically deal with domain registration/transfers in Route53