### PR TITLE
Add tags to IAM roles

### DIFF
--- a/aws-ecs-job-fargate/iam.tf
+++ b/aws-ecs-job-fargate/iam.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "execution_role" {
 resource "aws_iam_role" "task_execution_role" {
   name               = "${local.name}-execution-role"
   assume_role_policy = data.aws_iam_policy_document.execution_role.json
+  tags               = local.tags
 }
 
 # TODO(mbarrien): We can probably narrow this down to allowing access to only

--- a/aws-ecs-job/iam.tf
+++ b/aws-ecs-job/iam.tf
@@ -13,6 +13,7 @@ resource "aws_iam_role" "task_execution_role" {
   count              = var.registry_secretsmanager_arn != null ? 1 : 0
   name               = "${local.name}-execution-role"
   assume_role_policy = data.aws_iam_policy_document.execution_role.json
+  tags               = local.tags
 }
 
 # TODO(mbarrien): We can probably narrow this down to allowing access to only

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -24,21 +24,12 @@ data "aws_route53_zone" "zone" {
   private_zone = false
 }
 
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_role" "role" {
-  name               = "${var.project}-${var.env}-myservice"
-  description        = "Task role for myservice in ${var.env} environment"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+module "role" {
+  source    = "github.com/chanzuckerberg/cztack//aws-iam-ecs-task-role?ref=v0.21.3"
+  project   = var.project
+  env       = var.env
+  service   = var.component
+  owner     = var.owner
 }
 
 module "role-policy" {
@@ -47,7 +38,7 @@ module "role-policy" {
   env       = var.env
   service   = var.component
   region    = var.region
-  role_name = aws_iam_role.role.name
+  role_name = module.role.name
 }
 
 # This will define a task that runs this (example) container.
@@ -126,7 +117,7 @@ module "web-service" {
   task_definition     = local.template
 
   # The task is given this role. Useful for services that need to make API calls to AWS.
-  task_role_arn       = aws_iam_role.role.arn
+  task_role_arn       = module.role.arn
 
   cpu                 = 256
   memory              = 512

--- a/aws-ecs-service-fargate/iam.tf
+++ b/aws-ecs-service-fargate/iam.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "execution_role" {
 resource "aws_iam_role" "task_execution_role" {
   name               = "${local.name}-execution-role"
   assume_role_policy = data.aws_iam_policy_document.execution_role.json
+  tags               = local.tags
 }
 
 # TODO: Add support for giving permissions to ECR ARNs and possibly cloudwatch log group

--- a/aws-ecs-service/iam.tf
+++ b/aws-ecs-service/iam.tf
@@ -13,6 +13,7 @@ resource "aws_iam_role" "task_execution_role" {
   count              = var.registry_secretsmanager_arn != null ? 1 : 0
   name               = "${local.name}-execution-role"
   assume_role_policy = data.aws_iam_policy_document.execution_role.json
+  tags               = local.tags
 }
 
 # TODO: Add support for giving permissions to ECR ARNs and possibly cloudwatch log group

--- a/aws-iam-ecs-task-role/main.tf
+++ b/aws-iam-ecs-task-role/main.tf
@@ -1,3 +1,14 @@
+locals {
+  tags = {
+    Name      = "${var.project}-${var.env}-${var.service}"
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
+    managedBy = "terraform"
+  }
+}
+
 data "aws_iam_policy_document" "role" {
   statement {
     principals {
@@ -12,6 +23,7 @@ data "aws_iam_policy_document" "role" {
 resource "aws_iam_role" "role" {
   name               = "${var.project}-${var.env}-${var.service}"
   description        = "Task role for ${var.service} task in ${var.project}-${var.env}. Owned by ${var.owner}."
-  assume_role_policy = "${data.aws_iam_policy_document.role.json}"
-  path               = "${var.iam_path}"
+  assume_role_policy = data.aws_iam_policy_document.role.json
+  path               = var.iam_path
+  tags               = local.tags
 }

--- a/bless-ca/iam.tf
+++ b/bless-ca/iam.tf
@@ -59,6 +59,7 @@ resource "aws_iam_role" "bless" {
   name_prefix        = "${local.name}-"
   path               = "${var.iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy" "lambda" {
@@ -68,7 +69,7 @@ resource "aws_iam_role_policy" "lambda" {
 }
 
 module "logs_policy" {
-  source    = "github.com/chanzuckerberg/cztack//aws-iam-policy-cwlogs?ref=v0.14.0"
+  source    = "../aws-iam-policy-cwlogs"
   role_name = "${aws_iam_role.bless.name}"
   iam_path  = "${var.iam_path}"
 }

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -48,9 +48,10 @@ module "attach-logs" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = "${local.name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  name               = local.name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = local.tags
 }
 
 module "github_secret" {


### PR DESCRIPTION
Add tags to IAM roles where project/env/service/owner variables are available. Also updates READMEs for ecs modules to not instantiate own roles, and removes a self reference to the cztack module by URL.