### PR TITLE
add force_detach_policies to aws_iam_role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check-docs:
 	done;
 
 clean:
-		rm **/*.tfstate*
+		rm **/*.tfstate*; true
 
 test: fmt
-	GOCACHE=off AWS_PROFILE=cztack-ci-1 AWS_SDK_LOAD_CONFIG=true gotest -parallel 10 -test.timeout 45m $(TEST)
+	AWS_PROFILE=cztack-ci-1 AWS_SDK_LOAD_CONFIG=true gotest -count=1 -parallel 10 -test.timeout 45m $(TEST)

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -13,4 +13,9 @@ resource "aws_iam_role" "role" {
   name               = "${var.role_name}"
   path               = "${var.iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+
+  # We have to force detach policies in order to recreate roles.
+  # The other option would be to use name_prefix and create_before_destroy, but that
+  # doesn't work if you want a role with a stable, memorable name.
+  force_detach_policies = true
 }


### PR DESCRIPTION
This enables the role to be recreated without using name_prefix + create_before_destroy.

Also fixes tests for running with go 1.12, will upgrade the travis build later.

### Test Plan
* local unit tests

### References
* https://www.terraform.io/docs/providers/aws/r/iam_role.html#force_detach_policies
