### PR TITLE
allow aws-s3-private-bucket take in custom lifecycle_rule

### DIFF
--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -14,6 +14,7 @@
 | bucket\_policy | n/a | `string` | `""` | no |
 | enable\_versioning | Keep old versions of overwritten S3 objects. | `bool` | `true` | no |
 | env | n/a | `string` | n/a | yes |
+| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br>  {<br>    "enabled": true,<br>    "expiration": {<br>      "expired_object_delete_marker": true<br>    },<br>    "noncurrent_version_expiration": {<br>      "days": 365<br>    },<br>    "noncurrent_version_transition": {<br>      "days": 30,<br>      "storage_class": "STANDARD_IA"<br>    }<br>  }<br>]</pre> | no |
 | owner | n/a | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | service | n/a | `string` | n/a | yes |

--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -14,7 +14,7 @@
 | bucket\_policy | n/a | `string` | `""` | no |
 | enable\_versioning | Keep old versions of overwritten S3 objects. | `bool` | `true` | no |
 | env | n/a | `string` | n/a | yes |
-| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br>  {<br>    "enabled": true,<br>    "expiration": {<br>      "expired_object_delete_marker": true<br>    },<br>    "noncurrent_version_expiration": {<br>      "days": 365<br>    },<br>    "noncurrent_version_transition": {<br>      "days": 30,<br>      "storage_class": "STANDARD_IA"<br>    }<br>  }<br>]</pre> | no |
+| lifecycle\_rules | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br>  {<br>    "enabled": true,<br>    "expiration": {<br>      "expired_object_delete_marker": true<br>    },<br>    "noncurrent_version_expiration": {<br>      "days": 365<br>    },<br>    "noncurrent_version_transition": {<br>      "days": 30,<br>      "storage_class": "STANDARD_IA"<br>    }<br>  }<br>]</pre> | no |
 | owner | n/a | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |
 | service | n/a | `string` | n/a | yes |

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -20,10 +20,10 @@ resource "aws_s3_bucket" "bucket" {
 
   # dynamic block used instead of simply assigning a variable b/c lifecycle_rule is configuration block
   dynamic "lifecycle_rule" {
-    for_each = var.lifecycle_rule
+    for_each = var.lifecycle_rules
 
     content {
-      id                                     = lookup(lifecycle_rule.value, "id", null) #lookup() provides default value in case it does not exist in var.lifecycle_rule input
+      id                                     = lookup(lifecycle_rule.value, "id", null) #lookup() provides default value in case it does not exist in var.lifecycle_rules input
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -18,11 +18,12 @@ resource "aws_s3_bucket" "bucket" {
     enabled = var.enable_versioning
   }
 
+  # dynamic block used instead of simply assigning a variable b/c lifecycle_rule is configuration block
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rule
 
     content {
-      id                                     = lookup(lifecycle_rule.value, "id", null)
+      id                                     = lookup(lifecycle_rule.value, "id", null) #lookup() provides default value in case it does not exist in var.lifecycle_rule input
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -18,26 +18,54 @@ resource "aws_s3_bucket" "bucket" {
     enabled = var.enable_versioning
   }
 
-  lifecycle_rule {
-    enabled = true
+  dynamic "lifecycle_rule" {
+    for_each = var.lifecycle_rule
 
-    abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+    content {
+      id                                     = lookup(lifecycle_rule.value, "id", null)
+      prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
+      tags                                   = lookup(lifecycle_rule.value, "tags", null)
+      enabled                                = lookup(lifecycle_rule.value, "enabled", false)
+      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", null)
 
-    expiration {
-      expired_object_delete_marker = true
-    }
+      dynamic "expiration" {
+        for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]
 
-    noncurrent_version_transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
+        content {
+          date                         = lookup(expiration.value, "date", null)
+          days                         = lookup(expiration.value, "days", null)
+          expired_object_delete_marker = lookup(expiration.value, "expired_object_delete_marker", null)
+        }
+      }
 
-    noncurrent_version_expiration {
-      days = 365
+      dynamic "transition" {
+        for_each = length(keys(lookup(lifecycle_rule.value, "transition", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "transition", {})]
+
+        content {
+          date          = lookup(transition.value, "date", null)
+          days          = lookup(transition.value, "days", null)
+          storage_class = lookup(transition.value, "storage_class", null)
+        }
+      }
+
+      dynamic "noncurrent_version_expiration" {
+        for_each = length(keys(lookup(lifecycle_rule.value, "noncurrent_version_expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "noncurrent_version_expiration", {})]
+
+        content {
+          days = lookup(noncurrent_version_expiration.value, "days", null)
+        }
+      }
+
+      dynamic "noncurrent_version_transition" {
+        for_each = length(keys(lookup(lifecycle_rule.value, "noncurrent_version_transition", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "noncurrent_version_transition", {})]
+
+        content {
+          days          = lookup(lifecycle_rule.value.noncurrent_version_transition, "days", null)
+          storage_class = lookup(lifecycle_rule.value.noncurrent_version_transition, "storage_class", null)
+        }
+      }
     }
   }
-
-
 
   # TODO
   #   logging {

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket" "bucket" {
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)
-      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", null)
+      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 
       dynamic "expiration" {
         for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -42,8 +42,6 @@ variable "lifecycle_rule" {
     {
       enabled = true
 
-      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
-
       expiration = {
         expired_object_delete_marker = true
       }

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -34,3 +34,28 @@ variable "abort_incomplete_multipart_upload_days" {
   description = "Number of days after which an incomplete multipart upload is canceled."
   default     = 14
 }
+
+variable "lifecycle_rule" {
+  description = "List of maps containing configuration of object lifecycle management."
+  type        = any
+  default = [
+    {
+      enabled = true
+
+      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+
+      expiration = {
+        expired_object_delete_marker = true
+      }
+
+      noncurrent_version_transition = {
+        days          = 30
+        storage_class = "STANDARD_IA"
+      }
+
+      noncurrent_version_expiration = {
+        days = 365
+      }
+    }
+  ]
+}

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -35,7 +35,7 @@ variable "abort_incomplete_multipart_upload_days" {
   default     = 14
 }
 
-variable "lifecycle_rule" {
+variable "lifecycle_rules" {
   description = "List of maps containing configuration of object lifecycle management."
   type        = any
   default = [


### PR DESCRIPTION
### Summary
This change allows an implementation of `aws-s3-private-bucket` to use the current lifecycle_rule, or provide a different one via a TF variable. For example, in my implementation I'd like to have a shorter 30-day TTL on "current" objects in the bucket. 

This is a little cumbersome, but I'm unsure if there's a cleaner way (new to TF lol) of doing this, since the `s3` resource doesn't take in a named argument but rather a configuration block. 

### Test Plan
Verified via `make plan` on a resource. 

### References
(Optional) Additional links to provide more context.
