### PR TITLE
[fix] update syntax to simplified 0.12 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ release: ## run a release
 .PHONY: release
 
 fmt:
-	@for m in $(MODULES); do \
-		terraform fmt $m; \
+	for m in $(MODULES); do \
+		terraform fmt $$m; \
 	done
 .PHONY: fmt
 

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -1,20 +1,20 @@
 locals {
   tags = {
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
     managedBy = "terraform"
   }
 
-  cert_validation_count =  length(var.cert_subject_alternative_names) + 1
+  cert_validation_count = length(var.cert_subject_alternative_names) + 1
 }
 
 resource "aws_acm_certificate" "cert" {
-  domain_name               =  var.cert_domain_name
+  domain_name               = var.cert_domain_name
   subject_alternative_names = var.subject_alternative_names_order == null ? keys(var.cert_subject_alternative_names) : var.subject_alternative_names_order
   validation_method         = "DNS"
-  tags                      =  local.tags
+  tags                      = local.tags
 
   lifecycle {
     create_before_destroy = true
@@ -23,18 +23,18 @@ resource "aws_acm_certificate" "cert" {
 
 # https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html
 resource "aws_route53_record" "cert_validation" {
-  count =  local.cert_validation_count
+  count = local.cert_validation_count
 
-  name    =  lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
-  type    =  lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
-  zone_id =  lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)
+  name    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
+  type    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
+  zone_id = lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)
   records = ["${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl     =  var.validation_record_ttl
+  ttl     = var.validation_record_ttl
 
-  allow_overwrite =  var.allow_validation_record_overwrite
+  allow_overwrite = var.allow_validation_record_overwrite
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         =  aws_acm_certificate.cert.arn
-  validation_record_fqdns =  aws_route53_record.cert_validation.*.fqdn
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
 }

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -1,20 +1,20 @@
 locals {
   tags = {
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
     managedBy = "terraform"
   }
 
-  cert_validation_count = "${length(var.cert_subject_alternative_names) + 1}"
+  cert_validation_count =  length(var.cert_subject_alternative_names) + 1
 }
 
 resource "aws_acm_certificate" "cert" {
-  domain_name               = "${var.cert_domain_name}"
+  domain_name               =  var.cert_domain_name
   subject_alternative_names = var.subject_alternative_names_order == null ? keys(var.cert_subject_alternative_names) : var.subject_alternative_names_order
   validation_method         = "DNS"
-  tags                      = "${local.tags}"
+  tags                      =  local.tags
 
   lifecycle {
     create_before_destroy = true
@@ -23,18 +23,18 @@ resource "aws_acm_certificate" "cert" {
 
 # https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html
 resource "aws_route53_record" "cert_validation" {
-  count = "${local.cert_validation_count}"
+  count =  local.cert_validation_count
 
-  name    = "${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id = "${lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)}"
+  name    =  lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
+  type    =  lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
+  zone_id =  lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)
   records = ["${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl     = "${var.validation_record_ttl}"
+  ttl     =  var.validation_record_ttl
 
-  allow_overwrite = "${var.allow_validation_record_overwrite}"
+  allow_overwrite =  var.allow_validation_record_overwrite
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = "${aws_route53_record.cert_validation.*.fqdn}"
+  certificate_arn         =  aws_acm_certificate.cert.arn
+  validation_record_fqdns =  aws_route53_record.cert_validation.*.fqdn
 }

--- a/aws-acm-cert/outputs.tf
+++ b/aws-acm-cert/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value =  aws_acm_certificate.cert.arn
+  value = aws_acm_certificate.cert.arn
 }
 
 output "id" {
-  value =  aws_acm_certificate.cert.id
+  value = aws_acm_certificate.cert.id
 }

--- a/aws-acm-cert/outputs.tf
+++ b/aws-acm-cert/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_acm_certificate.cert.arn}"
+  value =  aws_acm_certificate.cert.arn
 }
 
 output "id" {
-  value = "${aws_acm_certificate.cert.id}"
+  value =  aws_acm_certificate.cert.id
 }

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,22 +1,22 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-mysql"
-  engine_version =  var.engine_version
+  engine_version = var.engine_version
 
-  project =  var.project
-  env     =  var.env
-  service =  var.service
-  owner   =  var.owner
+  project = var.project
+  env     = var.env
+  service = var.service
+  owner   = var.owner
 
-  database_name                       =  var.database_name
-  database_subnet_group               =  var.database_subnet_group
-  database_password                   =  var.database_password
-  database_username                   =  var.database_username
-  db_parameters                       =  var.db_parameters
-  db_deletion_protection              =  var.db_deletion_protection
-  rds_cluster_parameters              =  var.rds_cluster_parameters
-  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
-  performance_insights_enabled        =  var.performance_insights_enabled
+  database_name                       = var.database_name
+  database_subnet_group               = var.database_subnet_group
+  database_password                   = var.database_password
+  database_username                   = var.database_username
+  db_parameters                       = var.db_parameters
+  db_deletion_protection              = var.db_deletion_protection
+  rds_cluster_parameters              = var.rds_cluster_parameters
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
@@ -25,13 +25,13 @@ module "aurora" {
   publicly_accessible     = var.publicly_accessible
   port                    = 3306
 
-  instance_class =  var.instance_class
-  instance_count =  var.instance_count
+  instance_class = var.instance_class
+  instance_count = var.instance_count
 
-  backtrack_window    =  var.backtrack_window
-  skip_final_snapshot =  var.skip_final_snapshot
+  backtrack_window    = var.backtrack_window
+  skip_final_snapshot = var.skip_final_snapshot
 
-  kms_key_id =  var.kms_key_id
+  kms_key_id = var.kms_key_id
 
-  apply_immediately =  var.apply_immediately
+  apply_immediately = var.apply_immediately
 }

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,22 +1,22 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-mysql"
-  engine_version = "${var.engine_version}"
+  engine_version =  var.engine_version
 
-  project = "${var.project}"
-  env     = "${var.env}"
-  service = "${var.service}"
-  owner   = "${var.owner}"
+  project =  var.project
+  env     =  var.env
+  service =  var.service
+  owner   =  var.owner
 
-  database_name                       = "${var.database_name}"
-  database_subnet_group               = "${var.database_subnet_group}"
-  database_password                   = "${var.database_password}"
-  database_username                   = "${var.database_username}"
-  db_parameters                       = "${var.db_parameters}"
-  db_deletion_protection              = "${var.db_deletion_protection}"
-  rds_cluster_parameters              = "${var.rds_cluster_parameters}"
-  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
-  performance_insights_enabled        = "${var.performance_insights_enabled}"
+  database_name                       =  var.database_name
+  database_subnet_group               =  var.database_subnet_group
+  database_password                   =  var.database_password
+  database_username                   =  var.database_username
+  db_parameters                       =  var.db_parameters
+  db_deletion_protection              =  var.db_deletion_protection
+  rds_cluster_parameters              =  var.rds_cluster_parameters
+  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
+  performance_insights_enabled        =  var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
@@ -25,13 +25,13 @@ module "aurora" {
   publicly_accessible     = var.publicly_accessible
   port                    = 3306
 
-  instance_class = "${var.instance_class}"
-  instance_count = "${var.instance_count}"
+  instance_class =  var.instance_class
+  instance_count =  var.instance_count
 
-  backtrack_window    = "${var.backtrack_window}"
-  skip_final_snapshot = "${var.skip_final_snapshot}"
+  backtrack_window    =  var.backtrack_window
+  skip_final_snapshot =  var.skip_final_snapshot
 
-  kms_key_id = "${var.kms_key_id}"
+  kms_key_id =  var.kms_key_id
 
-  apply_immediately = "${var.apply_immediately}"
+  apply_immediately =  var.apply_immediately
 }

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -1,11 +1,11 @@
 output "database_name" {
-  value = "${module.aurora.database_name}"
+  value =  module.aurora.database_name
 }
 
 output "endpoint" {
-  value = "${module.aurora.endpoint}"
+  value =  module.aurora.endpoint
 }
 
 output "reader_endpoint" {
-  value = "${module.aurora.reader_endpoint}"
+  value =  module.aurora.reader_endpoint
 }

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -1,11 +1,11 @@
 output "database_name" {
-  value =  module.aurora.database_name
+  value = module.aurora.database_name
 }
 
 output "endpoint" {
-  value =  module.aurora.endpoint
+  value = module.aurora.endpoint
 }
 
 output "reader_endpoint" {
-  value =  module.aurora.reader_endpoint
+  value = module.aurora.reader_endpoint
 }

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,21 +1,21 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-postgresql"
-  engine_version = "${var.engine_version}"
+  engine_version =  var.engine_version
 
-  project = "${var.project}"
-  env     = "${var.env}"
-  service = "${var.service}"
-  owner   = "${var.owner}"
+  project =  var.project
+  env     =  var.env
+  service =  var.service
+  owner   =  var.owner
 
-  database_name                       = "${var.database_name}"
-  database_subnet_group               = "${var.database_subnet_group}"
-  database_password                   = "${var.database_password}"
-  database_username                   = "${var.database_username}"
-  db_parameters                       = "${var.db_parameters}"
-  rds_cluster_parameters              = "${var.rds_cluster_parameters}"
-  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
-  performance_insights_enabled        = "${var.performance_insights_enabled}"
+  database_name                       =  var.database_name
+  database_subnet_group               =  var.database_subnet_group
+  database_password                   =  var.database_password
+  database_username                   =  var.database_username
+  db_parameters                       =  var.db_parameters
+  rds_cluster_parameters              =  var.rds_cluster_parameters
+  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
+  performance_insights_enabled        =  var.performance_insights_enabled
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups
@@ -27,7 +27,7 @@ module "aurora" {
 
   # backtrack_window not supported yet
   backtrack_window    = 0
-  skip_final_snapshot = "${var.skip_final_snapshot}"
-  kms_key_id          = "${var.kms_key_id}"
-  apply_immediately   = "${var.apply_immediately}"
+  skip_final_snapshot =  var.skip_final_snapshot
+  kms_key_id          =  var.kms_key_id
+  apply_immediately   =  var.apply_immediately
 }

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,21 +1,21 @@
 module "aurora" {
   source         = "../aws-aurora"
   engine         = "aurora-postgresql"
-  engine_version =  var.engine_version
+  engine_version = var.engine_version
 
-  project =  var.project
-  env     =  var.env
-  service =  var.service
-  owner   =  var.owner
+  project = var.project
+  env     = var.env
+  service = var.service
+  owner   = var.owner
 
-  database_name                       =  var.database_name
-  database_subnet_group               =  var.database_subnet_group
-  database_password                   =  var.database_password
-  database_username                   =  var.database_username
-  db_parameters                       =  var.db_parameters
-  rds_cluster_parameters              =  var.rds_cluster_parameters
-  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
-  performance_insights_enabled        =  var.performance_insights_enabled
+  database_name                       = var.database_name
+  database_subnet_group               = var.database_subnet_group
+  database_password                   = var.database_password
+  database_username                   = var.database_username
+  db_parameters                       = var.db_parameters
+  rds_cluster_parameters              = var.rds_cluster_parameters
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  performance_insights_enabled        = var.performance_insights_enabled
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups
@@ -27,7 +27,7 @@ module "aurora" {
 
   # backtrack_window not supported yet
   backtrack_window    = 0
-  skip_final_snapshot =  var.skip_final_snapshot
-  kms_key_id          =  var.kms_key_id
-  apply_immediately   =  var.apply_immediately
+  skip_final_snapshot = var.skip_final_snapshot
+  kms_key_id          = var.kms_key_id
+  apply_immediately   = var.apply_immediately
 }

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -1,15 +1,15 @@
 output "database_name" {
-  value =  module.aurora.database_name
+  value = module.aurora.database_name
 }
 
 output "endpoint" {
-  value =  module.aurora.endpoint
+  value = module.aurora.endpoint
 }
 
 output "reader_endpoint" {
-  value =  module.aurora.reader_endpoint
+  value = module.aurora.reader_endpoint
 }
 
 output "port" {
-  value =  module.aurora.port
+  value = module.aurora.port
 }

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -1,15 +1,15 @@
 output "database_name" {
-  value = "${module.aurora.database_name}"
+  value =  module.aurora.database_name
 }
 
 output "endpoint" {
-  value = "${module.aurora.endpoint}"
+  value =  module.aurora.endpoint
 }
 
 output "reader_endpoint" {
-  value = "${module.aurora.reader_endpoint}"
+  value =  module.aurora.reader_endpoint
 }
 
 output "port" {
-  value = "${module.aurora.port}"
+  value =  module.aurora.port
 }

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -3,11 +3,11 @@ locals {
 
   tags = {
     managedBy = "terraform"
-    Name      = "${local.name}"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    Name      =  local.name
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
   }
 }
 
@@ -34,54 +34,54 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_rds_cluster" "db" {
-  engine         = "${var.engine}"
-  engine_version = "${var.engine_version}"
+  engine         =  var.engine
+  engine_version =  var.engine_version
 
-  cluster_identifier                  = "${local.name}"
-  database_name                       = "${var.database_name}"
-  master_username                     = "${var.database_username}"
-  master_password                     = "${var.database_password}"
+  cluster_identifier                  =  local.name
+  database_name                       =  var.database_name
+  master_username                     =  var.database_username
+  master_password                     =  var.database_password
   vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
-  db_subnet_group_name                = "${var.database_subnet_group}"
+  db_subnet_group_name                =  var.database_subnet_group
   storage_encrypted                   = true
-  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
+  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
   backup_retention_period             = 28
   final_snapshot_identifier           = "${local.name}-snapshot"
-  skip_final_snapshot                 = "${var.skip_final_snapshot}"
-  backtrack_window                    = "${var.backtrack_window}"
-  kms_key_id                          = "${var.kms_key_id}"
-  port                                = "${var.port}"
-  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.db.id}"
-  deletion_protection                 = "${var.db_deletion_protection}"
+  skip_final_snapshot                 =  var.skip_final_snapshot
+  backtrack_window                    =  var.backtrack_window
+  kms_key_id                          =  var.kms_key_id
+  port                                =  var.port
+  db_cluster_parameter_group_name     =  aws_rds_cluster_parameter_group.db.id
+  deletion_protection                 =  var.db_deletion_protection
 
-  enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
+  enabled_cloudwatch_logs_exports =  var.enabled_cloudwatch_logs_exports
 
-  apply_immediately = "${var.apply_immediately}"
+  apply_immediately =  var.apply_immediately
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_rds_cluster_instance" "db" {
-  engine         = "${var.engine}"
-  engine_version = "${var.engine_version}"
+  engine         =  var.engine
+  engine_version =  var.engine_version
 
-  count                   = "${var.instance_count}"
+  count                   =  var.instance_count
   identifier              = "${local.name}-${count.index}"
-  cluster_identifier      = "${aws_rds_cluster.db.id}"
-  instance_class          = "${var.instance_class}"
-  db_subnet_group_name    = "${var.database_subnet_group}"
-  db_parameter_group_name = "${aws_db_parameter_group.db.name}"
+  cluster_identifier      =  aws_rds_cluster.db.id
+  instance_class          =  var.instance_class
+  db_subnet_group_name    =  var.database_subnet_group
+  db_parameter_group_name =  aws_db_parameter_group.db.name
 
-  publicly_accessible          = "${var.publicly_accessible}"
-  performance_insights_enabled = "${var.performance_insights_enabled}"
+  publicly_accessible          =  var.publicly_accessible
+  performance_insights_enabled =  var.performance_insights_enabled
 
-  apply_immediately = "${var.apply_immediately}"
+  apply_immediately =  var.apply_immediately
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_rds_cluster_parameter_group" "db" {
-  name        = "${local.name}"
+  name        =  local.name
   family      = "${var.engine}${var.engine_version}"
   description = "RDS default cluster parameter group"
 
@@ -98,11 +98,11 @@ resource "aws_rds_cluster_parameter_group" "db" {
     ignore_changes = ["family"]
   }
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_db_parameter_group" "db" {
-  name   = "${local.name}"
+  name   =  local.name
   family = "${var.engine}${var.engine_version}"
 
   dynamic "parameter" {
@@ -118,5 +118,5 @@ resource "aws_db_parameter_group" "db" {
     ignore_changes = ["family"]
   }
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -3,11 +3,11 @@ locals {
 
   tags = {
     managedBy = "terraform"
-    Name      =  local.name
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    Name      = local.name
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
   }
 }
 
@@ -34,54 +34,54 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_rds_cluster" "db" {
-  engine         =  var.engine
-  engine_version =  var.engine_version
+  engine         = var.engine
+  engine_version = var.engine_version
 
-  cluster_identifier                  =  local.name
-  database_name                       =  var.database_name
-  master_username                     =  var.database_username
-  master_password                     =  var.database_password
+  cluster_identifier                  = local.name
+  database_name                       = var.database_name
+  master_username                     = var.database_username
+  master_password                     = var.database_password
   vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
-  db_subnet_group_name                =  var.database_subnet_group
+  db_subnet_group_name                = var.database_subnet_group
   storage_encrypted                   = true
-  iam_database_authentication_enabled =  var.iam_database_authentication_enabled
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
   backup_retention_period             = 28
   final_snapshot_identifier           = "${local.name}-snapshot"
-  skip_final_snapshot                 =  var.skip_final_snapshot
-  backtrack_window                    =  var.backtrack_window
-  kms_key_id                          =  var.kms_key_id
-  port                                =  var.port
-  db_cluster_parameter_group_name     =  aws_rds_cluster_parameter_group.db.id
-  deletion_protection                 =  var.db_deletion_protection
+  skip_final_snapshot                 = var.skip_final_snapshot
+  backtrack_window                    = var.backtrack_window
+  kms_key_id                          = var.kms_key_id
+  port                                = var.port
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.db.id
+  deletion_protection                 = var.db_deletion_protection
 
-  enabled_cloudwatch_logs_exports =  var.enabled_cloudwatch_logs_exports
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
-  apply_immediately =  var.apply_immediately
+  apply_immediately = var.apply_immediately
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_rds_cluster_instance" "db" {
-  engine         =  var.engine
-  engine_version =  var.engine_version
+  engine         = var.engine
+  engine_version = var.engine_version
 
-  count                   =  var.instance_count
+  count                   = var.instance_count
   identifier              = "${local.name}-${count.index}"
-  cluster_identifier      =  aws_rds_cluster.db.id
-  instance_class          =  var.instance_class
-  db_subnet_group_name    =  var.database_subnet_group
-  db_parameter_group_name =  aws_db_parameter_group.db.name
+  cluster_identifier      = aws_rds_cluster.db.id
+  instance_class          = var.instance_class
+  db_subnet_group_name    = var.database_subnet_group
+  db_parameter_group_name = aws_db_parameter_group.db.name
 
-  publicly_accessible          =  var.publicly_accessible
-  performance_insights_enabled =  var.performance_insights_enabled
+  publicly_accessible          = var.publicly_accessible
+  performance_insights_enabled = var.performance_insights_enabled
 
-  apply_immediately =  var.apply_immediately
+  apply_immediately = var.apply_immediately
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_rds_cluster_parameter_group" "db" {
-  name        =  local.name
+  name        = local.name
   family      = "${var.engine}${var.engine_version}"
   description = "RDS default cluster parameter group"
 
@@ -98,11 +98,11 @@ resource "aws_rds_cluster_parameter_group" "db" {
     ignore_changes = ["family"]
   }
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_db_parameter_group" "db" {
-  name   =  local.name
+  name   = local.name
   family = "${var.engine}${var.engine_version}"
 
   dynamic "parameter" {
@@ -118,5 +118,5 @@ resource "aws_db_parameter_group" "db" {
     ignore_changes = ["family"]
   }
 
-  tags =  local.tags
+  tags = local.tags
 }

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -1,15 +1,15 @@
 output "database_name" {
-  value =  aws_rds_cluster.db.database_name
+  value = aws_rds_cluster.db.database_name
 }
 
 output "endpoint" {
-  value =  aws_rds_cluster.db.endpoint
+  value = aws_rds_cluster.db.endpoint
 }
 
 output "reader_endpoint" {
-  value =  aws_rds_cluster.db.reader_endpoint
+  value = aws_rds_cluster.db.reader_endpoint
 }
 
 output "port" {
-  value =  var.port
+  value = var.port
 }

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -1,15 +1,15 @@
 output "database_name" {
-  value = "${aws_rds_cluster.db.database_name}"
+  value =  aws_rds_cluster.db.database_name
 }
 
 output "endpoint" {
-  value = "${aws_rds_cluster.db.endpoint}"
+  value =  aws_rds_cluster.db.endpoint
 }
 
 output "reader_endpoint" {
-  value = "${aws_rds_cluster.db.reader_endpoint}"
+  value =  aws_rds_cluster.db.reader_endpoint
 }
 
 output "port" {
-  value = "${var.port}"
+  value =  var.port
 }

--- a/aws-cloudwatch-log-group/main.tf
+++ b/aws-cloudwatch-log-group/main.tf
@@ -4,14 +4,14 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "group" {
-  name =  local.log_group_name
+  name = local.log_group_name
 
   tags = {
     Name      = local.name
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
     managedBy = "terraform"
   }
 }

--- a/aws-cloudwatch-log-group/main.tf
+++ b/aws-cloudwatch-log-group/main.tf
@@ -4,14 +4,14 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "group" {
-  name = "${local.log_group_name}"
+  name =  local.log_group_name
 
   tags = {
     Name      = local.name
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
     managedBy = "terraform"
   }
 }

--- a/aws-cloudwatch-log-group/outputs.tf
+++ b/aws-cloudwatch-log-group/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_cloudwatch_log_group.group.arn}"
+  value =  aws_cloudwatch_log_group.group.arn
 }
 
 output "name" {
-  value = "${local.log_group_name}"
+  value =  local.log_group_name
 }

