### PR TITLE
Add UpdateRoleDescription perms to aws-iam-role-poweruser

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -72,6 +72,7 @@ data "aws_iam_policy_document" "misc" {
       "iam:TagRole",
       "iam:UpdateAssumeRolePolicy",
       "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
### Summary
Adds iam:UpdateRoleDescription to poweruser, allowing them to update the descriptions of roles. In theory, iam:UpdateRole already has this and more, and the AWS docs say to use iam:UpdateRole, but one team ran into issues where Terraform came back with AWS rejecting their attempts to update the description, saying they lacked permission. Given that Terraform is using the old API, we should give them the permissions here.