### PR TITLE
Support multiple services in params reader policy

### DIFF
--- a/aws-params-reader-policy/README.md
+++ b/aws-params-reader-policy/README.md
@@ -8,6 +8,7 @@ Creates a policy to access encrypted parameters in Parameter Store for a given s
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
+| extra_services | Extra services to be given parameter read access to, within the same project and environment. | list(string) | `[]` | no |
 | parameter\_store\_key\_alias | Alias of the encryption key used to encrypt parameter store values. | string | `"parameter_store_key"` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | region | Region the parameter store values can be read from. Defaults to all. | string | `"*"` | no |

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -1,5 +1,10 @@
 locals {
   resource_name = "${var.project}-${var.env}-${var.service}"
+  services      = concat([var.service], var.extra_services)
+
+  param_resources = [
+    for serv in local.services : "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.project}-${var.env}-${serv}/*"
+  ]
 }
 
 data "aws_caller_identity" "current" {}
@@ -18,7 +23,7 @@ data "aws_iam_policy_document" "policy" {
       "ssm:DescribeParameters",
     ]
 
-    resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${local.resource_name}/*"]
+    resources = local.param_resources
   }
 
   statement {

--- a/aws-params-reader-policy/variables.tf
+++ b/aws-params-reader-policy/variables.tf
@@ -29,3 +29,9 @@ variable "region" {
   description = "Region the parameter store values can be read from. Defaults to all."
   type        = "string"
 }
+
+variable "extra_services" {
+  type        = list(string)
+  description = "Extra services to be given parameter read access to, within the same project and environment."
+  default     = []
+}


### PR DESCRIPTION
Adds support for the params-reader-policy to support multiple services for the params prefixes it can read. It uses the existing project-env-service pattern, but also allows users to specify other services, as long as those services also share the same project and env, i.e. project-env-service2, project-env-service3.

Instead of instantiating the params reader multiple times and thus adding multiple IAM policy attachment, this allows us to keep it all in a single IAM policy which keeps us from hitting the IAM policy count limit. Should be backwards compatible with existing usage. This is needed for a particular use case where one team is spreading their SSM parameters across multiple names.
