### PR TITLE
[fix] create aurora sg ingress blocks conditionally

### DIFF
--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "rds" {
       from_port   = var.port
       to_port     = var.port
       protocol    = "tcp"
-      cidr_blocks = ingress.value
+      cidr_blocks = [ingress.value]
     }
   }
 
@@ -33,7 +33,7 @@ resource "aws_security_group" "rds" {
       from_port       = var.port
       to_port         = var.port
       protocol        = "tcp"
-      security_groups = ingress.value
+      security_groups = [ingress.value]
     }
   }
 

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -17,13 +17,26 @@ resource "aws_security_group" "rds" {
 
   vpc_id = var.vpc_id
 
-  ingress {
-    from_port       = var.port
-    to_port         = var.port
-    protocol        = "tcp"
-    cidr_blocks     = var.ingress_cidr_blocks
-    security_groups = var.ingress_security_groups
+  dynamic ingress {
+    for_each = var.ingress_cidr_blocks
+    content {
+      from_port   = var.port
+      to_port     = var.port
+      protocol    = "tcp"
+      cidr_blocks = ingress.value
+    }
   }
+
+  dynamic ingress {
+    for_each = var.ingress_security_groups
+    content {
+      from_port       = var.port
+      to_port         = var.port
+      protocol        = "tcp"
+      security_groups = ingress.value
+    }
+  }
+
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Previously if you supplied empty lists for ingress cidr and security
groups you would end up with a diff that terraform could not resolve.
This is presumably because AWS will drop empty ingress rules.

With this change we will only create an ingress if they are configured.

### Test Plan
* unit tests
* tested manually in tfe

### References
*
