### PR TITLE
[breaking] fix tests for aurora

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -18,7 +18,7 @@ module "db" {
   database_subnet_group = "..."
   database_password     = "..."
   database_password     = "..."
-  
+
   vpc_id               = "..."
   ingress_cidr_blocks	 = "..."
 
@@ -41,7 +41,7 @@ No provider.
 |------|-------------|------|---------|:-----:|
 | apply\_immediately | If false changes will not be applied until next maintenance window. | `string` | `false` | no |
 | backtrack\_window | Turns on Backgrack for this many seconds. [Doc](https://aws.amazon.com/blogs/aws/amazon-aurora-backtrack-turn-back-time/) | `string` | `0` | no |
-| ca\_cert\_identifier | Identifier for the certificate authority. rds-ca-2015 is the latest available version. | `string` | `"rds-ca-2015"` | no |
+| ca\_cert\_identifier | Identifier for the certificate authority. 9 is the latest available version. | `string` | `"rds-ca-2015"` | no |
 | database\_name | The name of the database to be created in the cluster. | `string` | n/a | yes |
 | database\_password | Password for user that will be created. | `string` | n/a | yes |
 | database\_subnet\_group | The name of an existing database subnet group to use. | `string` | n/a | yes |

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -170,6 +170,6 @@ variable "engine_version" {
 
 variable ca_cert_identifier {
   type        = string
-  description = "Identifier for the certificate authority. rds-ca-2015 is the latest available version."
-  default     = "rds-ca-2015"
+  description = "Identifier for the certificate authority. 9 is the latest available version."
+  default     = "rds-ca-2019"
 }

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -121,6 +121,6 @@ variable "iam_database_authentication_enabled" {
 
 variable ca_cert_identifier {
   type        = string
-  description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
-  default     = "rds-ca-2015"
+  description = "Identifier for the certificate authority."
+  default     = "rds-ca-2019"
 }

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -133,5 +133,5 @@ variable "db_deletion_protection" {
 variable ca_cert_identifier {
   type        = string
   description = "Identifier for the certificate authority. Use rds-ca-2015 for anything new."
-  default     = "rds-ca-2015"
+  default     = "rds-ca-2019"
 }


### PR DESCRIPTION
Our defaults are triggering a state where the instance is created and
then immediately rebooted. That reboot races with the destroy operation
leading to errors
[like](https://travis-ci.com/chanzuckerberg/cztack/jobs/292461303).

Setting the default should improve this.

Marked as breaking because it changes the default for these modules.

### Test Plan
* CI

### References