### PR TITLE
 set engine_version for aws-aurora-postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 cache: pip
 install:
 # terraform
-- wget -t 10 -O terraform.zip https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip
+- wget -t 10 -O terraform.zip https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.6_linux_amd64.zip
 - unzip terraform.zip
 - mv terraform ~/bin/
 - chmod +x ~/bin/terraform
@@ -14,9 +14,9 @@ install:
 - wget -t 10 -O terraform-provider-bless.tar https://github.com/chanzuckerberg/terraform-provider-bless/releases/download/v0.2.8/terraform-provider-bless_0.2.8_linux_amd64.tar.gz
 - tar -C ~/bin -xzf terraform-provider-bless.tar
 # terraform-docs
-- wget -t 10 -O terraform-docs https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64
-- mv terraform-docs ~/bin/terraform-docs
-- chmod +x ~/bin/terraform-docs
+# - wget -t 10 -O terraform-docs https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64
+# - mv terraform-docs ~/bin/terraform-docs
+# - chmod +x ~/bin/terraform-docs
 # awscli
 - pip install awscli --upgrade --user
 # gotest
@@ -32,16 +32,11 @@ jobs:
   #   script: make check-docs
   - stage: check
     before_script:
-    - aws configure set aws_access_key_id     $CI1_AWS_ACCESS_KEY_ID     --profile
-      cztack-ci-1
-    - aws configure set aws_secret_access_key $CI1_AWS_SECRET_ACCESS_KEY --profile
-      cztack-ci-1
+    - aws configure set aws_access_key_id     $CI1_AWS_ACCESS_KEY_ID     --profile cztack-ci-1
+    - aws configure set aws_secret_access_key $CI1_AWS_SECRET_ACCESS_KEY --profile cztack-ci-1
     - aws --profile cztack-ci-1 sts get-caller-identity
-
-    - aws configure set aws_access_key_id     $CI2_AWS_ACCESS_KEY_ID     --profile
-      cztack-ci-2
-    - aws configure set aws_secret_access_key $CI2_AWS_SECRET_ACCESS_KEY --profile
-      cztack-ci-2
+    - aws configure set aws_access_key_id     $CI2_AWS_ACCESS_KEY_ID     --profile cztack-ci-2
+    - aws configure set aws_secret_access_key $CI2_AWS_SECRET_ACCESS_KEY --profile cztack-ci-2
     - aws --profile cztack-ci-2 sts get-caller-identity
     script: travis_wait 45 make test
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 cache: pip
 install:
 # terraform
-- wget -t 10 -O terraform.zip https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.6_linux_amd64.zip
+- wget -t 10 -O terraform.zip https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
 - unzip terraform.zip
 - mv terraform ~/bin/
 - chmod +x ~/bin/terraform

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -16,36 +16,43 @@ func TestAWSAuroraPostgresInit(t *testing.T) {
 
 func TestAWSAuroraPostgresInitAndApply(t *testing.T) {
 	t.Parallel()
-	project := testutil.UniqueId()
-	env := testutil.UniqueId()
-	service := testutil.UniqueId()
-	owner := testutil.UniqueId()
+	versions := []string{"9.6", "10"}
 
-	vpc := testutil.EnvVar(testutil.EnvVPCID)
-	databaseSubnetGroup := testutil.EnvVar(testutil.EnvDatabaseSubnetGroup)
-	ingressCidrBlocks := testutil.EnvVar(testutil.EnvVPCCIDRBlock)
+	for _, version := range versions {
+		func() {
+			project := testutil.UniqueId()
+			env := testutil.UniqueId()
+			service := testutil.UniqueId()
+			owner := testutil.UniqueId()
 
-	databasePassword := testutil.RandomString(testutil.AlphaNum, 8)
-	databaseUsername := testutil.RandomString(testutil.Alpha, 8)
-	databaseName := testutil.UniqueId()
+			vpc := testutil.EnvVar(testutil.EnvVPCID)
+			databaseSubnetGroup := testutil.EnvVar(testutil.EnvDatabaseSubnetGroup)
+			ingressCidrBlocks := testutil.EnvVar(testutil.EnvVPCCIDRBlock)
 
-	options := testutil.Options(
-		testutil.DefaultRegion,
-		map[string]interface{}{
-			"project": project,
-			"env":     env,
-			"service": service,
-			"owner":   owner,
+			databasePassword := testutil.RandomString(testutil.AlphaNum, 8)
+			databaseUsername := testutil.RandomString(testutil.Alpha, 8)
+			databaseName := testutil.UniqueId()
 
-			"vpc_id":                vpc,
-			"database_subnet_group": databaseSubnetGroup,
-			"database_password":     databasePassword,
-			"database_username":     databaseUsername,
-			"ingress_cidr_blocks":   []string{ingressCidrBlocks},
-			"database_name":         databaseName,
-			"skip_final_snapshot":   true,
-		},
-	)
-	defer terraform.Destroy(t, options)
-	testutil.Run(t, options)
+			options := testutil.Options(
+				testutil.DefaultRegion,
+				map[string]interface{}{
+					"project": project,
+					"env":     env,
+					"service": service,
+					"owner":   owner,
+
+					"vpc_id":                vpc,
+					"database_subnet_group": databaseSubnetGroup,
+					"database_password":     databasePassword,
+					"database_username":     databaseUsername,
+					"ingress_cidr_blocks":   []string{ingressCidrBlocks},
+					"database_name":         databaseName,
+					"skip_final_snapshot":   true,
+					"engine_version":        version,
+				},
+			)
+			defer terraform.Destroy(t, options)
+			testutil.Run(t, options)
+		}()
+	}
 }

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -99,7 +99,7 @@ variable "kms_key_id" {
 variable "engine_version" {
   type        = "string"
   description = "The version of Postgres to use."
-  default     = "9.6"
+  default     = "10"
 }
 
 variable "performance_insights_enabled" {

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -33,7 +33,8 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_rds_cluster" "db" {
-  engine = "${var.engine}"
+  engine         = "${var.engine}"
+  engine_version = "${var.engine_version}"
 
   cluster_identifier                  = "${local.name}"
   database_name                       = "${var.database_name}"
@@ -59,7 +60,8 @@ resource "aws_rds_cluster" "db" {
 }
 
 resource "aws_rds_cluster_instance" "db" {
-  engine = "${var.engine}"
+  engine         = "${var.engine}"
+  engine_version = "${var.engine_version}"
 
   count                   = "${var.instance_count}"
   identifier              = "${local.name}-${count.index}"


### PR DESCRIPTION
It seems that we were relying on 9.6 being the default and this broke when 10 become the default.

### Test Plan
* travis-ci

### References
* 
