### PR TITLE
[fix] ACM certificate route53 validation overwrite

### DIFF
--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -33,6 +33,7 @@ module "cert" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allow\_validation\_record\_overwrite | Allow the overwrite of validation records. This is needed if you are creating certificates in multiple regions. | string | `"true"` | no |
 | aws\_route53\_zone\_id |  | string | n/a | yes |
 | cert\_domain\_name | Like www.foo.bar.com or *.foo.bar.com | string | n/a | yes |
 | cert\_subject\_alternative\_names | A map of <alternative_domain:route53_zone_id> | map | `<map>` | no |

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -30,6 +30,8 @@ resource "aws_route53_record" "cert_validation" {
   zone_id = "${lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)}"
   records = ["${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")}"]
   ttl     = "${var.validation_record_ttl}"
+
+  allow_overwrite = "${var.allow_validation_record_overwrite}"
 }
 
 resource "aws_acm_certificate_validation" "cert" {

--- a/aws-acm-cert/variables.tf
+++ b/aws-acm-cert/variables.tf
@@ -37,3 +37,9 @@ variable "owner" {
   type        = "string"
   description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)."
 }
+
+variable "allow_validation_record_overwrite" {
+  type        = "string"
+  description = "Allow the overwrite of validation records. This is needed if you are creating certificates in multiple regions."
+  default     = true
+}


### PR DESCRIPTION
### Summary
The new tf provider refuses to overwrite existing route53 records breaking previous functionality. This is a problem for acm since we need the same record for each region. Therefore, we allow route53 records to be overwritten by default.

### Test Plan
unittests

### References
https://github.com/terraform-providers/terraform-provider-aws/issues/7918
