### PR TITLE
ACM cert lifecycle

### DIFF
--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -6,8 +6,6 @@ locals {
     owner     = "${var.owner}"
     managedBy = "terraform"
   }
-
-  cert_validation_count = "${length(var.cert_subject_alternative_names) + 1}"
 }
 
 resource "aws_acm_certificate" "cert" {
@@ -19,7 +17,7 @@ resource "aws_acm_certificate" "cert" {
 
 # https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html
 resource "aws_route53_record" "cert_validation" {
-  count = "${local.cert_validation_count}"
+  count = "${length(aws_acm_certificate.cert.domain_validation_options)}"
 
   name    = "${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")}"
   type    = "${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")}"

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -15,10 +15,6 @@ resource "aws_acm_certificate" "cert" {
   subject_alternative_names = ["${keys(var.cert_subject_alternative_names)}"]
   validation_method         = "DNS"
   tags                      = "${local.tags}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html


### PR DESCRIPTION
### Summary
If we have one resource with a create_before_destroy I think all of the dependent resources must also have this lifecycle. I don't think we can create_before_destroy on route53 records. Therefore I think we can't have the create_before_destroy on the acm_cert either. The problem we were seeing is that the cert validations were created for the "deposed" version of the cert. Then a new cert would be created. Then the next time around the cert validations would be out of sync with the new cert since they were created for the old cert (even though there was no code change in the middle).
