### PR TITLE
[breaking] [feature] allow setting ca_cert_identifier on aurora modules

### DIFF
--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -18,6 +18,7 @@ module "aurora" {
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  ca_cert_identifier                  = var.ca_cert_identifier
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups

--- a/aws-aurora-mysql/terraform.tf
+++ b/aws-aurora-mysql/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    # ca_cert_identifier on RDS was added in 2.44.0
+    aws = ">= 2.44.0"
+  }
+}

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -170,6 +170,6 @@ variable "engine_version" {
 
 variable ca_cert_identifier {
   type        = string
-  description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
+  description = "Identifier for the certificate authority. rds-ca-2015 is the latest available version."
   default     = "rds-ca-2015"
 }

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -167,3 +167,9 @@ variable "engine_version" {
   type    = string
   default = "5.7"
 }
+
+variable ca_cert_identifier {
+  type        = string
+  description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
+  default     = "rds-ca-2015"
+}

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -16,6 +16,7 @@ module "aurora" {
   rds_cluster_parameters              = var.rds_cluster_parameters
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   performance_insights_enabled        = var.performance_insights_enabled
+  ca_cert_identifier                  = var.ca_cert_identifier
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups

--- a/aws-aurora-postgres/terraform.tf
+++ b/aws-aurora-postgres/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    # ca_cert_identifier on RDS was added in 2.44.0
+    aws = ">= 2.44.0"
+  }
+}

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -118,3 +118,9 @@ variable "iam_database_authentication_enabled" {
   type    = string
   default = false
 }
+
+variable ca_cert_identifier {
+  type        = string
+  description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
+  default     = "rds-ca-2015"
+}

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -71,6 +71,7 @@ resource "aws_rds_cluster_instance" "db" {
   instance_class          = var.instance_class
   db_subnet_group_name    = var.database_subnet_group
   db_parameter_group_name = aws_db_parameter_group.db.name
+  ca_cert_identifier      = var.ca_cert_identifier
 
   publicly_accessible          = var.publicly_accessible
   performance_insights_enabled = var.performance_insights_enabled

--- a/aws-aurora/terraform.tf
+++ b/aws-aurora/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    # ca_cert_identifier on RDS was added in 2.44.0
+    aws = ">= 2.44.0"
+  }
+}

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -125,3 +125,9 @@ variable "db_deletion_protection" {
   type    = string
   default = false
 }
+
+variable ca_cert_identifier {
+  type        = string
+  description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
+  default     = "rds-ca-2015"
+}

--- a/aws-efs-volume/main.tf
+++ b/aws-efs-volume/main.tf
@@ -12,7 +12,7 @@ resource "aws_efs_file_system" "efs" {
   creation_token = var.volume_name
   encrypted      = true
   kms_key_id     = var.kms_key_id
-  tags           = merge(local.tags, {Name = var.volume_name})
+  tags           = merge(local.tags, { Name = var.volume_name })
 }
 
 resource "aws_efs_mount_target" "efs" {


### PR DESCRIPTION
This will allow upgrading aurora database instances to the new certificate authority.

* https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html