### PR TITLE
Fix aws-ssm-params readmes, add crossacct output

### DIFF
--- a/aws-iam-role-crossacct/outputs.tf
+++ b/aws-iam-role-crossacct/outputs.tf
@@ -2,6 +2,10 @@ output "role_name" {
   value = aws_iam_role.role.name
 }
 
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}
+
 output "iam_path" {
   value = var.iam_path
 }

--- a/aws-params-writer/README.md
+++ b/aws-params-writer/README.md
@@ -1,5 +1,7 @@
 # AWS Params Writer
 
+__*Deprecated. Please use `aws-ssm-params-writer` module for new code*__
+
 This module will set encrypted string parameters in the AWS SSM parameter store. Designed to be used in combination with
 [Chamber](https://github.com/segmentio/chamber) to send variables that are output by a Terraform run to a process via
 environment variables.

--- a/aws-ssm-params-writer/README.md
+++ b/aws-ssm-params-writer/README.md
@@ -1,7 +1,5 @@
 # AWS SSM Params Writer (DEPRECATED)
 
-__*Deprecated. Please use `aws-ssm-params-writer` module for new code*__
-
 This module will set encrypted string parameters in the AWS SSM parameter store. Designed to be used in combination with
 [Chamber](https://github.com/segmentio/chamber) to send variables that are output by a Terraform run to a process via
 environment variables.

--- a/aws-ssm-params/README.md
+++ b/aws-ssm-params/README.md
@@ -2,7 +2,7 @@
 
 This module is made to work together with [Chamber](https://github.com/segmentio/chamber) to manage secrets in AWS. Typically a user would use chamber to put secrets into the ParamStore and then use this module to read them out in Terraform code.
 
-You can use [our secrets setup module](../aws-param-secrets-setup/README.md) to prepare an AWS account/region to work with these tools.
+You can use [our secrets setup module](../aws-params-secrets-setup/README.md) to prepare an AWS account/region to work with these tools.
 
 ## Example
 

--- a/aws-ssm-params/main.tf
+++ b/aws-ssm-params/main.tf
@@ -3,7 +3,6 @@ locals {
 }
 
 data "aws_ssm_parameter" "secret" {
-  # https://github.com/hashicorp/terraform/issues/22281#issuecomment-517080564
-  for_each = { for v in var.parameters : v => v }
+  for_each = var.parameters
   name     = "/${local.service_name}/${each.key}"
 }

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -55,11 +55,11 @@ resource "aws_iam_role" "lambda" {
 }
 
 module "github_secret" {
-  source  = "../aws-param"
-  project = var.project
-  env     = var.env
-  service = var.service
-  name    = "github_secret"
+  source     = "../aws-ssm-params"
+  project    = var.project
+  env        = var.env
+  service    = var.service
+  parameters = ["github_secret"]
 }
 
 resource "aws_lambda_function" "lambda" {
@@ -77,7 +77,7 @@ resource "aws_lambda_function" "lambda" {
   environment {
     variables = {
       FIREHOSE_DELIVERY_STREAM = local.name
-      GITHUB_SECRET            = module.github_secret.value
+      GITHUB_SECRET            = module.github_secret.values["github_secret"]
     }
   }
 }


### PR DESCRIPTION
### Summary
* Fixes README files to properly note deprecations; a comment made it into the wrong README file.
* Fixes a README typo.
* Replaces a usage of deprecated aws-param modules with new aws-ssm-params
* Replaces a workaround of a Terraform bug with more straightforward usage now that bug is fixed
* Adds an output to aws-iam-role-crossacct