### PR TITLE
[bugfix] aws-ecs-service fix type of cidr_blocks

### DIFF
--- a/aws-ecs-service/alb.tf
+++ b/aws-ecs-service/alb.tf
@@ -102,7 +102,7 @@ module "alb-sg" {
 
   egress_with_cidr_blocks = var.awsvpc_network_mode ? [] : [
     {
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = "0.0.0.0/0"
       rule        = "all-all"
     },
   ]


### PR DESCRIPTION
Expects comma separated string, not list.