### PR TITLE
[test] run a plan to test to aws-aurora

### DIFF
--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -3,12 +3,34 @@ package test
 import (
 	"testing"
 
+	"github.com/chanzuckerberg/cztack/testutil"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAWSAurora(t *testing.T) {
-	options := &terraform.Options{
-		TerraformDir: ".",
-	}
-	terraform.Init(t, options)
+	a := assert.New(t)
+	options := testutil.Options(
+		testutil.DefaultRegion,
+		map[string]interface{}{
+			"database_name":         testutil.UniqueId(),
+			"engine_version":        "10.7",
+			"params_engine_version": "10",
+			"port":                  "5432",
+			"engine":                "aurora-postgresql",
+			"vpc_id":                "vpc-12345",
+
+			"project":               testutil.UniqueId(),
+			"service":               testutil.UniqueId(),
+			"env":                   testutil.UniqueId(),
+			"owner":                 testutil.UniqueId(),
+			"database_username":     testutil.UniqueId(),
+			"database_password":     testutil.UniqueId(),
+			"database_subnet_group": testutil.UniqueId(),
+		},
+	)
+
+	rc, e := terraform.InitAndPlanE(t, options)
+	a.NoError(e)
+	a.Equal(2, rc) // 2 means planned changes, no errors
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// IAMRegion IAM is allegedly hosted in us-east-1 use this region for IAM related things
+	// IAMRegion IAM is allegedly hosted in us-east-1, so use this region for IAM related things
 	IAMRegion     = "us-east-1"
 	DefaultRegion = "us-west-2"
 )


### PR DESCRIPTION
Rather than just an init, we run a plan and assert that it did not
error. This should at least catch straightforward semantic errors.
of changes or issues addressed by this PR. Provide links to relevant PRs if any.

### Test Plan
* new test!
