### PR TITLE
[fix] fix permissions on aws-ecs-job secrets

### DIFF
--- a/aws-ecs-job-fargate/iam.tf
+++ b/aws-ecs-job-fargate/iam.tf
@@ -29,23 +29,8 @@ data "aws_iam_policy_document" "registry_secretsmanager" {
 
   statement {
     actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [var.registry_secretsmanager_arn]
-  }
-
-  statement {
-    actions = [
       "secretsmanager:GetSecretValue",
     ]
-
-    # Limit to only current version of the secret
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "secretsmanager:VersionStage"
-      values   = ["AWSCURRENT"]
-    }
 
     resources = [var.registry_secretsmanager_arn]
   }

--- a/aws-ecs-job/iam.tf
+++ b/aws-ecs-job/iam.tf
@@ -30,23 +30,8 @@ data "aws_iam_policy_document" "registry_secretsmanager" {
 
   statement {
     actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [var.registry_secretsmanager_arn]
-  }
-
-  statement {
-    actions = [
       "secretsmanager:GetSecretValue",
     ]
-
-    # Limit to only current version of the secret
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "secretsmanager:VersionStage"
-      values   = ["AWSCURRENT"]
-    }
 
     resources = [var.registry_secretsmanager_arn]
   }


### PR DESCRIPTION
Forgot to include aws-ecs-job in previous PR #143 for fixing the IAM permissions for reading secrets manager secrets in task execution roles.