### PR TITLE
Allow restricting aws-aurora ingress by security groups

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -44,7 +44,8 @@ module "db" {
 | db\_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Instance) | list | `<list>` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | iam\_database\_authentication\_enabled |  | string | `"false"` | no |
-| ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | n/a | yes |
+| ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
+| ingress\_security\_groups | A list of security groups that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
 | instance\_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html) | string | `"db.t2.small"` | no |
 | instance\_count | Number of instances to create in this cluster. | string | `"1"` | no |
 | kms\_key\_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `""` | no |

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -19,10 +19,11 @@ module "aurora" {
   performance_insights_enabled        = "${var.performance_insights_enabled}"
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 
-  ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
-  vpc_id              = "${var.vpc_id}"
-  publicly_accessible = "${var.publicly_accessible}"
-  port                = 3306
+  ingress_cidr_blocks     = var.ingress_cidr_blocks
+  ingress_security_groups = var.ingress_security_groups
+  vpc_id                  = var.vpc_id
+  publicly_accessible     = var.publicly_accessible
+  port                    = 3306
 
   instance_class = "${var.instance_class}"
   instance_count = "${var.instance_count}"

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -24,8 +24,15 @@ variable "env" {
 }
 
 variable "ingress_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
+  default     = []
   description = "A list of CIDR blocks that should be allowed to communicate with this Aurora cluster."
+}
+
+variable "ingress_security_groups" {
+  type        = list(string)
+  description = "A list of security groups that should be allowed to communicate with this Aurora cluster."
+  default     = []
 }
 
 variable "instance_class" {

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -44,7 +44,8 @@ module "db" {
 | engine\_version | The version of Postgres to use. | string | `"10"` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | iam\_database\_authentication\_enabled |  | string | `"false"` | no |
-| ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list | n/a | yes |
+| ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
+| ingress\_security\_groups | A list of security groups that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
 | instance\_class | See valid instance types [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html) | string | `"db.r4.large"` | no |
 | instance\_count | Number of instances to create in this cluster. | string | `"1"` | no |
 | kms\_key\_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | string | `""` | no |

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -17,12 +17,13 @@ module "aurora" {
   iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
   performance_insights_enabled        = "${var.performance_insights_enabled}"
 
-  ingress_cidr_blocks = "${var.ingress_cidr_blocks}"
-  vpc_id              = "${var.vpc_id}"
-  publicly_accessible = "${var.publicly_accessible}"
-  port                = 5432
-  instance_class      = "${var.instance_class}"
-  instance_count      = "${var.instance_count}"
+  ingress_cidr_blocks     = var.ingress_cidr_blocks
+  ingress_security_groups = var.ingress_security_groups
+  vpc_id                  = var.vpc_id
+  publicly_accessible     = var.publicly_accessible
+  port                    = 5432
+  instance_class          = var.instance_class
+  instance_count          = var.instance_count
 
   # backtrack_window not supported yet
   backtrack_window    = 0

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -24,8 +24,15 @@ variable "env" {
 }
 
 variable "ingress_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
+  default     = []
   description = "A list of CIDR blocks that should be allowed to communicate with this Aurora cluster."
+}
+
+variable "ingress_security_groups" {
+  type        = list(string)
+  description = "A list of security groups that should be allowed to communicate with this Aurora cluster."
+  default     = []
 }
 
 variable "instance_class" {

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -19,7 +19,8 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | engine\_version |  | string | n/a | yes |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | string | n/a | yes |
 | iam\_database\_authentication\_enabled |  | string | `"true"` | no |
-| ingress\_cidr\_blocks |  | list | n/a | yes |
+| ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
+| ingress\_security\_groups | A list of security groups that should be allowed to communicate with this Aurora cluster. | list(string) | `[]` | no |
 | instance\_class |  | string | `"db.t2.small"` | no |
 | instance\_count |  | string | `"1"` | no |
 | kms\_key\_id | If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module. | string | `""` | no |

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -12,16 +12,17 @@ locals {
 }
 
 resource "aws_security_group" "rds" {
-  name        = "${local.name}"
+  name        = local.name
   description = "Allow db traffic."
 
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   ingress {
-    from_port   = "${var.port}"
-    to_port     = "${var.port}"
-    protocol    = "tcp"
-    cidr_blocks = "${var.ingress_cidr_blocks}"
+    from_port       = var.port
+    to_port         = var.port
+    protocol        = "tcp"
+    cidr_blocks     = var.ingress_cidr_blocks
+    security_groups = var.ingress_security_groups
   }
 
   lifecycle {
@@ -29,7 +30,7 @@ resource "aws_security_group" "rds" {
     ignore_changes        = ["name", "description"]
   }
 
-  tags = "${local.tags}"
+  tags = local.tags
 }
 
 resource "aws_rds_cluster" "db" {

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -20,7 +20,15 @@ variable "env" {
 }
 
 variable "ingress_cidr_blocks" {
-  type = "list"
+  type        = list(string)
+  default     = []
+  description = "A list of CIDR blocks that should be allowed to communicate with this Aurora cluster."
+}
+
+variable "ingress_security_groups" {
+  type        = list(string)
+  description = "A list of security groups that should be allowed to communicate with this Aurora cluster."
+  default     = []
 }
 
 variable "instance_class" {


### PR DESCRIPTION
Add ability to restrict aws-aurora ingress by security group, not just by CIDR blocks.