### PR TITLE
Add internal features to aws-single-page-static-site

### DIFF
--- a/aws-single-page-static-site/README.md
+++ b/aws-single-page-static-site/README.md
@@ -45,13 +45,25 @@ module "site" {
 | aliases | Vanity aliases. Make sure your provided cert supports these. | list | `<list>` | no |
 | aws\_acm\_cert\_arn | An AWS ACM cert. Note that Cloudfront requires certs to be in us-east-1. | string | n/a | yes |
 | aws\_route53\_zone\_id | A route53 zone ID used to write records. | string | n/a | yes |
+| bucket\_name | Name of the bucket to created. If not given, it will use the domain name. | string | `""` | no |
 | cloudfront\_price\_class | Cloudfront [price class](https://aws.amazon.com/cloudfront/pricing/). | string | `"PriceClass_100"` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | index\_document\_path | The path to the index document of your site. | string | `"index.html"` | no |
 | minimum\_tls\_version | Minimum TLS version to accept. | string | `"TLSv1_2016"` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
+| path\_pattern | The pattern (for example, images/*.jpg) that specifies which requests you want this cache behavior to apply to. | string | `"*"` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | subdomain | The subdomain for this static site. | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket\_name |  |
+| bucket\_arn |  |
+| cloudfront\_arn |  |
+| cloudfront\_domain\_name |  |
+| cloudfront\_hosted\_zone\_id |  |
 
 <!-- END -->

--- a/aws-single-page-static-site/outputs.tf
+++ b/aws-single-page-static-site/outputs.tf
@@ -1,3 +1,15 @@
+output "bucket_name" {
+  value = local.bucket_name
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.bucket.arn
+}
+
+output "cloudfront_arn" {
+  value = aws_cloudfront_distribution.s3_distribution.arn
+}
+
 output "cloudfront_domain_name" {
   value = aws_cloudfront_distribution.s3_distribution.domain_name
 }

--- a/aws-single-page-static-site/variables.tf
+++ b/aws-single-page-static-site/variables.tf
@@ -47,7 +47,7 @@ variable "cloudfront_price_class" {
 
 variable "minimum_tls_version" {
   type        = "string"
-  default     = "TLSv1_2016"
+  default     = "TLSv1.1_2016"
   description = "Minimum TLS version to accept."
 }
 
@@ -55,4 +55,16 @@ variable "aliases" {
   type        = "list"
   default     = []
   description = "Vanity aliases. Make sure your provided cert supports these."
+}
+
+variable "bucket_name" {
+  type        = "string"
+  description = "Name of the bucket to created. If not given, it will use the domain name."
+  default     = ""
+}
+
+variable "path_pattern" {
+  type        = "string"
+  description = "The pattern (for example, images/*.jpg) that specifies which requests you want this cache behavior to apply to."
+  default     = "*"
 }


### PR DESCRIPTION
### Summary
This PR brings features over from CZI's internal repo to the public aws-single-page-static-site module. This includes overriding the bucket name, public access blocks, more allowed headers, ordered cache behavior, more outputs, and upgrading the minimum TLS version.