### PR TITLE
Output ALB listener ARNs from aws-ecs-service

### DIFF
--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -188,6 +188,8 @@ resolvable from within the VPC; it is not publicly resolvable.
 |------|-------------|
 | alb\_access\_logs\_prefix | ALB access logs S3 prefix |
 | alb\_dns\_name |  |
+| alb\_http\_listener\_arn | ALB HTTPS listener ARN" |
+| alb\_https\_listener\_arn | ALB HTTP listener ARN, only if HTTPS forwarding is disabled |
 | alb\_route53\_zone\_id |  |
 | container\_security\_group\_id | Security group id for the container. |
 | ecs\_task\_definition\_family | The family of the task definition defined for the given/generated container definition. |

--- a/aws-ecs-service-fargate/outputs.tf
+++ b/aws-ecs-service-fargate/outputs.tf
@@ -25,3 +25,13 @@ output "alb_access_logs_prefix" {
   description = "ALB access logs S3 prefix"
   value       = local.access_logs_prefix
 }
+
+output "alb_https_listener_arn" {
+  description = "ALB HTTPS listener ARN"
+  value       = aws_lb_listener.https.arn
+}
+
+output "alb_http_listener_arn" {
+  description = "ALB HTTP listener ARN, only if HTTPS forwarding is disabled"
+  value       = var.disable_http_redirect ? aws_lb_listener.http.arn : null
+}

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -178,9 +178,10 @@ resolvable from within the VPC; it is not publicly resolvable.
 |------|-------------|
 | alb\_access\_logs\_prefix | ALB access logs S3 prefix |
 | alb\_dns\_name |  |
+| alb\_http\_listener\_arn | ALB HTTPS listener ARN" |
+| alb\_https\_listener\_arn | ALB HTTP listener ARN, only if HTTPS forwarding is disabled |
 | alb\_route53\_zone\_id |  |
 | container\_security\_group\_id | Security group id for the container. |
 | ecs\_task\_definition\_family | The family of the task definition defined for the given/generated container definition. |
 | private\_service\_discovery\_domain | Domain name for service discovery, if with_service_discovery=true. Only resolvable within the VPC. |
-
 <!-- END -->

--- a/aws-ecs-service/outputs.tf
+++ b/aws-ecs-service/outputs.tf
@@ -25,3 +25,13 @@ output "alb_access_logs_prefix" {
   description = "ALB access logs S3 prefix"
   value       = local.access_logs_prefix
 }
+
+output "alb_https_listener_arn" {
+  description = "ALB HTTPS listener ARN"
+  value       = aws_lb_listener.https.arn
+}
+
+output "alb_http_listener_arn" {
+  description = "ALB HTTP listener ARN, only if HTTPS forwarding is disabled"
+  value       = var.disable_http_redirect ? aws_lb_listener.http.arn : null
+}


### PR DESCRIPTION
To provide the ability to customize the ALB's rules for an ECS service, we need to provide the ARN of the listener so that they can attach aws_lb_listener_rule instances with references to it. This PR outputs the ARN of the HTTPS listener (usually the one you want), and in cases where we do not auto-redirect the HTTP requests to HTTPS, the HTTP listener. (We intentionally do not output the HTTP listener when redirecting to HTTPS, since we'd prefer users not do any custom rules on the HTTP side.)