### PR TITLE
[feature]: Allows poweruser role to iam:ListUsers

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "misc" {
       "iam:ListRolePolicies",
       "iam:ListRoles",
       "iam:ListServerCertificates",
+      "iam:ListUsers",
       "iam:PassRole",
       "iam:PutRole",
       "iam:PutRolePolicy",


### PR DESCRIPTION
### Summary
Allow poweruser to list users within any account they are poweruser for. This will allow them to view the users within the IAM console. Note that iam:CreateUser and iam:DeleteUser are still explicitly denied in a statement below.