### PR TITLE
[bugfix] fix permissions on aws-ecs-service secrets

### DIFF
--- a/aws-ecs-service-fargate/iam.tf
+++ b/aws-ecs-service-fargate/iam.tf
@@ -28,23 +28,8 @@ data "aws_iam_policy_document" "registry_secretsmanager" {
 
   statement {
     actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [var.registry_secretsmanager_arn]
-  }
-
-  statement {
-    actions = [
       "secretsmanager:GetSecretValue",
     ]
-
-    # Limit to only current version of the secret
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "secretsmanager:VersionStage"
-      values   = ["AWSCURRENT"]
-    }
 
     resources = [var.registry_secretsmanager_arn]
   }

--- a/aws-ecs-service/iam.tf
+++ b/aws-ecs-service/iam.tf
@@ -29,23 +29,8 @@ data "aws_iam_policy_document" "registry_secretsmanager" {
 
   statement {
     actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [var.registry_secretsmanager_arn]
-  }
-
-  statement {
-    actions = [
       "secretsmanager:GetSecretValue",
     ]
-
-    # Limit to only current version of the secret
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "secretsmanager:VersionStage"
-      values   = ["AWSCURRENT"]
-    }
 
     resources = [var.registry_secretsmanager_arn]
   }


### PR DESCRIPTION
Removes permission restriction to only latest version of registry secret; tasks were failing to launch with that restriction even when the secret had only one version and it was marked current.

Also removing kms permission; in most use cases we are currently using the default encryption key and no special permission is needed for it. The permission granted through the current policy is invalid since it isn't actually pointing at a KMS key. Just removing it for now; not adding an input to provide a KMS key ARN for decryption until we actually have that use case.