### PR TITLE
[feature] lifecycle policy for s3 buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ check-docs:
 .PHONY: check-docs
 
 clean:
-		rm **/*.tfstate*; true
+	rm **/*.tfstate*; true
 .PHONY: clean
 
 test: fmt

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -18,6 +18,27 @@ resource "aws_s3_bucket" "bucket" {
     enabled = var.enable_versioning
   }
 
+  lifecycle_rule {
+    enabled = true
+
+    abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      days = 365
+    }
+  }
+
+
+
   # TODO
   #   logging {
   #   target_bucket = ""

--- a/aws-s3-private-bucket/module_test.go
+++ b/aws-s3-private-bucket/module_test.go
@@ -3,12 +3,31 @@ package test
 import (
 	"testing"
 
+	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestPrivateBucket(t *testing.T) {
-	options := &terraform.Options{
-		TerraformDir: ".",
-	}
-	terraform.Init(t, options)
+
+	project := testutil.UniqueId()
+	env := testutil.UniqueId()
+	service := testutil.UniqueId()
+	owner := testutil.UniqueId()
+
+	bucketName := testutil.UniqueId()
+
+	options := testutil.Options(
+		testutil.DefaultRegion,
+		map[string]interface{}{
+			"project": project,
+			"env":     env,
+			"service": service,
+			"owner":   owner,
+
+			"bucket_name": bucketName,
+		},
+	)
+
+	defer terraform.Destroy(t, options)
+	testutil.Run(t, options)
 }

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -28,3 +28,9 @@ variable "enable_versioning" {
   description = "Keep old versions of overwritten S3 objects."
   default     = true
 }
+
+variable "abort_incomplete_multipart_upload_days" {
+  type        = number
+  description = "Number of days after which an incomplete multipart upload is canceled."
+  default     = 14
+}


### PR DESCRIPTION
S3 buckets will now have a lifecycle policy that does a few things

1. incomplete multipart uploads will be aborted after 14 days [doc](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config)
2. non-current versions will be moved to infrequent-access storage after 30 days
3. non-current versions will be deleted after 365 days

The test for this module is also changed from just 'init' to doing an apply.

### Test Plan
* newly updated unit test

### References
* https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config