--- a/aws-cloudwatch-log-group/outputs.tf
+++ b/aws-cloudwatch-log-group/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value =  aws_cloudwatch_log_group.group.arn
+  value = aws_cloudwatch_log_group.group.arn
 }
 
 output "name" {
-  value =  local.log_group_name
+  value = local.log_group_name
 }

--- a/aws-default-vpc-security/main.tf
+++ b/aws-default-vpc-security/main.tf
@@ -25,11 +25,11 @@ data "aws_internet_gateway" "default" {
 }
 
 resource "aws_default_route_table" "default" {
-  default_route_table_id = "${aws_default_vpc.default.default_route_table_id}"
+  default_route_table_id =  aws_default_vpc.default.default_route_table_id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${data.aws_internet_gateway.default.id}"
+    gateway_id =  data.aws_internet_gateway.default.id
   }
 
   tags = {
@@ -40,16 +40,16 @@ resource "aws_default_route_table" "default" {
 # count hack here based on https://github.com/hashicorp/terraform/issues/11574#issuecomment-365690226
 # :(
 resource "aws_default_subnet" "default" {
-  count = "${length(split(",", join(",", flatten(data.aws_availability_zones.available.*.names))))}"
+  count =  length(split(",", join(",", flatten(data.aws_availability_zones.available.*.names))))
 
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  availability_zone =  data.aws_availability_zones.available.names[count.index]
 }
 
 # Re-attach default subnets to the default netowrk ACL to avoid this issue–
 # https://github.com/hashicorp/terraform/issues/9824
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = "${aws_default_vpc.default.default_network_acl_id}"
-  subnet_ids             = "${aws_default_subnet.default.*.id}"
+  default_network_acl_id =  aws_default_vpc.default.default_network_acl_id
+  subnet_ids             =  aws_default_subnet.default.*.id
 
   # According to https://www.terraform.io/docs/providers/aws/r/default_network_acl.html
   # these are the default rules (ie allow all).
@@ -77,8 +77,8 @@ resource "aws_default_network_acl" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  count  = "${var.default_sg_lockdown ? 1 : 0}"
-  vpc_id = "${aws_default_vpc.default.id}"
+  count  =  var.default_sg_lockdown ? 1 : 0
+  vpc_id =  aws_default_vpc.default.id
 
   # No ingress or egress here means we permit no traffic.
 
@@ -90,9 +90,9 @@ resource "aws_default_security_group" "default" {
 # TODO turn on flow logs for default vpc
 #   https://app.asana.com/0/335732894489412/503937337513570
 # resource "aws_flow_log" "default_vpc_flow_logs" {
-#   log_group_name = "${var.vpc_flow_logs_group_name}"
-#   iam_role_arn   = "${var.vpc_flow_logs_iam_role_arn}"
-#   vpc_id         = "${aws_default_vpc.default.id}"
+#   log_group_name =  var.vpc_flow_logs_group_name
+#   iam_role_arn   =  var.vpc_flow_logs_iam_role_arn
+#   vpc_id         =  aws_default_vpc.default.id
 #   traffic_type   = "ALL"
 # }
 

--- a/aws-default-vpc-security/main.tf
+++ b/aws-default-vpc-security/main.tf
@@ -25,11 +25,11 @@ data "aws_internet_gateway" "default" {
 }
 
 resource "aws_default_route_table" "default" {
-  default_route_table_id =  aws_default_vpc.default.default_route_table_id
+  default_route_table_id = aws_default_vpc.default.default_route_table_id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id =  data.aws_internet_gateway.default.id
+    gateway_id = data.aws_internet_gateway.default.id
   }
 
   tags = {
@@ -40,16 +40,16 @@ resource "aws_default_route_table" "default" {
 # count hack here based on https://github.com/hashicorp/terraform/issues/11574#issuecomment-365690226
 # :(
 resource "aws_default_subnet" "default" {
-  count =  length(split(",", join(",", flatten(data.aws_availability_zones.available.*.names))))
+  count = length(split(",", join(",", flatten(data.aws_availability_zones.available.*.names))))
 
-  availability_zone =  data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
 }
 
 # Re-attach default subnets to the default netowrk ACL to avoid this issue–
 # https://github.com/hashicorp/terraform/issues/9824
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id =  aws_default_vpc.default.default_network_acl_id
-  subnet_ids             =  aws_default_subnet.default.*.id
+  default_network_acl_id = aws_default_vpc.default.default_network_acl_id
+  subnet_ids             = aws_default_subnet.default.*.id
 
   # According to https://www.terraform.io/docs/providers/aws/r/default_network_acl.html
   # these are the default rules (ie allow all).
@@ -77,8 +77,8 @@ resource "aws_default_network_acl" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  count  =  var.default_sg_lockdown ? 1 : 0
-  vpc_id =  aws_default_vpc.default.id
+  count  = var.default_sg_lockdown ? 1 : 0
+  vpc_id = aws_default_vpc.default.id
 
   # No ingress or egress here means we permit no traffic.
 

--- a/aws-iam-ecs-task-role/outputs.tf
+++ b/aws-iam-ecs-task-role/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_iam_role.role.arn}"
+  value =  aws_iam_role.role.arn
 }
 
 output "name" {
-  value = "${aws_iam_role.role.name}"
+  value =  aws_iam_role.role.name
 }

--- a/aws-iam-ecs-task-role/outputs.tf
+++ b/aws-iam-ecs-task-role/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value =  aws_iam_role.role.arn
+  value = aws_iam_role.role.arn
 }
 
 output "name" {
-  value =  aws_iam_role.role.name
+  value = aws_iam_role.role.name
 }

--- a/aws-iam-group-assume-role/main.tf
+++ b/aws-iam-group-assume-role/main.tf
@@ -3,36 +3,36 @@ locals {
 }
 
 resource "aws_iam_group" "assume-role" {
-  name = "${var.group_name}"
-  path = "${var.iam_path}"
+  name =  var.group_name
+  path =  var.iam_path
 }
 
 resource "aws_iam_group_membership" "assume-role" {
-  name  = "${var.group_name}"
-  users = "${var.users}"
-  group = "${aws_iam_group.assume-role.name}"
+  name  =  var.group_name
+  users =  var.users
+  group =  aws_iam_group.assume-role.name
 
   # depends_on = ["null_resource.dependency_getter"]
 }
 
 resource "aws_iam_policy" "assume-role" {
-  name        = "${var.group_name}"
-  path        = "${var.iam_path}"
+  name        =  var.group_name
+  path        =  var.iam_path
   description = ""
-  policy      = "${data.aws_iam_policy_document.assume-role.json}"
+  policy      =  data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "assume-role" {
   statement {
     sid       = "assume0"
-    resources = "${local.account_arns}"
+    resources =  local.account_arns
     actions   = ["sts:AssumeRole"]
   }
 }
 
 resource "aws_iam_group_policy_attachment" "assume-role" {
-  policy_arn = "${aws_iam_policy.assume-role.arn}"
-  group      = "${aws_iam_group.assume-role.name}"
+  policy_arn =  aws_iam_policy.assume-role.arn
+  group      =  aws_iam_group.assume-role.name
 }
 
 # # https://github.com/hashicorp/terraform/issues/1178

--- a/aws-iam-group-assume-role/main.tf
+++ b/aws-iam-group-assume-role/main.tf
@@ -3,36 +3,36 @@ locals {
 }
 
 resource "aws_iam_group" "assume-role" {
-  name =  var.group_name
-  path =  var.iam_path
+  name = var.group_name
+  path = var.iam_path
 }
 
 resource "aws_iam_group_membership" "assume-role" {
-  name  =  var.group_name
-  users =  var.users
-  group =  aws_iam_group.assume-role.name
+  name  = var.group_name
+  users = var.users
+  group = aws_iam_group.assume-role.name
 
   # depends_on = ["null_resource.dependency_getter"]
 }
 
 resource "aws_iam_policy" "assume-role" {
-  name        =  var.group_name
-  path        =  var.iam_path
+  name        = var.group_name
+  path        = var.iam_path
   description = ""
-  policy      =  data.aws_iam_policy_document.assume-role.json
+  policy      = data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "assume-role" {
   statement {
     sid       = "assume0"
-    resources =  local.account_arns
+    resources = local.account_arns
     actions   = ["sts:AssumeRole"]
   }
 }
 
 resource "aws_iam_group_policy_attachment" "assume-role" {
-  policy_arn =  aws_iam_policy.assume-role.arn
-  group      =  aws_iam_group.assume-role.name
+  policy_arn = aws_iam_policy.assume-role.arn
+  group      = aws_iam_group.assume-role.name
 }
 
 # # https://github.com/hashicorp/terraform/issues/1178

--- a/aws-iam-group-assume-role/outputs.tf
+++ b/aws-iam-group-assume-role/outputs.tf
@@ -1,9 +1,9 @@
 output "group_arn" {
-  value =  aws_iam_group.assume-role.arn
+  value = aws_iam_group.assume-role.arn
 }
 
 output "group_name" {
-  value =  aws_iam_group.assume-role.name
+  value = aws_iam_group.assume-role.name
 }
 
 # # https://github.com/hashicorp/terraform/issues/1178

--- a/aws-iam-group-assume-role/outputs.tf
+++ b/aws-iam-group-assume-role/outputs.tf
@@ -1,13 +1,13 @@
 output "group_arn" {
-  value = "${aws_iam_group.assume-role.arn}"
+  value =  aws_iam_group.assume-role.arn
 }
 
 output "group_name" {
-  value = "${aws_iam_group.assume-role.name}"
+  value =  aws_iam_group.assume-role.name
 }
 
 # # https://github.com/hashicorp/terraform/issues/1178
 # output "depended_on" {
-#   value = "${null_resource.dependency_setter.id}"
+#   value =  null_resource.dependency_setter.id
 # }
 

--- a/aws-iam-group-console-login/main.tf
+++ b/aws-iam-group-console-login/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_group" "login" {
-  name = "${var.group_name}"
-  path = "${var.iam_path}"
+  name =  var.group_name
+  path =  var.iam_path
 }
 
 # This policy was based on one published by AWS (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_users-self-manage-mfa-and-creds.html)
@@ -114,9 +114,9 @@ data "aws_iam_policy_document" "self-iam" {
 
 resource "aws_iam_policy" "self-iam" {
   name        = "${var.group_name}-self-iam"
-  path        = "${var.iam_path}"
+  path        =  var.iam_path
   description = ""
-  policy      = "${data.aws_iam_policy_document.self-iam.json}"
+  policy      =  data.aws_iam_policy_document.self-iam.json
 
   lifecycle {
     ignore_changes = ["name"]
@@ -124,6 +124,6 @@ resource "aws_iam_policy" "self-iam" {
 }
 
 resource "aws_iam_group_policy_attachment" "self-iam" {
-  policy_arn = "${aws_iam_policy.self-iam.arn}"
-  group      = "${aws_iam_group.login.name}"
+  policy_arn =  aws_iam_policy.self-iam.arn
+  group      =  aws_iam_group.login.name
 }

--- a/aws-iam-group-console-login/main.tf
+++ b/aws-iam-group-console-login/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_group" "login" {
-  name =  var.group_name
-  path =  var.iam_path
+  name = var.group_name
+  path = var.iam_path
 }
 
 # This policy was based on one published by AWS (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_users-self-manage-mfa-and-creds.html)
@@ -114,9 +114,9 @@ data "aws_iam_policy_document" "self-iam" {
 
 resource "aws_iam_policy" "self-iam" {
   name        = "${var.group_name}-self-iam"
-  path        =  var.iam_path
+  path        = var.iam_path
   description = ""
-  policy      =  data.aws_iam_policy_document.self-iam.json
+  policy      = data.aws_iam_policy_document.self-iam.json
 
   lifecycle {
     ignore_changes = ["name"]
@@ -124,6 +124,6 @@ resource "aws_iam_policy" "self-iam" {
 }
 
 resource "aws_iam_group_policy_attachment" "self-iam" {
-  policy_arn =  aws_iam_policy.self-iam.arn
-  group      =  aws_iam_group.login.name
+  policy_arn = aws_iam_policy.self-iam.arn
+  group      = aws_iam_group.login.name
 }

--- a/aws-iam-group-console-login/outputs.tf
+++ b/aws-iam-group-console-login/outputs.tf
@@ -1,3 +1,3 @@
 output "group_name" {
-  value = "${aws_iam_group.login.name}"
+  value =  aws_iam_group.login.name
 }

--- a/aws-iam-group-console-login/outputs.tf
+++ b/aws-iam-group-console-login/outputs.tf
@@ -1,3 +1,3 @@
 output "group_name" {
-  value =  aws_iam_group.login.name
+  value = aws_iam_group.login.name
 }

--- a/aws-iam-instance-profile/main.tf
+++ b/aws-iam-instance-profile/main.tf
@@ -11,10 +11,10 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name_prefix        =  var.name_prefix
-  description        =  var.role_description
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name_prefix        = var.name_prefix
+  description        = var.role_description
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 
   lifecycle {
     ignore_changes = ["name", "name_prefix", "path"]
@@ -22,20 +22,20 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_role_policy" "ssm" {
-  count  =  var.enable_ssm ? 1 : 0
-  role   =  aws_iam_role.role.name
-  policy =  data.aws_iam_policy_document.ssm_policy.json
+  count  = var.enable_ssm ? 1 : 0
+  role   = aws_iam_role.role.name
+  policy = data.aws_iam_policy_document.ssm_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
-  role       =  aws_iam_role.role.name
+  role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 resource "aws_iam_instance_profile" "profile" {
-  name_prefix =  var.name_prefix
-  path        =  var.iam_path
-  role        =  aws_iam_role.role.name
+  name_prefix = var.name_prefix
+  path        = var.iam_path
+  role        = aws_iam_role.role.name
 
   lifecycle {
     ignore_changes = ["name", "name_prefix", "path"]

--- a/aws-iam-instance-profile/main.tf
+++ b/aws-iam-instance-profile/main.tf
@@ -11,10 +11,10 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name_prefix        = "${var.name_prefix}"
-  description        = "${var.role_description}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name_prefix        =  var.name_prefix
+  description        =  var.role_description
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 
   lifecycle {
     ignore_changes = ["name", "name_prefix", "path"]
@@ -22,20 +22,20 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_role_policy" "ssm" {
-  count  = "${var.enable_ssm ? 1 : 0}"
-  role   = "${aws_iam_role.role.name}"
-  policy = "${data.aws_iam_policy_document.ssm_policy.json}"
+  count  =  var.enable_ssm ? 1 : 0
+  role   =  aws_iam_role.role.name
+  policy =  data.aws_iam_policy_document.ssm_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
-  role       = "${aws_iam_role.role.name}"
+  role       =  aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 resource "aws_iam_instance_profile" "profile" {
-  name_prefix = "${var.name_prefix}"
-  path        = "${var.iam_path}"
-  role        = "${aws_iam_role.role.name}"
+  name_prefix =  var.name_prefix
+  path        =  var.iam_path
+  role        =  aws_iam_role.role.name
 
   lifecycle {
     ignore_changes = ["name", "name_prefix", "path"]

--- a/aws-iam-instance-profile/outputs.tf
+++ b/aws-iam-instance-profile/outputs.tf
@@ -1,19 +1,19 @@
 output "role_arn" {
-  value       =  aws_iam_role.role.arn
+  value       = aws_iam_role.role.arn
   description = "The Amazon Resource Name (ARN) specifying the role."
 }
 
 output "role_name" {
-  value       =  aws_iam_role.role.name
+  value       = aws_iam_role.role.name
   description = "The name of the role."
 }
 
 output "profile_arn" {
-  value       =  aws_iam_instance_profile.profile.arn
+  value       = aws_iam_instance_profile.profile.arn
   description = "The ARN assigned by AWS to the instance profile."
 }
 
 output "profile_name" {
-  value       =  aws_iam_instance_profile.profile.name
+  value       = aws_iam_instance_profile.profile.name
   description = "The instance profile's name."
 }

--- a/aws-iam-instance-profile/outputs.tf
+++ b/aws-iam-instance-profile/outputs.tf
@@ -1,19 +1,19 @@
 output "role_arn" {
-  value       = "${aws_iam_role.role.arn}"
+  value       =  aws_iam_role.role.arn
   description = "The Amazon Resource Name (ARN) specifying the role."
 }
 
 output "role_name" {
-  value       = "${aws_iam_role.role.name}"
+  value       =  aws_iam_role.role.name
   description = "The name of the role."
 }
 
 output "profile_arn" {
-  value       = "${aws_iam_instance_profile.profile.arn}"
+  value       =  aws_iam_instance_profile.profile.arn
   description = "The ARN assigned by AWS to the instance profile."
 }
 
 output "profile_name" {
-  value       = "${aws_iam_instance_profile.profile.name}"
+  value       =  aws_iam_instance_profile.profile.name
   description = "The instance profile's name."
 }

--- a/aws-iam-policy-cwlogs/main.tf
+++ b/aws-iam-policy-cwlogs/main.tf
@@ -14,12 +14,12 @@ data "aws_iam_policy_document" "logs-policy" {
 resource "aws_iam_policy" "logs-policy" {
   name_prefix = "${var.role_name}-logs-policy"
   description = "A terraform created policy for cloudwatch logs"
-  path        =  var.iam_path
-  policy      =  data.aws_iam_policy_document.logs-policy.json
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.logs-policy.json
 }
 
 resource "aws_iam_policy_attachment" "attach-logs" {
   name       = "logs-attachment"
   roles      = ["${var.role_name}"]
-  policy_arn =  aws_iam_policy.logs-policy.arn
+  policy_arn = aws_iam_policy.logs-policy.arn
 }

--- a/aws-iam-policy-cwlogs/main.tf
+++ b/aws-iam-policy-cwlogs/main.tf
@@ -14,12 +14,12 @@ data "aws_iam_policy_document" "logs-policy" {
 resource "aws_iam_policy" "logs-policy" {
   name_prefix = "${var.role_name}-logs-policy"
   description = "A terraform created policy for cloudwatch logs"
-  path        = "${var.iam_path}"
-  policy      = "${data.aws_iam_policy_document.logs-policy.json}"
+  path        =  var.iam_path
+  policy      =  data.aws_iam_policy_document.logs-policy.json
 }
 
 resource "aws_iam_policy_attachment" "attach-logs" {
   name       = "logs-attachment"
   roles      = ["${var.role_name}"]
-  policy_arn = "${aws_iam_policy.logs-policy.arn}"
+  policy_arn =  aws_iam_policy.logs-policy.arn
 }

--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -2,20 +2,20 @@ data "aws_iam_policy_document" "client" {
   statement {
     sid       = "Lambda"
     actions   = ["lambda:InvokeFunction"]
-    resources =  var.bless_lambda_arns
+    resources = var.bless_lambda_arns
   }
 }
 
 resource "aws_iam_role_policy" "client" {
   name   = "lambda"
-  role   =  module.client.role_name
-  policy =  data.aws_iam_policy_document.client.json
+  role   = module.client.role_name
+  policy = data.aws_iam_policy_document.client.json
 }
 
 module "client" {
   source = "../aws-iam-role-crossacct"
 
-  role_name         =  var.role_name
-  iam_path          =  var.iam_path
-  source_account_id =  var.source_account_id
+  role_name         = var.role_name
+  iam_path          = var.iam_path
+  source_account_id = var.source_account_id
 }

--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -2,20 +2,20 @@ data "aws_iam_policy_document" "client" {
   statement {
     sid       = "Lambda"
     actions   = ["lambda:InvokeFunction"]
-    resources = "${var.bless_lambda_arns}"
+    resources =  var.bless_lambda_arns
   }
 }
 
 resource "aws_iam_role_policy" "client" {
   name   = "lambda"
-  role   = "${module.client.role_name}"
-  policy = "${data.aws_iam_policy_document.client.json}"
+  role   =  module.client.role_name
+  policy =  data.aws_iam_policy_document.client.json
 }
 
 module "client" {
   source = "../aws-iam-role-crossacct"
 
-  role_name         = "${var.role_name}"
-  iam_path          = "${var.iam_path}"
-  source_account_id = "${var.source_account_id}"
+  role_name         =  var.role_name
+  iam_path          =  var.iam_path
+  source_account_id =  var.source_account_id
 }

--- a/aws-iam-role-bless/outputs.tf
+++ b/aws-iam-role-bless/outputs.tf
@@ -1,3 +1,3 @@
 output "role_name" {
-  value = "${module.client.role_name}"
+  value =  module.client.role_name
 }

--- a/aws-iam-role-bless/outputs.tf
+++ b/aws-iam-role-bless/outputs.tf
@@ -1,3 +1,3 @@
 output "role_name" {
-  value =  module.client.role_name
+  value = module.client.role_name
 }

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -30,8 +30,8 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name               =  var.role_name
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "s3" {
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "s3" {
       "s3:PutObjectAcl",
     ]
 
-    resources =  formatlist("arn:aws:s3:::%s*/*", var.s3_bucket_prefixes)
+    resources = formatlist("arn:aws:s3:::%s*/*", var.s3_bucket_prefixes)
   }
 
   statement {
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "s3" {
       "s3:ListBucket",
     ]
 
-    resources =  formatlist("arn:aws:s3:::%s*", var.s3_bucket_prefixes)
+    resources = formatlist("arn:aws:s3:::%s*", var.s3_bucket_prefixes)
   }
 }
 
@@ -71,21 +71,21 @@ data "aws_iam_policy_document" "cloudfront" {
 resource "aws_iam_policy" "s3" {
   name        = "${var.role_name}-s3"
   description = "Provide access to s3 resources for a distribution ${var.role_name}"
-  policy      =  data.aws_iam_policy_document.s3.json
+  policy      = data.aws_iam_policy_document.s3.json
 }
 
 resource "aws_iam_policy" "cloudfront" {
   name        = "${var.role_name}-cloudfront"
   description = "Provide access to cloudfront ${var.role_name}"
-  policy      =  data.aws_iam_policy_document.cloudfront.json
+  policy      = data.aws_iam_policy_document.cloudfront.json
 }
 
 resource "aws_iam_role_policy_attachment" "s3" {
-  role       =  aws_iam_role.role.name
-  policy_arn =  aws_iam_policy.s3.arn
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.s3.arn
 }
 
 resource "aws_iam_role_policy_attachment" "cloudfront" {
-  role       =  aws_iam_role.role.name
-  policy_arn =  aws_iam_policy.cloudfront.arn
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.cloudfront.arn
 }

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -30,8 +30,8 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name               = "${var.role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "s3" {
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "s3" {
       "s3:PutObjectAcl",
     ]
 
-    resources = "${formatlist("arn:aws:s3:::%s*/*", var.s3_bucket_prefixes)}"
+    resources =  formatlist("arn:aws:s3:::%s*/*", var.s3_bucket_prefixes)
   }
 
   statement {
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "s3" {
       "s3:ListBucket",
     ]
 
-    resources = "${formatlist("arn:aws:s3:::%s*", var.s3_bucket_prefixes)}"
+    resources =  formatlist("arn:aws:s3:::%s*", var.s3_bucket_prefixes)
   }
 }
 
@@ -71,21 +71,21 @@ data "aws_iam_policy_document" "cloudfront" {
 resource "aws_iam_policy" "s3" {
   name        = "${var.role_name}-s3"
   description = "Provide access to s3 resources for a distribution ${var.role_name}"
-  policy      = "${data.aws_iam_policy_document.s3.json}"
+  policy      =  data.aws_iam_policy_document.s3.json
 }
 
 resource "aws_iam_policy" "cloudfront" {
   name        = "${var.role_name}-cloudfront"
   description = "Provide access to cloudfront ${var.role_name}"
-  policy      = "${data.aws_iam_policy_document.cloudfront.json}"
+  policy      =  data.aws_iam_policy_document.cloudfront.json
 }
 
 resource "aws_iam_role_policy_attachment" "s3" {
-  role       = "${aws_iam_role.role.name}"
-  policy_arn = "${aws_iam_policy.s3.arn}"
+  role       =  aws_iam_role.role.name
+  policy_arn =  aws_iam_policy.s3.arn
 }
 
 resource "aws_iam_role_policy_attachment" "cloudfront" {
-  role       = "${aws_iam_role.role.name}"
-  policy_arn = "${aws_iam_policy.cloudfront.arn}"
+  role       =  aws_iam_role.role.name
+  policy_arn =  aws_iam_policy.cloudfront.arn
 }

--- a/aws-iam-role-cloudfront-poweruser/outputs.tf
+++ b/aws-iam-role-cloudfront-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value = "${aws_iam_role.role.name}"
+  value =  aws_iam_role.role.name
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.role.arn}"
+  value =  aws_iam_role.role.arn
 }

--- a/aws-iam-role-cloudfront-poweruser/outputs.tf
+++ b/aws-iam-role-cloudfront-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value =  aws_iam_role.role.name
+  value = aws_iam_role.role.name
 }
 
 output "role_arn" {
-  value =  aws_iam_role.role.arn
+  value = aws_iam_role.role.arn
 }

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -30,9 +30,9 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -30,9 +30,9 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "role" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/outputs.tf
+++ b/aws-iam-role-crossacct/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value =  aws_iam_role.role.name
+  value = aws_iam_role.role.name
 }
 
 output "iam_path" {
-  value =  var.iam_path
+  value = var.iam_path
 }

--- a/aws-iam-role-crossacct/outputs.tf
+++ b/aws-iam-role-crossacct/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value = "${aws_iam_role.role.name}"
+  value =  aws_iam_role.role.name
 }
 
 output "iam_path" {
-  value = "${var.iam_path}"
+  value =  var.iam_path
 }

--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -30,9 +30,9 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "ec2-poweruser" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "ec2" {
@@ -46,11 +46,11 @@ data "aws_iam_policy_document" "ec2" {
 resource "aws_iam_policy" "ec2" {
   name        = "${var.role_name}-ec2"
   description = "Provides full access to the ec2 api"
-  path        =  var.iam_path
-  policy      =  data.aws_iam_policy_document.ec2.json
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.ec2.json
 }
 
 resource "aws_iam_role_policy_attachment" "ec2" {
-  role       =  aws_iam_role.ec2-poweruser.name
-  policy_arn =  aws_iam_policy.ec2.arn
+  role       = aws_iam_role.ec2-poweruser.name
+  policy_arn = aws_iam_policy.ec2.arn
 }

--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -30,9 +30,9 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "ec2-poweruser" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 data "aws_iam_policy_document" "ec2" {
@@ -46,11 +46,11 @@ data "aws_iam_policy_document" "ec2" {
 resource "aws_iam_policy" "ec2" {
   name        = "${var.role_name}-ec2"
   description = "Provides full access to the ec2 api"
-  path        = "${var.iam_path}"
-  policy      = "${data.aws_iam_policy_document.ec2.json}"
+  path        =  var.iam_path
+  policy      =  data.aws_iam_policy_document.ec2.json
 }
 
 resource "aws_iam_role_policy_attachment" "ec2" {
-  role       = "${aws_iam_role.ec2-poweruser.name}"
-  policy_arn = "${aws_iam_policy.ec2.arn}"
+  role       =  aws_iam_role.ec2-poweruser.name
+  policy_arn =  aws_iam_policy.ec2.arn
 }

--- a/aws-iam-role-ec2-poweruser/outputs.tf
+++ b/aws-iam-role-ec2-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_iam_role.ec2-poweruser.arn}"
+  value =  aws_iam_role.ec2-poweruser.arn
 }
 
 output "role_name" {
-  value = "${aws_iam_role.ec2-poweruser.name}"
+  value =  aws_iam_role.ec2-poweruser.name
 }

--- a/aws-iam-role-ec2-poweruser/outputs.tf
+++ b/aws-iam-role-ec2-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value =  aws_iam_role.ec2-poweruser.arn
+  value = aws_iam_role.ec2-poweruser.arn
 }
 
 output "role_name" {
-  value =  aws_iam_role.ec2-poweruser.name
+  value = aws_iam_role.ec2-poweruser.name
 }

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -30,18 +30,18 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "ecs-poweruser" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-fullaccess" {
-  role       = "${aws_iam_role.ecs-poweruser.name}"
+  role       =  aws_iam_role.ecs-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "ecr-poweruser" {
-  role       = "${aws_iam_role.ecs-poweruser.name}"
+  role       =  aws_iam_role.ecs-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }
 
@@ -69,12 +69,12 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_policy" "secrets" {
   name        = "${var.role_name}-secrets"
-  path        = "${var.iam_path}"
+  path        =  var.iam_path
   description = "Provide access to the parameters of service ${var.role_name}"
-  policy      = "${data.aws_iam_policy_document.secrets.json}"
+  policy      =  data.aws_iam_policy_document.secrets.json
 }
 
 resource "aws_iam_role_policy_attachment" "secrets" {
-  role       = "${aws_iam_role.ecs-poweruser.name}"
-  policy_arn = "${aws_iam_policy.secrets.arn}"
+  role       =  aws_iam_role.ecs-poweruser.name
+  policy_arn =  aws_iam_policy.secrets.arn
 }

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -30,18 +30,18 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "ecs-poweruser" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-fullaccess" {
-  role       =  aws_iam_role.ecs-poweruser.name
+  role       = aws_iam_role.ecs-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "ecr-poweruser" {
-  role       =  aws_iam_role.ecs-poweruser.name
+  role       = aws_iam_role.ecs-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }
 
@@ -69,12 +69,12 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_policy" "secrets" {
   name        = "${var.role_name}-secrets"
-  path        =  var.iam_path
+  path        = var.iam_path
   description = "Provide access to the parameters of service ${var.role_name}"
-  policy      =  data.aws_iam_policy_document.secrets.json
+  policy      = data.aws_iam_policy_document.secrets.json
 }
 
 resource "aws_iam_role_policy_attachment" "secrets" {
-  role       =  aws_iam_role.ecs-poweruser.name
-  policy_arn =  aws_iam_policy.secrets.arn
+  role       = aws_iam_role.ecs-poweruser.name
+  policy_arn = aws_iam_policy.secrets.arn
 }

--- a/aws-iam-role-ecs-poweruser/outputs.tf
+++ b/aws-iam-role-ecs-poweruser/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value =  aws_iam_role.ecs-poweruser.arn
+  value = aws_iam_role.ecs-poweruser.arn
 }

--- a/aws-iam-role-ecs-poweruser/outputs.tf
+++ b/aws-iam-role-ecs-poweruser/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value = "${aws_iam_role.ecs-poweruser.arn}"
+  value =  aws_iam_role.ecs-poweruser.arn
 }

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "infraci" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "infraci" {
-  role       =  aws_iam_role.infraci.name
+  role       = aws_iam_role.infraci.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
@@ -105,8 +105,8 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_policy" "secrets" {
   name   = "${var.role_name}-secrets-reader"
-  path   =  var.iam_path
-  policy =  data.aws_iam_policy_document.secrets.json
+  path   = var.iam_path
+  policy = data.aws_iam_policy_document.secrets.json
 
   lifecycle {
     ignore_changes = ["name"]
@@ -114,6 +114,6 @@ resource "aws_iam_policy" "secrets" {
 }
 
 resource "aws_iam_role_policy_attachment" "secrets" {
-  role       =  aws_iam_role.infraci.name
-  policy_arn =  aws_iam_policy.secrets.arn
+  role       = aws_iam_role.infraci.name
+  policy_arn = aws_iam_policy.secrets.arn
 }

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "infraci" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "infraci" {
-  role       = "${aws_iam_role.infraci.name}"
+  role       =  aws_iam_role.infraci.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
@@ -105,8 +105,8 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_policy" "secrets" {
   name   = "${var.role_name}-secrets-reader"
-  path   = "${var.iam_path}"
-  policy = "${data.aws_iam_policy_document.secrets.json}"
+  path   =  var.iam_path
+  policy =  data.aws_iam_policy_document.secrets.json
 
   lifecycle {
     ignore_changes = ["name"]
@@ -114,6 +114,6 @@ resource "aws_iam_policy" "secrets" {
 }
 
 resource "aws_iam_role_policy_attachment" "secrets" {
-  role       = "${aws_iam_role.infraci.name}"
-  policy_arn = "${aws_iam_policy.secrets.arn}"
+  role       =  aws_iam_role.infraci.name
+  policy_arn =  aws_iam_policy.secrets.arn
 }

--- a/aws-iam-role-infraci/outputs.tf
+++ b/aws-iam-role-infraci/outputs.tf
@@ -1,3 +1,3 @@
 output "role_name" {
-  value =  aws_iam_role.infraci.name
+  value = aws_iam_role.infraci.name
 }

--- a/aws-iam-role-infraci/outputs.tf
+++ b/aws-iam-role-infraci/outputs.tf
@@ -1,3 +1,3 @@
 output "role_name" {
-  value = "${aws_iam_role.infraci.name}"
+  value =  aws_iam_role.infraci.name
 }

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "poweruser" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser" {
-  role       = "${aws_iam_role.poweruser.name}"
+  role       =  aws_iam_role.poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
@@ -135,12 +135,12 @@ data "aws_iam_policy_document" "misc" {
 
 resource "aws_iam_policy" "misc" {
   name        = "${var.role_name}-misc"
-  path        = "${var.iam_path}"
+  path        =  var.iam_path
   description = "Extra permissions we're granting that PowerUserAccess lacks"
-  policy      = "${data.aws_iam_policy_document.misc.json}"
+  policy      =  data.aws_iam_policy_document.misc.json
 }
 
 resource "aws_iam_role_policy_attachment" "misc" {
-  role       = "${aws_iam_role.poweruser.name}"
-  policy_arn = "${aws_iam_policy.misc.arn}"
+  role       =  aws_iam_role.poweruser.name
+  policy_arn =  aws_iam_policy.misc.arn
 }

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "poweruser" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser" {
-  role       =  aws_iam_role.poweruser.name
+  role       = aws_iam_role.poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
@@ -135,12 +135,12 @@ data "aws_iam_policy_document" "misc" {
 
 resource "aws_iam_policy" "misc" {
   name        = "${var.role_name}-misc"
-  path        =  var.iam_path
+  path        = var.iam_path
   description = "Extra permissions we're granting that PowerUserAccess lacks"
-  policy      =  data.aws_iam_policy_document.misc.json
+  policy      = data.aws_iam_policy_document.misc.json
 }
 
 resource "aws_iam_role_policy_attachment" "misc" {
-  role       =  aws_iam_role.poweruser.name
-  policy_arn =  aws_iam_policy.misc.arn
+  role       = aws_iam_role.poweruser.name
+  policy_arn = aws_iam_policy.misc.arn
 }

--- a/aws-iam-role-poweruser/outputs.tf
+++ b/aws-iam-role-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_iam_role.poweruser.arn}"
+  value =  aws_iam_role.poweruser.arn
 }
 
 output "role_name" {
-  value = "${aws_iam_role.poweruser.name}"
+  value =  aws_iam_role.poweruser.name
 }

--- a/aws-iam-role-poweruser/outputs.tf
+++ b/aws-iam-role-poweruser/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value =  aws_iam_role.poweruser.arn
+  value = aws_iam_role.poweruser.arn
 }
 
 output "role_name" {
-  value =  aws_iam_role.poweruser.name
+  value = aws_iam_role.poweruser.name
 }

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "readonly" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {
-  role       =  aws_iam_role.readonly.name
+  role       = aws_iam_role.readonly.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
@@ -55,6 +55,6 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_role_policy" "secrets" {
   name   = "secrets"
-  role   =  aws_iam_role.readonly.name
-  policy =  data.aws_iam_policy_document.secrets.json
+  role   = aws_iam_role.readonly.name
+  policy = data.aws_iam_policy_document.secrets.json
 }

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "readonly" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {
-  role       = "${aws_iam_role.readonly.name}"
+  role       =  aws_iam_role.readonly.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
@@ -55,6 +55,6 @@ data "aws_iam_policy_document" "secrets" {
 
 resource "aws_iam_role_policy" "secrets" {
   name   = "secrets"
-  role   = "${aws_iam_role.readonly.name}"
-  policy = "${data.aws_iam_policy_document.secrets.json}"
+  role   =  aws_iam_role.readonly.name
+  policy =  data.aws_iam_policy_document.secrets.json
 }

--- a/aws-iam-role-readonly/outputs.tf
+++ b/aws-iam-role-readonly/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value = "${aws_iam_role.readonly.name}"
+  value =  aws_iam_role.readonly.name
 }
 
 output "arn" {
-  value = "${aws_iam_role.readonly.arn}"
+  value =  aws_iam_role.readonly.arn
 }

--- a/aws-iam-role-readonly/outputs.tf
+++ b/aws-iam-role-readonly/outputs.tf
@@ -1,7 +1,7 @@
 output "role_name" {
-  value =  aws_iam_role.readonly.name
+  value = aws_iam_role.readonly.name
 }
 
 output "arn" {
-  value =  aws_iam_role.readonly.arn
+  value = aws_iam_role.readonly.arn
 }

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -30,17 +30,17 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "route53domains-poweruser" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "route53domains-fullaccess" {
-  role       =  aws_iam_role.route53domains-poweruser.name
+  role       = aws_iam_role.route53domains-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53DomainsFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "route53-readonly" {
-  role       =  aws_iam_role.route53domains-poweruser.name
+  role       = aws_iam_role.route53domains-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
 }

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -30,17 +30,17 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "route53domains-poweruser" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "route53domains-fullaccess" {
-  role       = "${aws_iam_role.route53domains-poweruser.name}"
+  role       =  aws_iam_role.route53domains-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53DomainsFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "route53-readonly" {
-  role       = "${aws_iam_role.route53domains-poweruser.name}"
+  role       =  aws_iam_role.route53domains-poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
 }

--- a/aws-iam-role-route53domains-poweruser/outputs.tf
+++ b/aws-iam-role-route53domains-poweruser/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value =  aws_iam_role.route53domains-poweruser.arn
+  value = aws_iam_role.route53domains-poweruser.arn
 }

--- a/aws-iam-role-route53domains-poweruser/outputs.tf
+++ b/aws-iam-role-route53domains-poweruser/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value = "${aws_iam_role.route53domains-poweruser.arn}"
+  value =  aws_iam_role.route53domains-poweruser.arn
 }

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -30,12 +30,12 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "security-audit" {
-  name               =  var.role_name
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
+  name               = var.role_name
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "security-audit" {
-  role       =  aws_iam_role.security-audit.name
+  role       = aws_iam_role.security-audit.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -30,12 +30,12 @@ data "aws_iam_policy_document" "assume-role" {
 }
 
 resource "aws_iam_role" "security-audit" {
-  name               = "${var.role_name}"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume-role.json}"
+  name               =  var.role_name
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume-role.json
 }
 
 resource "aws_iam_role_policy_attachment" "security-audit" {
-  role       = "${aws_iam_role.security-audit.name}"
+  role       =  aws_iam_role.security-audit.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }

--- a/aws-param/outputs.tf
+++ b/aws-param/outputs.tf
@@ -1,3 +1,3 @@
 output "value" {
-  value = "${data.aws_ssm_parameter.secret.value}"
+  value =  data.aws_ssm_parameter.secret.value
 }

--- a/aws-param/outputs.tf
+++ b/aws-param/outputs.tf
@@ -1,3 +1,3 @@
 output "value" {
-  value =  data.aws_ssm_parameter.secret.value
+  value = data.aws_ssm_parameter.secret.value
 }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -34,6 +34,6 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_iam_role_policy" "policy" {
   name   = "${local.resource_name}-parameter-policy"
-  role   =  var.role_name
-  policy =  data.aws_iam_policy_document.policy.json
+  role   = var.role_name
+  policy = data.aws_iam_policy_document.policy.json
 }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -34,6 +34,6 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_iam_role_policy" "policy" {
   name   = "${local.resource_name}-parameter-policy"
-  role   = "${var.role_name}"
-  policy = "${data.aws_iam_policy_document.policy.json}"
+  role   =  var.role_name
+  policy =  data.aws_iam_policy_document.policy.json
 }

--- a/aws-params-secrets-setup/main.tf
+++ b/aws-params-secrets-setup/main.tf
@@ -4,10 +4,10 @@ resource "aws_kms_key" "parameter_store" {
   enable_key_rotation     = true
 
   tags = {
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
     managedBy = "terraform"
   }
 }
@@ -17,5 +17,5 @@ resource "aws_kms_key" "parameter_store" {
 # encryption and access control for specific keys
 resource "aws_kms_alias" "parameter_store_alias" {
   name          = "alias/${var.alias_name}"
-  target_key_id = "${aws_kms_key.parameter_store.id}"
+  target_key_id =  aws_kms_key.parameter_store.id
 }

--- a/aws-params-secrets-setup/main.tf
+++ b/aws-params-secrets-setup/main.tf
@@ -4,10 +4,10 @@ resource "aws_kms_key" "parameter_store" {
   enable_key_rotation     = true
 
   tags = {
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
     managedBy = "terraform"
   }
 }
@@ -17,5 +17,5 @@ resource "aws_kms_key" "parameter_store" {
 # encryption and access control for specific keys
 resource "aws_kms_alias" "parameter_store_alias" {
   name          = "alias/${var.alias_name}"
-  target_key_id =  aws_kms_key.parameter_store.id
+  target_key_id = aws_kms_key.parameter_store.id
 }

--- a/aws-params-writer/main.tf
+++ b/aws-params-writer/main.tf
@@ -7,20 +7,20 @@ data "aws_kms_key" "key" {
 }
 
 resource "aws_ssm_parameter" "parameter" {
-  count = "${var.parameters_count}"
+  count =  var.parameters_count
 
   name  = "/${local.service_name}/${element(keys(var.parameters), count.index)}"
-  value = "${lookup(var.parameters, element(keys(var.parameters), count.index))}"
+  value =  lookup(var.parameters, element(keys(var.parameters), count.index))
 
   type      = "SecureString"
-  key_id    = "${data.aws_kms_key.key.id}"
+  key_id    =  data.aws_kms_key.key.id
   overwrite = "true"
 
   tags = {
     managedBy = "terraform"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
   }
 }

--- a/aws-params-writer/main.tf
+++ b/aws-params-writer/main.tf
@@ -7,20 +7,20 @@ data "aws_kms_key" "key" {
 }
 
 resource "aws_ssm_parameter" "parameter" {
-  count =  var.parameters_count
+  count = var.parameters_count
 
   name  = "/${local.service_name}/${element(keys(var.parameters), count.index)}"
-  value =  lookup(var.parameters, element(keys(var.parameters), count.index))
+  value = lookup(var.parameters, element(keys(var.parameters), count.index))
 
   type      = "SecureString"
-  key_id    =  data.aws_kms_key.key.id
+  key_id    = data.aws_kms_key.key.id
   overwrite = "true"
 
   tags = {
     managedBy = "terraform"
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
   }
 }

--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -4,10 +4,10 @@ locals {
   tags = {
     managedBy = "terraform"
     Name      = "${var.project}-${var.env}-${var.service}"
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
   }
 }
 
@@ -33,21 +33,21 @@ module "sg" {
 }
 
 resource "aws_elasticache_subnet_group" "default" {
-  name       =  var.resource_name != "" ? var.resource_name : local.name
-  subnet_ids =  var.subnets
+  name       = var.resource_name != "" ? var.resource_name : local.name
+  subnet_ids = var.subnets
 }
 
 resource "aws_elasticache_cluster" "default" {
-  cluster_id           =  var.resource_name != "" ? var.resource_name : local.name
+  cluster_id           = var.resource_name != "" ? var.resource_name : local.name
   engine               = "redis"
-  engine_version       =  var.engine_version
-  node_type            =  var.instance_type
-  port                 =  var.port
+  engine_version       = var.engine_version
+  node_type            = var.instance_type
+  port                 = var.port
   num_cache_nodes      = 1
-  parameter_group_name =  var.parameter_group_name
-  subnet_group_name    =  aws_elasticache_subnet_group.default.name
+  parameter_group_name = var.parameter_group_name
+  subnet_group_name    = aws_elasticache_subnet_group.default.name
   security_group_ids   = [module.sg.this_security_group_id]
-  apply_immediately    =  var.apply_immediately
-  availability_zone    =  var.availability_zone
-  tags                 =  local.tags
+  apply_immediately    = var.apply_immediately
+  availability_zone    = var.availability_zone
+  tags                 = local.tags
 }

--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -4,10 +4,10 @@ locals {
   tags = {
     managedBy = "terraform"
     Name      = "${var.project}-${var.env}-${var.service}"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
   }
 }
 
@@ -33,21 +33,21 @@ module "sg" {
 }
 
 resource "aws_elasticache_subnet_group" "default" {
-  name       = "${var.resource_name != "" ? var.resource_name : local.name}"
-  subnet_ids = "${var.subnets}"
+  name       =  var.resource_name != "" ? var.resource_name : local.name
+  subnet_ids =  var.subnets
 }
 
 resource "aws_elasticache_cluster" "default" {
-  cluster_id           = "${var.resource_name != "" ? var.resource_name : local.name}"
+  cluster_id           =  var.resource_name != "" ? var.resource_name : local.name
   engine               = "redis"
-  engine_version       = "${var.engine_version}"
-  node_type            = "${var.instance_type}"
-  port                 = "${var.port}"
+  engine_version       =  var.engine_version
+  node_type            =  var.instance_type
+  port                 =  var.port
   num_cache_nodes      = 1
-  parameter_group_name = "${var.parameter_group_name}"
-  subnet_group_name    = "${aws_elasticache_subnet_group.default.name}"
+  parameter_group_name =  var.parameter_group_name
+  subnet_group_name    =  aws_elasticache_subnet_group.default.name
   security_group_ids   = [module.sg.this_security_group_id]
-  apply_immediately    = "${var.apply_immediately}"
-  availability_zone    = "${var.availability_zone}"
-  tags                 = "${local.tags}"
+  apply_immediately    =  var.apply_immediately
+  availability_zone    =  var.availability_zone
+  tags                 =  local.tags
 }

--- a/aws-redis-node/outputs.tf
+++ b/aws-redis-node/outputs.tf
@@ -1,7 +1,7 @@
 output "address" {
-  value = "${aws_elasticache_cluster.default.cache_nodes.0.address}"
+  value =  aws_elasticache_cluster.default.cache_nodes.0.address
 }
 
 output "port" {
-  value = "${var.port}"
+  value =  var.port
 }

--- a/aws-redis-node/outputs.tf
+++ b/aws-redis-node/outputs.tf
@@ -1,7 +1,7 @@
 output "address" {
-  value =  aws_elasticache_cluster.default.cache_nodes.0.address
+  value = aws_elasticache_cluster.default.cache_nodes.0.address
 }
 
 output "port" {
-  value =  var.port
+  value = var.port
 }

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -1,18 +1,18 @@
 locals {
   tags = {
-    project   =  var.project
-    env       =  var.env
-    service   =  var.service
-    owner     =  var.owner
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
     managedBy = "terraform"
   }
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket =  var.bucket_name
+  bucket = var.bucket_name
   acl    = "private"
 
-  policy =  data.aws_iam_policy_document.bucket_policy.json
+  policy = data.aws_iam_policy_document.bucket_policy.json
 
   versioning {
     enabled = var.enable_versioning
@@ -52,11 +52,11 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-  bucket =  aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -66,7 +66,7 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 
 data "aws_iam_policy_document" "bucket_policy" {
   # Deny access to bucket if it's not accessed through HTTPS
-  source_json =  var.bucket_policy
+  source_json = var.bucket_policy
 
   statement {
     sid       = "EnforceTLS"

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -1,18 +1,18 @@
 locals {
   tags = {
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
     managedBy = "terraform"
   }
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.bucket_name}"
+  bucket =  var.bucket_name
   acl    = "private"
 
-  policy = "${data.aws_iam_policy_document.bucket_policy.json}"
+  policy =  data.aws_iam_policy_document.bucket_policy.json
 
   versioning {
     enabled = var.enable_versioning
@@ -52,11 +52,11 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket =  aws_s3_bucket.bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -66,7 +66,7 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 
 data "aws_iam_policy_document" "bucket_policy" {
   # Deny access to bucket if it's not accessed through HTTPS
-  source_json = "${var.bucket_policy}"
+  source_json =  var.bucket_policy
 
   statement {
     sid       = "EnforceTLS"

--- a/aws-s3-private-bucket/outputs.tf
+++ b/aws-s3-private-bucket/outputs.tf
@@ -1,16 +1,16 @@
 // HACK(el): we do this to hint TF dependency graph since modules can't depend_on
 output "name" {
-  value =  var.bucket_name
+  value = var.bucket_name
 }
 
 output "domain_name" {
-  value =  aws_s3_bucket.bucket.bucket_domain_name
+  value = aws_s3_bucket.bucket.bucket_domain_name
 }
 
 output "arn" {
-  value =  aws_s3_bucket.bucket.arn
+  value = aws_s3_bucket.bucket.arn
 }
 
 output "id" {
-  value =  aws_s3_bucket.bucket.id
+  value = aws_s3_bucket.bucket.id
 }

--- a/aws-s3-private-bucket/outputs.tf
+++ b/aws-s3-private-bucket/outputs.tf
@@ -1,16 +1,16 @@
 // HACK(el): we do this to hint TF dependency graph since modules can't depend_on
 output "name" {
-  value = "${var.bucket_name}"
+  value =  var.bucket_name
 }
 
 output "domain_name" {
-  value = "${aws_s3_bucket.bucket.bucket_domain_name}"
+  value =  aws_s3_bucket.bucket.bucket_domain_name
 }
 
 output "arn" {
-  value = "${aws_s3_bucket.bucket.arn}"
+  value =  aws_s3_bucket.bucket.arn
 }
 
 output "id" {
-  value = "${aws_s3_bucket.bucket.id}"
+  value =  aws_s3_bucket.bucket.id
 }

--- a/aws-single-page-static-site/main.tf
+++ b/aws-single-page-static-site/main.tf
@@ -1,15 +1,15 @@
 locals {
   tags = {
-    project   = "${var.project}"
-    env       = "${var.env}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    project   =  var.project
+    env       =  var.env
+    service   =  var.service
+    owner     =  var.owner
     managedBy = "terraform"
   }
 
-  domain       = "${replace(data.aws_route53_zone.zone.name, "/\\.$/", "")}"
+  domain       =  replace(data.aws_route53_zone.zone.name, "/\\.$/", "")
   website_fqdn = "${var.subdomain}.${local.domain}"
-  bucket_name  = "${var.bucket_name != "" ? var.bucket_name : local.website_fqdn}"
+  bucket_name  =  var.bucket_name != "" ? var.bucket_name : local.website_fqdn
 
   aliases = [
     "${local.website_fqdn}",
@@ -18,7 +18,7 @@ locals {
 }
 
 data "aws_route53_zone" "zone" {
-  zone_id = "${var.aws_route53_zone_id}"
+  zone_id =  var.aws_route53_zone_id
 }
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {}
@@ -48,9 +48,9 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${local.bucket_name}"
+  bucket =  local.bucket_name
   acl    = "private"
-  policy = "${data.aws_iam_policy_document.bucket_policy.json}"
+  policy =  data.aws_iam_policy_document.bucket_policy.json
 
   // Cloudfront needs this to compress assets
   // https://stackoverflow.com/questions/35590622/cloudfront-with-s3-website-as-origin-is-not-serving-gzipped-files
@@ -70,11 +70,11 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket =  aws_s3_bucket.bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -84,25 +84,25 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = "${aws_s3_bucket.bucket.bucket_domain_name}"
-    origin_id   = "${local.website_fqdn}"
+    domain_name =  aws_s3_bucket.bucket.bucket_domain_name
+    origin_id   =  local.website_fqdn
 
     s3_origin_config {
-      origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+      origin_access_identity =  aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
     }
   }
 
   enabled             = true
   is_ipv6_enabled     = true
-  default_root_object = "${var.index_document_path}"
+  default_root_object =  var.index_document_path
 
-  aliases = "${concat(var.aliases, local.aliases)}"
+  aliases =  concat(var.aliases, local.aliases)
 
   default_cache_behavior {
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD"]
 
-    target_origin_id = "${local.website_fqdn}"
+    target_origin_id =  local.website_fqdn
 
     forwarded_values {
       query_string = false
@@ -120,11 +120,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   ordered_cache_behavior {
-    path_pattern    = "${var.path_pattern}"
+    path_pattern    =  var.path_pattern
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD"]
 
-    target_origin_id = "${local.website_fqdn}"
+    target_origin_id =  local.website_fqdn
 
     forwarded_values {
       query_string = true
@@ -148,12 +148,12 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
   }
 
-  price_class = "${var.cloudfront_price_class}"
+  price_class =  var.cloudfront_price_class
 
   viewer_certificate {
-    acm_certificate_arn      = "${var.aws_acm_cert_arn}"
+    acm_certificate_arn      =  var.aws_acm_cert_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "${var.minimum_tls_version}"
+    minimum_protocol_version =  var.minimum_tls_version
   }
 
   # This is error handling logic for single page applications
@@ -175,57 +175,57 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_page_path = "/${var.index_document_path}"
   }
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 # for ipv4
 resource "aws_route53_record" "ipv4-record" {
-  zone_id = "${var.aws_route53_zone_id}"
-  name    = "${local.website_fqdn}"
+  zone_id =  var.aws_route53_zone_id
+  name    =  local.website_fqdn
   type    = "A"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.s3_distribution.hosted_zone_id}"
+    name                   =  aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                =  aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = true
   }
 }
 
 # for ipv6
 resource "aws_route53_record" "ipv6-record" {
-  zone_id = "${var.aws_route53_zone_id}"
-  name    = "${local.website_fqdn}"
+  zone_id =  var.aws_route53_zone_id
+  name    =  local.website_fqdn
   type    = "AAAA"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.s3_distribution.hosted_zone_id}"
+    name                   =  aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                =  aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = true
   }
 }
 
 # for ipv4
 resource "aws_route53_record" "www-ipv4-record" {
-  zone_id = "${var.aws_route53_zone_id}"
+  zone_id =  var.aws_route53_zone_id
   name    = "www.${local.website_fqdn}"
   type    = "A"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.s3_distribution.hosted_zone_id}"
+    name                   =  aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                =  aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = true
   }
 }
 
 # for ipv6
 resource "aws_route53_record" "www-ipv6-record" {
-  zone_id = "${var.aws_route53_zone_id}"
+  zone_id =  var.aws_route53_zone_id
   name    = "www.${local.website_fqdn}"
   type    = "AAAA"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.s3_distribution.hosted_zone_id}"
+    name                   =  aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                =  aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = true
   }
 }

--- a/bless-ca/ca.tf
+++ b/bless-ca/ca.tf
@@ -2,5 +2,5 @@
 // generates the CA keypair and encrypts them with KMS
 // no sensitive material is persisted to the terraform value store
 resource "bless_ca" "bless" {
-  kms_key_id = "${aws_kms_key.bless.key_id}"
+  kms_key_id =  aws_kms_key.bless.key_id
 }

--- a/bless-ca/ca.tf
+++ b/bless-ca/ca.tf
@@ -2,5 +2,5 @@
 // generates the CA keypair and encrypts them with KMS
 // no sensitive material is persisted to the terraform value store
 resource "bless_ca" "bless" {
-  kms_key_id =  aws_kms_key.bless.key_id
+  kms_key_id = aws_kms_key.bless.key_id
 }

--- a/bless-ca/iam.tf
+++ b/bless-ca/iam.tf
@@ -57,19 +57,19 @@ data "aws_iam_policy_document" "lambda" {
 
 resource "aws_iam_role" "bless" {
   name_prefix        = "${local.name}-"
-  path               = "${var.iam_path}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  path               =  var.iam_path
+  assume_role_policy =  data.aws_iam_policy_document.assume_role.json
   tags               = local.tags
 }
 
 resource "aws_iam_role_policy" "lambda" {
   name   = "${local.name}-lambda"
-  role   = "${aws_iam_role.bless.id}"
-  policy = "${data.aws_iam_policy_document.lambda.json}"
+  role   =  aws_iam_role.bless.id
+  policy =  data.aws_iam_policy_document.lambda.json
 }
 
 module "logs_policy" {
   source    = "../aws-iam-policy-cwlogs"
-  role_name = "${aws_iam_role.bless.name}"
-  iam_path  = "${var.iam_path}"
+  role_name =  aws_iam_role.bless.name
+  iam_path  =  var.iam_path
 }

--- a/bless-ca/iam.tf
+++ b/bless-ca/iam.tf
@@ -57,19 +57,19 @@ data "aws_iam_policy_document" "lambda" {
 
 resource "aws_iam_role" "bless" {
   name_prefix        = "${local.name}-"
-  path               =  var.iam_path
-  assume_role_policy =  data.aws_iam_policy_document.assume_role.json
+  path               = var.iam_path
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags               = local.tags
 }
 
 resource "aws_iam_role_policy" "lambda" {
   name   = "${local.name}-lambda"
-  role   =  aws_iam_role.bless.id
-  policy =  data.aws_iam_policy_document.lambda.json
+  role   = aws_iam_role.bless.id
+  policy = data.aws_iam_policy_document.lambda.json
 }
 
 module "logs_policy" {
   source    = "../aws-iam-policy-cwlogs"
-  role_name =  aws_iam_role.bless.name
-  iam_path  =  var.iam_path
+  role_name = aws_iam_role.bless.name
+  iam_path  = var.iam_path
 }

--- a/bless-ca/kms.tf
+++ b/bless-ca/kms.tf
@@ -4,12 +4,12 @@ resource "aws_kms_key" "bless" {
   description             = "KMS key for ${local.name}"
   deletion_window_in_days = 7
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_kms_alias" "bless" {
   name          = "alias/${local.name}"
-  target_key_id =  aws_kms_key.bless.key_id
+  target_key_id = aws_kms_key.bless.key_id
 }
 
 data "aws_iam_policy_document" "kmsauth" {
@@ -63,12 +63,12 @@ data "aws_iam_policy_document" "kmsauth" {
 resource "aws_kms_key" "bless_kms_auth" {
   description             = "KMS key for kmsauth for ${local.name}"
   deletion_window_in_days = 7
-  policy                  =  data.aws_iam_policy_document.kmsauth.json
+  policy                  = data.aws_iam_policy_document.kmsauth.json
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_kms_alias" "bless_kms_auth" {
   name          = "alias/${local.name}-kms-auth"
-  target_key_id =  aws_kms_key.bless_kms_auth.key_id
+  target_key_id = aws_kms_key.bless_kms_auth.key_id
 }

--- a/bless-ca/kms.tf
+++ b/bless-ca/kms.tf
@@ -4,12 +4,12 @@ resource "aws_kms_key" "bless" {
   description             = "KMS key for ${local.name}"
   deletion_window_in_days = 7
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_kms_alias" "bless" {
   name          = "alias/${local.name}"
-  target_key_id = "${aws_kms_key.bless.key_id}"
+  target_key_id =  aws_kms_key.bless.key_id
 }
 
 data "aws_iam_policy_document" "kmsauth" {
@@ -63,12 +63,12 @@ data "aws_iam_policy_document" "kmsauth" {
 resource "aws_kms_key" "bless_kms_auth" {
   description             = "KMS key for kmsauth for ${local.name}"
   deletion_window_in_days = 7
-  policy                  = "${data.aws_iam_policy_document.kmsauth.json}"
+  policy                  =  data.aws_iam_policy_document.kmsauth.json
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_kms_alias" "bless_kms_auth" {
   name          = "alias/${local.name}-kms-auth"
-  target_key_id = "${aws_kms_key.bless_kms_auth.key_id}"
+  target_key_id =  aws_kms_key.bless_kms_auth.key_id
 }

--- a/bless-ca/lambda.tf
+++ b/bless-ca/lambda.tf
@@ -7,23 +7,23 @@ resource "random_id" "path" {
 }
 
 data "bless_lambda" "code" {
-  kmsauth_key_id                =  aws_kms_key.bless_kms_auth.key_id
-  encrypted_password            =  bless_ca.bless.encrypted_password
-  encrypted_ca                  =  bless_ca.bless.encrypted_ca
-  service_name                  =  local.name
-  output_path                   =  local.lambda_zip_file
-  logging_level                 =  var.bless_logging_level
-  kmsauth_iam_group_name_format =  var.kmsauth_iam_group_name_format
+  kmsauth_key_id                = aws_kms_key.bless_kms_auth.key_id
+  encrypted_password            = bless_ca.bless.encrypted_password
+  encrypted_ca                  = bless_ca.bless.encrypted_ca
+  service_name                  = local.name
+  output_path                   = local.lambda_zip_file
+  logging_level                 = var.bless_logging_level
+  kmsauth_iam_group_name_format = var.kmsauth_iam_group_name_format
 }
 
 resource "aws_lambda_function" "bless" {
-  filename         =  local.lambda_zip_file
-  function_name    =  local.name
+  filename         = local.lambda_zip_file
+  function_name    = local.name
   handler          = "bless_lambda.lambda_handler"
-  source_code_hash =  data.bless_lambda.code.output_base64sha256
+  source_code_hash = data.bless_lambda.code.output_base64sha256
   runtime          = "python3.6"
-  kms_key_arn      =  aws_kms_key.bless.arn
+  kms_key_arn      = aws_kms_key.bless.arn
   timeout          = 10
-  tags             =  local.tags
-  role             =  aws_iam_role.bless.arn
+  tags             = local.tags
+  role             = aws_iam_role.bless.arn
 }

--- a/bless-ca/lambda.tf
+++ b/bless-ca/lambda.tf
@@ -7,23 +7,23 @@ resource "random_id" "path" {
 }
 
 data "bless_lambda" "code" {
-  kmsauth_key_id                = "${aws_kms_key.bless_kms_auth.key_id}"
-  encrypted_password            = "${bless_ca.bless.encrypted_password}"
-  encrypted_ca                  = "${bless_ca.bless.encrypted_ca}"
-  service_name                  = "${local.name}"
-  output_path                   = "${local.lambda_zip_file}"
-  logging_level                 = "${var.bless_logging_level}"
-  kmsauth_iam_group_name_format = "${var.kmsauth_iam_group_name_format}"
+  kmsauth_key_id                =  aws_kms_key.bless_kms_auth.key_id
+  encrypted_password            =  bless_ca.bless.encrypted_password
+  encrypted_ca                  =  bless_ca.bless.encrypted_ca
+  service_name                  =  local.name
+  output_path                   =  local.lambda_zip_file
+  logging_level                 =  var.bless_logging_level
+  kmsauth_iam_group_name_format =  var.kmsauth_iam_group_name_format
 }
 
 resource "aws_lambda_function" "bless" {
-  filename         = "${local.lambda_zip_file}"
-  function_name    = "${local.name}"
+  filename         =  local.lambda_zip_file
+  function_name    =  local.name
   handler          = "bless_lambda.lambda_handler"
-  source_code_hash = "${data.bless_lambda.code.output_base64sha256}"
+  source_code_hash =  data.bless_lambda.code.output_base64sha256
   runtime          = "python3.6"
-  kms_key_arn      = "${aws_kms_key.bless.arn}"
+  kms_key_arn      =  aws_kms_key.bless.arn
   timeout          = 10
-  tags             = "${local.tags}"
-  role             = "${aws_iam_role.bless.arn}"
+  tags             =  local.tags
+  role             =  aws_iam_role.bless.arn
 }

--- a/bless-ca/main.tf
+++ b/bless-ca/main.tf
@@ -3,9 +3,9 @@ locals {
 
   tags = {
     managedBy = "terraform"
-    project   = "${var.project}"
-    env       = "${var.env}"
-    owner     = "${var.owner}"
-    service   = "${var.service}"
+    project   =  var.project
+    env       =  var.env
+    owner     =  var.owner
+    service   =  var.service
   }
 }

--- a/bless-ca/main.tf
+++ b/bless-ca/main.tf
@@ -3,9 +3,9 @@ locals {
 
   tags = {
     managedBy = "terraform"
-    project   =  var.project
-    env       =  var.env
-    owner     =  var.owner
-    service   =  var.service
+    project   = var.project
+    env       = var.env
+    owner     = var.owner
+    service   = var.service
   }
 }

--- a/bless-ca/outputs.tf
+++ b/bless-ca/outputs.tf
@@ -1,7 +1,7 @@
 output "ca_public_key" {
-  value =  bless_ca.bless.public_key
+  value = bless_ca.bless.public_key
 }
 
 output "lambda_arn" {
-  value =  aws_lambda_function.bless.arn
+  value = aws_lambda_function.bless.arn
 }

--- a/bless-ca/outputs.tf
+++ b/bless-ca/outputs.tf
@@ -1,7 +1,7 @@
 output "ca_public_key" {
-  value = "${bless_ca.bless.public_key}"
+  value =  bless_ca.bless.public_key
 }
 
 output "lambda_arn" {
-  value = "${aws_lambda_function.bless.arn}"
+  value =  aws_lambda_function.bless.arn
 }

--- a/bless-ca/test/main.tf
+++ b/bless-ca/test/main.tf
@@ -1,24 +1,24 @@
 provider "bless" {
-  region  = "${var.region}"
-  profile = "${var.bless_provider_aws_profile}"
+  region  =  var.region
+  profile =  var.bless_provider_aws_profile
 }
 
 # create a dummy user to test
 resource "aws_iam_user" "bless-test" {
-  name = "${var.test_user_name}"
-  path = "${var.iam_path}"
+  name =  var.test_user_name
+  path =  var.iam_path
 }
 
 module "bless" {
   source = "./.."
 
-  project = "${var.project}"
-  service = "${var.service}"
-  env     = "${var.env}"
-  owner   = "${var.owner}"
+  project =  var.project
+  service =  var.service
+  env     =  var.env
+  owner   =  var.owner
 
-  iam_path                      = "${var.iam_path}"
+  iam_path                      =  var.iam_path
   authorized_users              = ["${aws_iam_user.bless-test.arn}"]
-  kmsauth_iam_group_name_format = "${var.kmsauth_iam_group_name_format}"
-  bless_logging_level           = "${var.bless_logging_level}"
+  kmsauth_iam_group_name_format =  var.kmsauth_iam_group_name_format
+  bless_logging_level           =  var.bless_logging_level
 }

--- a/github-webhooks-to-s3/api_gateway.tf
+++ b/github-webhooks-to-s3/api_gateway.tf
@@ -1,47 +1,47 @@
 // https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
 resource "aws_api_gateway_rest_api" "github" {
-  name        =  local.name
+  name        = local.name
   description = "Github webhook ingestion"
 }
 
 resource "aws_api_gateway_resource" "github" {
-  rest_api_id =  aws_api_gateway_rest_api.github.id
-  parent_id   =  aws_api_gateway_rest_api.github.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.github.id
+  parent_id   = aws_api_gateway_rest_api.github.root_resource_id
   path_part   = "{proxy+}"
 }
 
 resource "aws_api_gateway_method" "github" {
-  rest_api_id   =  aws_api_gateway_rest_api.github.id
-  resource_id   =  aws_api_gateway_resource.github.id
+  rest_api_id   = aws_api_gateway_rest_api.github.id
+  resource_id   = aws_api_gateway_resource.github.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "lambda" {
-  rest_api_id =  aws_api_gateway_rest_api.github.id
-  resource_id =  aws_api_gateway_method.github.resource_id
-  http_method =  aws_api_gateway_method.github.http_method
+  rest_api_id = aws_api_gateway_rest_api.github.id
+  resource_id = aws_api_gateway_method.github.resource_id
+  http_method = aws_api_gateway_method.github.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     =  aws_lambda_function.lambda.invoke_arn
+  uri                     = aws_lambda_function.lambda.invoke_arn
 }
 
 resource "aws_api_gateway_method" "github_root" {
-  rest_api_id   =  aws_api_gateway_rest_api.github.id
-  resource_id   =  aws_api_gateway_rest_api.github.root_resource_id
+  rest_api_id   = aws_api_gateway_rest_api.github.id
+  resource_id   = aws_api_gateway_rest_api.github.root_resource_id
   http_method   = "ANY"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "lambda_root" {
-  rest_api_id =  aws_api_gateway_rest_api.github.id
-  resource_id =  aws_api_gateway_method.github_root.resource_id
-  http_method =  aws_api_gateway_method.github_root.http_method
+  rest_api_id = aws_api_gateway_rest_api.github.id
+  resource_id = aws_api_gateway_method.github_root.resource_id
+  http_method = aws_api_gateway_method.github_root.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     =  aws_lambda_function.lambda.invoke_arn
+  uri                     = aws_lambda_function.lambda.invoke_arn
 }
 
 resource "aws_api_gateway_deployment" "github" {
@@ -50,14 +50,14 @@ resource "aws_api_gateway_deployment" "github" {
     "aws_api_gateway_integration.lambda_root",
   ]
 
-  rest_api_id =  aws_api_gateway_rest_api.github.id
-  stage_name  =  var.env
+  rest_api_id = aws_api_gateway_rest_api.github.id
+  stage_name  = var.env
 }
 
 resource "aws_lambda_permission" "apigw" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name =  aws_lambda_function.lambda.arn
+  function_name = aws_lambda_function.lambda.arn
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "${aws_api_gateway_deployment.github.execution_arn}/*/*"

--- a/github-webhooks-to-s3/api_gateway.tf
+++ b/github-webhooks-to-s3/api_gateway.tf
@@ -1,47 +1,47 @@
 // https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
 resource "aws_api_gateway_rest_api" "github" {
-  name        = "${local.name}"
+  name        =  local.name
   description = "Github webhook ingestion"
 }
 
 resource "aws_api_gateway_resource" "github" {
-  rest_api_id = "${aws_api_gateway_rest_api.github.id}"
-  parent_id   = "${aws_api_gateway_rest_api.github.root_resource_id}"
+  rest_api_id =  aws_api_gateway_rest_api.github.id
+  parent_id   =  aws_api_gateway_rest_api.github.root_resource_id
   path_part   = "{proxy+}"
 }
 
 resource "aws_api_gateway_method" "github" {
-  rest_api_id   = "${aws_api_gateway_rest_api.github.id}"
-  resource_id   = "${aws_api_gateway_resource.github.id}"
+  rest_api_id   =  aws_api_gateway_rest_api.github.id
+  resource_id   =  aws_api_gateway_resource.github.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.github.id}"
-  resource_id = "${aws_api_gateway_method.github.resource_id}"
-  http_method = "${aws_api_gateway_method.github.http_method}"
+  rest_api_id =  aws_api_gateway_rest_api.github.id
+  resource_id =  aws_api_gateway_method.github.resource_id
+  http_method =  aws_api_gateway_method.github.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.lambda.invoke_arn}"
+  uri                     =  aws_lambda_function.lambda.invoke_arn
 }
 
 resource "aws_api_gateway_method" "github_root" {
-  rest_api_id   = "${aws_api_gateway_rest_api.github.id}"
-  resource_id   = "${aws_api_gateway_rest_api.github.root_resource_id}"
+  rest_api_id   =  aws_api_gateway_rest_api.github.id
+  resource_id   =  aws_api_gateway_rest_api.github.root_resource_id
   http_method   = "ANY"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "lambda_root" {
-  rest_api_id = "${aws_api_gateway_rest_api.github.id}"
-  resource_id = "${aws_api_gateway_method.github_root.resource_id}"
-  http_method = "${aws_api_gateway_method.github_root.http_method}"
+  rest_api_id =  aws_api_gateway_rest_api.github.id
+  resource_id =  aws_api_gateway_method.github_root.resource_id
+  http_method =  aws_api_gateway_method.github_root.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.lambda.invoke_arn}"
+  uri                     =  aws_lambda_function.lambda.invoke_arn
 }
 
 resource "aws_api_gateway_deployment" "github" {
@@ -50,14 +50,14 @@ resource "aws_api_gateway_deployment" "github" {
     "aws_api_gateway_integration.lambda_root",
   ]
 
-  rest_api_id = "${aws_api_gateway_rest_api.github.id}"
-  stage_name  = "${var.env}"
+  rest_api_id =  aws_api_gateway_rest_api.github.id
+  stage_name  =  var.env
 }
 
 resource "aws_lambda_permission" "apigw" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda.arn}"
+  function_name =  aws_lambda_function.lambda.arn
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "${aws_api_gateway_deployment.github.execution_arn}/*/*"

--- a/github-webhooks-to-s3/certs.tf
+++ b/github-webhooks-to-s3/certs.tf
@@ -1,34 +1,34 @@
 resource "aws_api_gateway_domain_name" "github" {
-  certificate_arn =  var.certificate_arn
-  domain_name     =  var.fqdn
+  certificate_arn = var.certificate_arn
+  domain_name     = var.fqdn
 }
 
 resource "aws_api_gateway_base_path_mapping" "github" {
-  api_id      =  aws_api_gateway_rest_api.github.id
-  stage_name  =  aws_api_gateway_deployment.github.stage_name
-  domain_name =  aws_api_gateway_domain_name.github.domain_name
+  api_id      = aws_api_gateway_rest_api.github.id
+  stage_name  = aws_api_gateway_deployment.github.stage_name
+  domain_name = aws_api_gateway_domain_name.github.domain_name
 }
 
 resource "aws_route53_record" "github" {
-  name    =  aws_api_gateway_domain_name.github.domain_name
+  name    = aws_api_gateway_domain_name.github.domain_name
   type    = "A"
-  zone_id =  var.route53_zone_id
+  zone_id = var.route53_zone_id
 
   alias {
     evaluate_target_health = true
-    name                   =  aws_api_gateway_domain_name.github.cloudfront_domain_name
-    zone_id                =  aws_api_gateway_domain_name.github.cloudfront_zone_id
+    name                   = aws_api_gateway_domain_name.github.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.github.cloudfront_zone_id
   }
 }
 
 resource "aws_route53_record" "github-ipv6" {
-  name    =  aws_api_gateway_domain_name.github.domain_name
+  name    = aws_api_gateway_domain_name.github.domain_name
   type    = "AAAA"
-  zone_id =  var.route53_zone_id
+  zone_id = var.route53_zone_id
 
   alias {
     evaluate_target_health = true
-    name                   =  aws_api_gateway_domain_name.github.cloudfront_domain_name
-    zone_id                =  aws_api_gateway_domain_name.github.cloudfront_zone_id
+    name                   = aws_api_gateway_domain_name.github.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.github.cloudfront_zone_id
   }
 }

--- a/github-webhooks-to-s3/certs.tf
+++ b/github-webhooks-to-s3/certs.tf
@@ -1,34 +1,34 @@
 resource "aws_api_gateway_domain_name" "github" {
-  certificate_arn = "${var.certificate_arn}"
-  domain_name     = "${var.fqdn}"
+  certificate_arn =  var.certificate_arn
+  domain_name     =  var.fqdn
 }
 
 resource "aws_api_gateway_base_path_mapping" "github" {
-  api_id      = "${aws_api_gateway_rest_api.github.id}"
-  stage_name  = "${aws_api_gateway_deployment.github.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.github.domain_name}"
+  api_id      =  aws_api_gateway_rest_api.github.id
+  stage_name  =  aws_api_gateway_deployment.github.stage_name
+  domain_name =  aws_api_gateway_domain_name.github.domain_name
 }
 
 resource "aws_route53_record" "github" {
-  name    = "${aws_api_gateway_domain_name.github.domain_name}"
+  name    =  aws_api_gateway_domain_name.github.domain_name
   type    = "A"
-  zone_id = "${var.route53_zone_id}"
+  zone_id =  var.route53_zone_id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.github.cloudfront_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.github.cloudfront_zone_id}"
+    name                   =  aws_api_gateway_domain_name.github.cloudfront_domain_name
+    zone_id                =  aws_api_gateway_domain_name.github.cloudfront_zone_id
   }
 }
 
 resource "aws_route53_record" "github-ipv6" {
-  name    = "${aws_api_gateway_domain_name.github.domain_name}"
+  name    =  aws_api_gateway_domain_name.github.domain_name
   type    = "AAAA"
-  zone_id = "${var.route53_zone_id}"
+  zone_id =  var.route53_zone_id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.github.cloudfront_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.github.cloudfront_zone_id}"
+    name                   =  aws_api_gateway_domain_name.github.cloudfront_domain_name
+    zone_id                =  aws_api_gateway_domain_name.github.cloudfront_zone_id
   }
 }

--- a/github-webhooks-to-s3/firehose.tf
+++ b/github-webhooks-to-s3/firehose.tf
@@ -1,13 +1,13 @@
 module "bucket" {
   source = "../aws-s3-private-bucket"
 
-  bucket_name   = "${local.name}"
+  bucket_name   =  local.name
   bucket_policy = ""
 
-  project = "${var.project}"
-  env     = "${var.env}"
-  service = "${var.service}"
-  owner   = "${var.owner}"
+  project =  var.project
+  env     =  var.env
+  service =  var.service
+  owner   =  var.owner
 }
 
 data "aws_iam_policy_document" "firehose" {
@@ -26,8 +26,8 @@ data "aws_iam_policy_document" "firehose" {
 resource "aws_iam_role" "firehose" {
   name = "${local.name}-firehose"
 
-  assume_role_policy = "${data.aws_iam_policy_document.firehose.json}"
-  tags               = "${local.tags}"
+  assume_role_policy =  data.aws_iam_policy_document.firehose.json
+  tags               =  local.tags
 }
 
 data "aws_iam_policy_document" "firehose-to-s3" {
@@ -67,36 +67,36 @@ data "aws_iam_policy_document" "firehose-to-s3" {
 
 resource "aws_iam_role_policy" "firehose-s3" {
   name   = "firehose-s3"
-  role   = "${aws_iam_role.firehose.id}"
-  policy = "${data.aws_iam_policy_document.firehose-to-s3.json}"
+  role   =  aws_iam_role.firehose.id
+  policy =  data.aws_iam_policy_document.firehose-to-s3.json
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose" {
-  name        = "${local.name}"
+  name        =  local.name
   destination = "s3"
 
   s3_configuration {
-    role_arn           = "${aws_iam_role.firehose.arn}"
-    bucket_arn         = "${module.bucket.arn}"
-    prefix             = "${var.s3_prefix}"
+    role_arn           =  aws_iam_role.firehose.arn
+    bucket_arn         =  module.bucket.arn
+    prefix             =  var.s3_prefix
     compression_format = "GZIP"
 
     cloudwatch_logging_options {
       enabled         = true
-      log_group_name  = "${aws_cloudwatch_log_group.firehose.name}"
-      log_stream_name = "${aws_cloudwatch_log_stream.firehose.name}"
+      log_group_name  =  aws_cloudwatch_log_group.firehose.name
+      log_stream_name =  aws_cloudwatch_log_stream.firehose.name
     }
   }
 
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_cloudwatch_log_group" "firehose" {
   name = "${local.name}-firehose"
-  tags = "${local.tags}"
+  tags =  local.tags
 }
 
 resource "aws_cloudwatch_log_stream" "firehose" {
   name           = "status"
-  log_group_name = "${aws_cloudwatch_log_group.firehose.name}"
+  log_group_name =  aws_cloudwatch_log_group.firehose.name
 }

--- a/github-webhooks-to-s3/firehose.tf
+++ b/github-webhooks-to-s3/firehose.tf
@@ -1,13 +1,13 @@
 module "bucket" {
   source = "../aws-s3-private-bucket"
 
-  bucket_name   =  local.name
+  bucket_name   = local.name
   bucket_policy = ""
 
-  project =  var.project
-  env     =  var.env
-  service =  var.service
-  owner   =  var.owner
+  project = var.project
+  env     = var.env
+  service = var.service
+  owner   = var.owner
 }
 
 data "aws_iam_policy_document" "firehose" {
@@ -26,8 +26,8 @@ data "aws_iam_policy_document" "firehose" {
 resource "aws_iam_role" "firehose" {
   name = "${local.name}-firehose"
 
-  assume_role_policy =  data.aws_iam_policy_document.firehose.json
-  tags               =  local.tags
+  assume_role_policy = data.aws_iam_policy_document.firehose.json
+  tags               = local.tags
 }
 
 data "aws_iam_policy_document" "firehose-to-s3" {
@@ -67,36 +67,36 @@ data "aws_iam_policy_document" "firehose-to-s3" {
 
 resource "aws_iam_role_policy" "firehose-s3" {
   name   = "firehose-s3"
-  role   =  aws_iam_role.firehose.id
-  policy =  data.aws_iam_policy_document.firehose-to-s3.json
+  role   = aws_iam_role.firehose.id
+  policy = data.aws_iam_policy_document.firehose-to-s3.json
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose" {
-  name        =  local.name
+  name        = local.name
   destination = "s3"
 
   s3_configuration {
-    role_arn           =  aws_iam_role.firehose.arn
-    bucket_arn         =  module.bucket.arn
-    prefix             =  var.s3_prefix
+    role_arn           = aws_iam_role.firehose.arn
+    bucket_arn         = module.bucket.arn
+    prefix             = var.s3_prefix
     compression_format = "GZIP"
 
     cloudwatch_logging_options {
       enabled         = true
-      log_group_name  =  aws_cloudwatch_log_group.firehose.name
-      log_stream_name =  aws_cloudwatch_log_stream.firehose.name
+      log_group_name  = aws_cloudwatch_log_group.firehose.name
+      log_stream_name = aws_cloudwatch_log_stream.firehose.name
     }
   }
 
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_log_group" "firehose" {
   name = "${local.name}-firehose"
-  tags =  local.tags
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_log_stream" "firehose" {
   name           = "status"
-  log_group_name =  aws_cloudwatch_log_group.firehose.name
+  log_group_name = aws_cloudwatch_log_group.firehose.name
 }

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -4,10 +4,10 @@ locals {
   tags = {
     managedBy = "terraform"
     Name      = local.name
-    env       = "${var.env}"
-    owner     = "${var.owner}"
-    service   = "${var.service}"
-    owner     = "${var.owner}"
+    env       =  var.env
+    owner     =  var.owner
+    service   =  var.service
+    owner     =  var.owner
   }
 }
 
@@ -37,14 +37,14 @@ data "aws_iam_policy_document" "firehose-write" {
 
 resource "aws_iam_role_policy" "firehose" {
   name   = "firehose"
-  role   = "${aws_iam_role.lambda.id}"
-  policy = "${data.aws_iam_policy_document.firehose-write.json}"
+  role   =  aws_iam_role.lambda.id
+  policy =  data.aws_iam_policy_document.firehose-write.json
 }
 
 module "attach-logs" {
   source    = "../aws-iam-policy-cwlogs"
-  role_name = "${aws_iam_role.lambda.name}"
-  iam_path  = "${var.iam_path}"
+  role_name =  aws_iam_role.lambda.name
+  iam_path  =  var.iam_path
 }
 
 resource "aws_iam_role" "lambda" {
@@ -56,28 +56,28 @@ resource "aws_iam_role" "lambda" {
 
 module "github_secret" {
   source  = "../aws-param"
-  project = "${var.project}"
-  env     = "${var.env}"
-  service = "${var.service}"
+  project =  var.project
+  env     =  var.env
+  service =  var.service
   name    = "github_secret"
 }
 
 resource "aws_lambda_function" "lambda" {
-  s3_bucket = "${var.lambda_source_s3_bucket}"
-  s3_key    = "${var.lambda_source_s3_key}"
+  s3_bucket =  var.lambda_source_s3_bucket
+  s3_key    =  var.lambda_source_s3_key
 
-  function_name = "${local.name}"
+  function_name =  local.name
   handler       = "handler"
 
   runtime = "go1.x"
-  role    = "${aws_iam_role.lambda.arn}"
+  role    =  aws_iam_role.lambda.arn
   timeout = 20
-  tags    = "${local.tags}"
+  tags    =  local.tags
 
   environment {
     variables = {
-      FIREHOSE_DELIVERY_STREAM = "${local.name}"
-      GITHUB_SECRET            = "${module.github_secret.value}"
+      FIREHOSE_DELIVERY_STREAM =  local.name
+      GITHUB_SECRET            =  module.github_secret.value
     }
   }
 }

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -4,10 +4,10 @@ locals {
   tags = {
     managedBy = "terraform"
     Name      = local.name
-    env       =  var.env
-    owner     =  var.owner
-    service   =  var.service
-    owner     =  var.owner
+    env       = var.env
+    owner     = var.owner
+    service   = var.service
+    owner     = var.owner
   }
 }
 
@@ -37,14 +37,14 @@ data "aws_iam_policy_document" "firehose-write" {
 
 resource "aws_iam_role_policy" "firehose" {
   name   = "firehose"
-  role   =  aws_iam_role.lambda.id
-  policy =  data.aws_iam_policy_document.firehose-write.json
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.firehose-write.json
 }
 
 module "attach-logs" {
   source    = "../aws-iam-policy-cwlogs"
-  role_name =  aws_iam_role.lambda.name
-  iam_path  =  var.iam_path
+  role_name = aws_iam_role.lambda.name
+  iam_path  = var.iam_path
 }
 
 resource "aws_iam_role" "lambda" {
@@ -56,28 +56,28 @@ resource "aws_iam_role" "lambda" {
 
 module "github_secret" {
   source  = "../aws-param"
-  project =  var.project
-  env     =  var.env
-  service =  var.service
+  project = var.project
+  env     = var.env
+  service = var.service
   name    = "github_secret"
 }
 
 resource "aws_lambda_function" "lambda" {
-  s3_bucket =  var.lambda_source_s3_bucket
-  s3_key    =  var.lambda_source_s3_key
+  s3_bucket = var.lambda_source_s3_bucket
+  s3_key    = var.lambda_source_s3_key
 
-  function_name =  local.name
+  function_name = local.name
   handler       = "handler"
 
   runtime = "go1.x"
-  role    =  aws_iam_role.lambda.arn
+  role    = aws_iam_role.lambda.arn
   timeout = 20
-  tags    =  local.tags
+  tags    = local.tags
 
   environment {
     variables = {
-      FIREHOSE_DELIVERY_STREAM =  local.name
-      GITHUB_SECRET            =  module.github_secret.value
+      FIREHOSE_DELIVERY_STREAM = local.name
+      GITHUB_SECRET            = module.github_secret.value
     }
   }
 }


### PR DESCRIPTION
This was a scripted change that updates as many instances as could be found to the new, simpler syntax.

I used codemod with this command:

``` codemod --extensions tf '=(\s)+"\$\{([^}]+)}"$' '=\1 \2'```

### Test Plan
* unit tests

### References

