### PR TITLE
[fix] naming template for Aurora Postgres param group name

### DIFF
--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,7 +1,8 @@
 module "aurora" {
-  source         = "../aws-aurora"
-  engine         = "aurora-mysql"
-  engine_version = var.engine_version
+  source                = "../aws-aurora"
+  engine                = "aurora-mysql"
+  engine_version        = var.engine_version
+  params_engine_version = var.engine_version
 
   project = var.project
   env     = var.env

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,7 +1,17 @@
+locals {
+  # For Aurora postgres, the parameter group names before Postgres version 10
+  # are named like "aurora-postgresql9.6", but for version 10 and above the
+  # name omits the minor version e.g. "aurora-postgresql10". We parse the
+  # engine version to distinguish the 2 cases.
+  split_engine_version  = split(".", var.engine_version)
+  params_engine_version = local.split_engine_version[0] == "9" ? join(".", slice(local.split_engine_version, 0, 2)) : local.split_engine_version[0]
+}
+
 module "aurora" {
-  source         = "../aws-aurora"
-  engine         = "aurora-postgresql"
-  engine_version = var.engine_version
+  source                = "../aws-aurora"
+  engine                = "aurora-postgresql"
+  engine_version        = var.engine_version
+  params_engine_version = local.params_engine_version
 
   project = var.project
   env     = var.env

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -83,7 +83,7 @@ resource "aws_rds_cluster_instance" "db" {
 
 resource "aws_rds_cluster_parameter_group" "db" {
   name        = local.name
-  family      = "${var.engine}${var.engine_version}"
+  family      = "${var.engine}${var.params_engine_version}"
   description = "RDS default cluster parameter group"
 
   dynamic "parameter" {
@@ -95,16 +95,12 @@ resource "aws_rds_cluster_parameter_group" "db" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [family]
-  }
-
   tags = local.tags
 }
 
 resource "aws_db_parameter_group" "db" {
   name   = local.name
-  family = "${var.engine}${var.engine_version}"
+  family = "${var.engine}${var.params_engine_version}"
 
   dynamic "parameter" {
     for_each = var.db_parameters
@@ -113,10 +109,6 @@ resource "aws_db_parameter_group" "db" {
       value        = parameter.value.value
       apply_method = parameter.value.apply_method
     }
-  }
-
-  lifecycle {
-    ignore_changes = [family]
   }
 
   tags = local.tags

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -106,6 +106,10 @@ variable "engine_version" {
   type = string
 }
 
+variable "params_engine_version" {
+  type = string
+}
+
 variable "iam_database_authentication_enabled" {
   type    = string
   default = true


### PR DESCRIPTION
For Aurora postgres, the parameter group names before Postgres version 10 are named like "aurora-postgresql9.6", but for version 10 and above the name omits the minor version e.g. "aurora-postgresql10". We parse the engine version to distinguish the 2 cases. We also remove the ignore_changes on family, since these parameter group family versions do need to match the engine version.