### PR TITLE
WIP: Create region-bound poweruser role

### DIFF
--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -17,19 +17,4 @@ module "group" {
 ```
 
 <!-- START -->
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| iam\_path |  | string | `"/"` | no |
-| role\_name |  | string | `"poweruser"` | no |
-| source\_account\_id |  | string | n/a | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| arn |  |
-| role\_name |  |
-
 <!-- END -->

--- a/aws-iam-role-poweruser/kms.tf
+++ b/aws-iam-role-poweruser/kms.tf
@@ -1,0 +1,37 @@
+
+locals {
+  enable_kms = "${var.enable_kms ? 1 : 0}"
+
+// Write confined to regions
+data "aws_iam_policy_document" "kms-write-regional" {
+  statement {
+    sid       = "kmsWriteRegional"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    // HACK: I wish I could conditionally assign this block but don't know how to do it in terraform
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = ["${var.authorized_regions}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "kms-write" {
+  statement {
+    sid       = "kmsWrite"
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+resource "aws_iam_role_policy" "kms-write-regional" {
+  count  = "${local.enable_kms * local.all_regions_disabled}"
+  name   = "kms-write-regional"
+  policy = "${data.aws_iam_policy_document.kms-write-regional.json}"
+}
+
+resource "aws_iam_role_policy" "kms-write-all-regions" {
+  count      = "${local.enable_kms * local.all_regions_enabled}"
+  role       = "${aws_iam_role.poweruser.name}"
+  policy = "${var.aws_iam_policy_document.kms-write.json}"
+}

--- a/aws-iam-role-poweruser/lambda.tf
+++ b/aws-iam-role-poweruser/lambda.tf
@@ -1,0 +1,57 @@
+
+locals {
+  enable_lambda = "${var.enable_lambda ? 1 : 0}"
+
+}
+// Readonly everywhere
+resource "aws_iam_role_policy_attachment" "lambda-readonly" {
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess"
+}
+
+
+// Write confined to regions
+// adapted from arn:aws:iam::aws:policy/AWSLambdaFullAccess
+data "aws_iam_policy_document" "lambda-write-regional" {
+  statement {
+    sid = "lambdaWriteRegional"
+    actions = [
+      "lambda:*",
+
+      // TODO: what to do about these
+      "cloudwatch:*",
+      "events:*",
+      "logs:*",
+      "sns:ListSubscriptions",
+      "sns:ListSubscriptionsByTopic",
+      "sns:ListTopics",
+      "sns:Publish",
+      "sns:Subscribe",
+      "sns:Unsubscribe",
+      "sqs:ListQueues",
+      "sqs:SendMessage",
+      "tag:GetResources",
+      "xray:PutTelemetryRecords",
+      "xray:PutTraceSegments"
+    ]
+    resources = ["*"]
+    // HACK: I wish I could conditionally assign this block but don't know how to do it in terraform
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = ["${var.authorized_regions}"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "lambda-write-regional" {
+  count  = "${local.enable_lambda * local.all_regions_disabled}"
+  name   = "lambda-write-regional"
+  policy = "${data.aws_iam_policy_document.lambda-write-regional.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda-write-all-regions" {
+  count      = "${local.enable_lambda * local.all_regions_enabled}"
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+}

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -1,3 +1,8 @@
+locals {
+  all_regions_enabled  = "${length(var.authorized_regions) == 0 ? 1 : 0}"
+  all_regions_disabled = "${1 - local.all_regions_enabled}"
+}
+
 data "aws_iam_policy_document" "assume-role" {
   statement {
     principals {
@@ -18,17 +23,6 @@ resource "aws_iam_role" "poweruser" {
 resource "aws_iam_role_policy_attachment" "poweruser" {
   role       = "${aws_iam_role.poweruser.name}"
   policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
-}
-
-data "aws_iam_policy_document" "poweruser" {
-  statement {
-    sid = "misc"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
-    }
-  }
 }
 
 # These are extra permissions we're adding that

--- a/aws-iam-role-poweruser/s3.tf
+++ b/aws-iam-role-poweruser/s3.tf
@@ -1,0 +1,37 @@
+locals {
+  enable_s3 = "${var.enable_s3 ? 1 : 0}"
+
+}
+// Readonly everywhere
+resource "aws_iam_role_policy_attachment" "s3-readonly" {
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+
+// Write confined to regions
+data "aws_iam_policy_document" "s3-write-regional" {
+  statement {
+    sid       = "s3WriteRegional"
+    actions   = ["s3:*"]
+    resources = ["*"]
+    // HACK: I wish I could conditionally assign this block but don't know how to do it in terraform
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = ["${var.authorized_regions}"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "s3-write-regional" {
+  count  = "${local.enable_s3 * local.all_regions_disabled}"
+  name   = "s3-write-regional"
+  policy = "${data.aws_iam_policy_document.s3-write-regional.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "s3-write-all-regions" {
+  count      = "${local.enable_s3 * local.all_regions_enabled}"
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -11,3 +11,22 @@ variable "iam_path" {
   type    = "string"
   default = "/"
 }
+
+variable "authorized_regions" {
+  type        = "list"
+  default     = []
+  description = "Authorized regions for this role. Empty list means all regions."
+}
+
+variable "enable_s3" {
+  type    = "string"
+  default = false
+}
+variable "enable_lambda" {
+  type    = "string"
+  default = false
+}
+variable "enable_kms" {
+  type    = "string"
+  default = false
+}


### PR DESCRIPTION
### Summary
Opening this PR draft to get some early feedback before I invest more time going down this path.
The idea is to limit the surface area powerusers can interact with by:
- constraining regions available
- constraining aws services available

risks:
- [iam limits](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html)

### Test Plan
- test in some of our roles

### References
- https://aws.amazon.com/blogs/security/easier-way-to-control-access-to-aws-regions-using-iam-policies/
