### PR TITLE
aws-acm-cert Add workaround for TF bug

### DIFF
--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -41,6 +41,7 @@ module "cert" {
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
+| subject\_alternative\_names\_order | Order to list the subject alternative names in the ACM cert. Workaround for https://github.com/terraform-providers/terraform-provider-aws/issues/8531 | list(string) | `null` | no |
 | validation\_record\_ttl |  | string | `"60"` | no |
 
 ## Outputs

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -12,7 +12,7 @@ locals {
 
 resource "aws_acm_certificate" "cert" {
   domain_name               = "${var.cert_domain_name}"
-  subject_alternative_names = "${keys(var.cert_subject_alternative_names)}"
+  subject_alternative_names = var.subject_alternative_names_order == null ? keys(var.cert_subject_alternative_names) : var.subject_alternative_names_order
   validation_method         = "DNS"
   tags                      = "${local.tags}"
 

--- a/aws-acm-cert/variables.tf
+++ b/aws-acm-cert/variables.tf
@@ -43,3 +43,9 @@ variable "allow_validation_record_overwrite" {
   description = "Allow the overwrite of validation records. This is needed if you are creating certificates in multiple regions."
   default     = true
 }
+
+variable "subject_alternative_names_order" {
+  type        = list(string)
+  description = "Order to list the subject alternative names in the ACM cert. Workaround for https://github.com/terraform-providers/terraform-provider-aws/issues/8531"
+  default     = null
+}


### PR DESCRIPTION
Adds the ability for the user to specify the specific order they want for the certificate subject alternative names at a particular time applying. Unfortunately this cannot be a permanent workaround because of <https://github.com/terraform-providers/terraform-provider-aws/issues/8531>, meaning AWS will change the order arbitrarily on their own discretion although the order seems stable within short periods of time allowing the workaround to work. Because of this constantly changing order, just changing the type of cert_subject_alternative_names to a type that allows specifying ordering won't help. This workaround is only needed when the user starts providing more than 1 SAN for a cert.

In most cases, the user can omit this argument, but can possibly set a temporary one time value locally if only to get their PR to go through cleanly one time. Hopefully when Terraform or AWS fixes its bug, we won't need to change the module or its interface to support the fixed value.