### PR TITLE
Adding in Route53ReadOnly Access to Route53Domains-PowerUser Role

### DIFF
--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -1,12 +1,12 @@
 # AWS IAM role for Route53Domains Poweruser
 
-This module will create a role which has Route53Domains FullAccess privileges.
+This module will create a role which has Route53Domains FullAccess privileges and Route53 ReadOnly priveleges.
 
 ## Example
 
 ```hcl
 module "route53domains-poweruser" {
-  source = "github.com/chanzuckerberg/cztack//aws-iam-role-route53domains-poweruser?ref=v0.14.0"
+  source = "github.com/chanzuckerberg/cztack/aws-iam-role-route53domains-poweruser?ref=v0.14.0"
 
   # The name of the role to create in this account.
   role_name = "..."

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -19,3 +19,8 @@ resource "aws_iam_role_policy_attachment" "route53domains-fullaccess" {
   role       = "${aws_iam_role.route53domains-poweruser.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53DomainsFullAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "route53-readonly" {
+  role       = "${aws_iam_role.route53domains-poweruser.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
+}


### PR DESCRIPTION
Needed to add the route53ReadOnly policy to the Route53 power user IAM role that I created previously. I need to be able to read and download the zone files for our hosted domains and this should give me the privileges to do that.