### PR TITLE
Add cloudfront outputs for single-page-static-site

### DIFF
--- a/aws-single-page-static-site/outputs.tf
+++ b/aws-single-page-static-site/outputs.tf
@@ -1,1 +1,7 @@
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
+}
 
+output "cloudfront_hosted_zone_id" {
+  value = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+}


### PR DESCRIPTION
### Summary
This PR adds the cloudfront hostname and zone ID to the outputs for the single page static site module. This is needed for supporting vanity aliases to a top level domain (e.g cellxgene-example-data.czi.technology) when the actual bucket/cloudfront is not in the same account as the top level domain.