### PR TITLE
Make aws-redis-node match internal lib, upgrade default

### DIFF
--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -19,7 +19,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "default" {
   cluster_id           = "${var.resource_name != "" ? var.resource_name : local.name}"
   engine               = "redis"
-  engine_version       = "3.2.6"
+  engine_version       = "${var.engine_version}"
   node_type            = "${var.instance_type}"
   port                 = "${var.port}"
   num_cache_nodes      = 1

--- a/aws-redis-node/variables.tf
+++ b/aws-redis-node/variables.tf
@@ -21,6 +21,7 @@ variable "subnets" {
 variable "availability_zone" {
   type        = "string"
   description = "Availability zone in which this instance should run."
+  default     = null
 }
 
 variable "ingress_security_group_ids" {
@@ -42,17 +43,17 @@ variable "port" {
 variable "instance_type" {
   type        = "string"
   description = "The type of instance to run. See [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html)"
-  default     = "cache.m4.large"
+  default     = "cache.m5.large"
 }
 
 variable "parameter_group_name" {
-  default = "default.redis3.2"
+  default = "default.redis5.0"
 }
 
 variable "engine_version" {
   type        = "string"
   description = "The version of Redis to run. See [supported versions](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html)"
-  default     = "4.0.10"
+  default     = "5.0.5"
 }
 
 variable "apply_immediately" {


### PR DESCRIPTION
Porting arguments and defaults from CZI internal module library (with the intent of deleting the internal lib module in favor of this one), and upgrading default Redis engine from 5.0.3 to 5.0.5