### PR TITLE
Fix aws-ecs-* task execution role permissions

### DIFF
--- a/aws-ecs-job-fargate/iam.tf
+++ b/aws-ecs-job-fargate/iam.tf
@@ -19,7 +19,6 @@ resource "aws_iam_role" "task_execution_role" {
 # the specific ECR arn if applicable, and the specific cloudwatch log group.
 # Either pass both identifiers in, or pass the entire role ARN as an argument
 resource "aws_iam_role_policy_attachment" "task_execution_role" {
-  count      = var.registry_secretsmanager_arn != null ? 1 : 0
   role       = aws_iam_role.task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/aws-ecs-service-fargate/iam.tf
+++ b/aws-ecs-service-fargate/iam.tf
@@ -18,7 +18,6 @@ resource "aws_iam_role" "task_execution_role" {
 # TODO: Add support for giving permissions to ECR ARNs and possibly cloudwatch log group
 # Or provide ability to pass in own execution role ARN
 resource "aws_iam_role_policy_attachment" "task_execution_role" {
-  count      = var.registry_secretsmanager_arn != null ? 1 : 0
   role       = aws_iam_role.task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }


### PR DESCRIPTION
Fix some permissions that accidentally were made conditional for ECS task execution roles; policy should actually always be attached.