### PR TITLE
[fix] aws-ecs support not applying tags to services

### DIFF
--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -30,6 +30,7 @@ changes to the definition, allowing external task definition management.
 | registry\_secretsmanager\_arn | ARN for AWS Secrets Manager secret for credentials to private registry | string | `null` | no |
 | security\_group\_ids | Security group to use for the Fargate task. | list | `<list>` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
+| tag\_service | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | bool | `true` | no |
 | task\_definition | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | string | `null` | no |
 | task\_role\_arn |  | string | n/a | yes |
 | task\_subnets | Subnets to launch Fargate task in. | list | `<list>` | no |

--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -13,6 +13,15 @@ container definition external to Terraform (e.g. using [czecs](https://github.co
 Terraform will use a stub definition, but from that point forward will ignore any
 changes to the definition, allowing external task definition management.
 
+## Migrating old ECS services
+Older ECS services were created with an ARN in an old format that did not include the ECS cluster name as part of the ARN. AWS began allowing opt-in to the new ARN format starting November 15, 2018, and will require the new format starting January 1, 2020. ECS only allows applying tags (such as cost tags) on services that have the new ARN format. Applying tags to older ECS services using the old ARN format will return the following error message:
+```
+InvalidParameterException: Long arn format must be used for tagging operations
+```
+This module by default will assume your organization has opted in to the new ARN format and will apply tags to the ECS service. Creating new services after the opt-in will work fine, but migrating an existing older ECS service to using this module (via a state mv or an import) will encounter the above error message the next time it is applied.
+
+Since changing a service to use the new ARN requires destroying and recreating the service, this can result in downtime. In such cases, you can opt-out applying tags by passing `tag_service = false` as an argument to the module. It is recommended that at the next possible down time, the ECS service be replaced by running `terraform taint`, and if `manage_task_definition = false` restoring the ECS task definition version (the taint/replace will restore to only the last stub definition). After the service is destroy/replaced, the `tag_service = false` argument can be removed.
+
 <!-- START -->
 ## Inputs
 

--- a/aws-ecs-job-fargate/main.tf
+++ b/aws-ecs-job-fargate/main.tf
@@ -33,7 +33,7 @@ resource "aws_ecs_service" "job" {
     security_groups = var.security_group_ids
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 }
 
 resource "aws_ecs_service" "unmanaged-job" {
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "unmanaged-job" {
     ignore_changes = [task_definition]
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 }
 
 # Default container definition if var.manage_task_definition == false

--- a/aws-ecs-job-fargate/variables.tf
+++ b/aws-ecs-job-fargate/variables.tf
@@ -89,3 +89,9 @@ variable "manage_task_definition" {
   type        = bool
   default     = true
 }
+
+variable "tag_service" {
+  description = "Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services."
+  type        = bool
+  default     = true
+}

--- a/aws-ecs-job/README.md
+++ b/aws-ecs-job/README.md
@@ -27,6 +27,7 @@ changes to the definition, allowing external task definition management.
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | string | n/a | yes |
 | scheduling\_strategy | Scheduling strategy for the service: REPLICA or DAEMON. | string | `"REPLICA"` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
+| tag\_service | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | bool | `true` | no |
 | task\_definition | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | string | `null` | no |
 | task\_role\_arn |  | string | n/a | yes |
 

--- a/aws-ecs-job/README.md
+++ b/aws-ecs-job/README.md
@@ -13,6 +13,16 @@ container definition external to Terraform (e.g. using [czecs](https://github.co
 Terraform will use a stub definition, but from that point forward will ignore any
 changes to the definition, allowing external task definition management.
 
+## Migrating old ECS services
+Older ECS services were created with an ARN in an old format that did not include the ECS cluster name as part of the ARN. AWS began allowing opt-in to the new ARN format starting November 15, 2018, and will require the new format starting January 1, 2020. ECS only allows applying tags (such as cost tags) on services that have the new ARN format. Applying tags to older ECS services using the old ARN format will return the following error message:
+```
+InvalidParameterException: Long arn format must be used for tagging operations
+```
+This module by default will assume your organization has opted in to the new ARN format and will apply tags to the ECS service. Creating new services after the opt-in will work fine, but migrating an existing older ECS service to using this module (via a state mv or an import) will encounter the above error message the next time it is applied.
+
+Since changing a service to use the new ARN requires destroying and recreating the service, this can result in downtime. In such cases, you can opt-out applying tags by passing `tag_service = false` as an argument to the module. It is recommended that at the next possible down time, the ECS service be replaced by running `terraform taint`, and if `manage_task_definition = false` restoring the ECS task definition version (the taint/replace will restore to only the last stub definition). After the service is destroy/replaced, the `tag_
+service = false` argument can be removed.
+
 <!-- START -->
 ## Inputs
 

--- a/aws-ecs-job/main.tf
+++ b/aws-ecs-job/main.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_service" "job" {
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   scheduling_strategy                = var.scheduling_strategy
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 }
 
 resource "aws_ecs_service" "unmanaged-job" {
@@ -45,7 +45,7 @@ resource "aws_ecs_service" "unmanaged-job" {
     ignore_changes = [task_definition]
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 }
 
 # Default container definition if var.manage_task_definition == false

--- a/aws-ecs-job/variables.tf
+++ b/aws-ecs-job/variables.tf
@@ -70,3 +70,9 @@ variable "manage_task_definition" {
   type        = bool
   default     = true
 }
+
+variable "tag_service" {
+  description = "Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services."
+  type        = bool
+  default     = true
+}

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -42,7 +42,7 @@ resource "aws_iam_role" "role" {
 }
 
 module "role-policy" {
-  source    = "github.com/chanzuckerberg/cztack//aws-params-reader-policy?ref=v0.19.4"
+  source    = "github.com/chanzuckerberg/cztack//aws-params-reader-policy?ref=v0.21.3"
   project   = var.project
   env       = var.env
   service   = var.component
@@ -90,7 +90,7 @@ data "aws_acm_certificate" "staging" {
 }
 
 module "web-service" {
-  source = "github.com/chanzuckerberg/cztack//aws-ecs-service-fargate?ref=v0.20.0"
+  source = "github.com/chanzuckerberg/cztack//aws-ecs-service-fargate?ref=v0.21.3"
 
   # this is the name of the service and many of the resources will have this name
   service = "myservice"
@@ -141,6 +141,16 @@ In addition to a load balancer, this module supports registering all instances o
 tasks with DNS via ECS service discovery. If with_service_discovery is true, a new private
 DNS zone is created, and the tasks are registered in that DNS zone. The domain name is only
 resolvable from within the VPC; it is not publicly resolvable.
+
+## Migrating old ECS services
+Older ECS services were created with an ARN in an old format that did not include the ECS cluster name as part of the ARN. AWS began allowing opt-in to the new ARN format starting November 15, 2018, and will require the new format starting January 1, 2020. ECS only allows applying tags (such as cost tags) on services that have the new ARN format. Applying tags to older ECS services using the old ARN format will return the following error message:
+```
+InvalidParameterException: Long arn format must be used for tagging operations
+```
+This module by default will assume your organization has opted in to the new ARN format and will apply tags to the ECS service. Creating new services after the opt-in will work fine, but migrating an existing older ECS service to using this module (via a state mv or an import) will encounter the above error message the next time it is applied.
+
+Since changing a service to use the new ARN requires destroying and recreating the service, this can result in downtime. In such cases, you can opt-out applying tags by passing `tag_service = false` as an argument to the module. It is recommended that at the next possible down time, the ECS service be replaced by running `terraform taint`, and if `manage_task_definition = false` restoring the ECS task definition version (the taint/replace will restore to only the last stub definition). After the service is destroy/replaced, the `tag_
+service = false` argument can be removed.
 
 <!-- START -->
 ## Inputs

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -176,6 +176,7 @@ resolvable from within the VPC; it is not publicly resolvable.
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | ssl\_policy | ELB policy to determine which SSL/TLS encryption protocols are enabled. Probably don't touch this. | string | `null` | no |
 | subdomain | Subdomain in the zone. Final domain name will be subdomain.zone | string | n/a | yes |
+| tag\_service | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | bool | `true` | no |
 | task\_definition | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | string | `null` | no |
 | task\_role\_arn |  | string | n/a | yes |
 | task\_subnets | List of subnets in which to deploy the task for awsvpc networking mode. | list | `[]` | no |

--- a/aws-ecs-service-fargate/service.tf
+++ b/aws-ecs-service-fargate/service.tf
@@ -66,7 +66,7 @@ resource "aws_ecs_service" "job" {
     }
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 
   depends_on = [aws_lb.service]
 }
@@ -104,8 +104,7 @@ resource "aws_ecs_service" "unmanaged-job" {
     ignore_changes = [task_definition]
   }
 
-  tags = local.tags
-
+  tags = var.tag_service ? local.tags : {}
 
   depends_on = [aws_lb.service]
 }

--- a/aws-ecs-service-fargate/variables.tf
+++ b/aws-ecs-service-fargate/variables.tf
@@ -190,3 +190,9 @@ variable "manage_task_definition" {
   type        = bool
   default     = true
 }
+
+variable "tag_service" {
+  description = "Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services."
+  type        = bool
+  default     = true
+}

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -38,7 +38,7 @@ resource "aws_iam_role" "role" {
 }
 
 module "role-policy" {
-  source    = "github.com/chanzuckerberg/cztack//aws-params-reader-policy?ref=v0.19.4"
+  source    = "github.com/chanzuckerberg/cztack//aws-params-reader-policy?ref=v0.21.3"
   project   = var.project
   env       = var.env
   service   = var.component
@@ -86,7 +86,7 @@ data "aws_acm_certificate" "staging" {
 }
 
 module "web-service" {
-  source = "github.com/chanzuckerberg/cztack//aws-ecs-service?ref=v0.20.0"
+  source = "github.com/chanzuckerberg/cztack//aws-ecs-service?ref=v0.21.3"
 
   # this is the name of the service and many of the resources will have this name
   service = "myservice"
@@ -133,6 +133,16 @@ In addition to a load balancer, this module supports registering all instances o
 tasks with DNS via ECS service discovery. If with_service_discovery is true, a new private
 DNS zone is created, and the tasks are registered in that DNS zone. The domain name is only
 resolvable from within the VPC; it is not publicly resolvable.
+
+## Migrating old ECS services
+Older ECS services were created with an ARN in an old format that did not include the ECS cluster name as part of the ARN. AWS began allowing opt-in to the new ARN format starting November 15, 2018, and will require the new format starting January 1, 2020. ECS only allows applying tags (such as cost tags) on services that have the new ARN format. Applying tags to older ECS services using the old ARN format will return the following error message:
+```
+InvalidParameterException: Long arn format must be used for tagging operations
+```
+This module by default will assume your organization has opted in to the new ARN format and will apply tags to the ECS service. Creating new services after the opt-in will work fine, but migrating an existing older ECS service to using this module (via a state mv or an import) will encounter the above error message the next time it is applied.
+
+Since changing a service to use the new ARN requires destroying and recreating the service, this can result in downtime. In such cases, you can opt-out applying tags by passing `tag_service = false` as an argument to the module. It is recommended that at the next possible down time, the ECS service be replaced by running `terraform taint`, and if `manage_task_definition = false` restoring the ECS task definition version (the taint/replace will restore to only the last stub definition). After the service is destroy/replaced, the `tag_
+service = false` argument can be removed.
 
 <!-- START -->
 ## Inputs

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -166,6 +166,7 @@ resolvable from within the VPC; it is not publicly resolvable.
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | ssl\_policy | ELB policy to determine which SSL/TLS encryption protocols are enabled. Probably don't touch this. | string | `null` | no |
 | subdomain | Subdomain in the zone. Final domain name will be subdomain.zone | string | n/a | yes |
+| tag\_service | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | bool | `true` | no |
 | task\_definition | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | string | `null` | no |
 | task\_role\_arn |  | string | n/a | yes |
 | task\_subnets | List of subnets in which to deploy the task for awsvpc networking mode. Only used if awsvpc_network_mode is true. | list | `[]` | no |

--- a/aws-ecs-service/service.tf
+++ b/aws-ecs-service/service.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_service" "job" {
     }
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 
   depends_on = [aws_lb.service]
 }
@@ -109,7 +109,7 @@ resource "aws_ecs_service" "unmanaged-job" {
     ignore_changes = [task_definition]
   }
 
-  tags = local.tags
+  tags = var.tag_service ? local.tags : {}
 
   depends_on = [aws_lb.service]
 }

--- a/aws-ecs-service/variables.tf
+++ b/aws-ecs-service/variables.tf
@@ -184,3 +184,9 @@ variable "manage_task_definition" {
   type        = bool
   default     = true
 }
+
+variable "tag_service" {
+  description = "Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
### Summary
AWS added support for tagging ECS services in a way that is not backwards compatible with ECS services that have been deployed for a long time. Tags can only be added to ECS services that use a new ARN format that embeds a cluster name inside of the ARN, but older ECS service do not have the name embedded.

For some teams, there are many services that are already deployed, and replacing the ECS service just to apply tags will result in user-visible downtime. We provide a flag for users migrating from the CZI internal module to this public cztack module to be able to prevent Terraform from trying to apply tags, in those cases where the user has determined that applying tags is incompatible with the existing resource. It is recommended that at the next possible down time, that the service be replaced by running terraform taint, then restoring the ECS task definition version (since the taint/replace will restore to only the last stub definition). After the service is destroyed/replaced, the tag_service=false flag can be removed.