### PR TITLE
[feature] aws-iam-role-*: Allow multiple accounts to assume role, deprecate source_account_id

### DIFF
--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -33,7 +33,8 @@ output "..." {
 | bless\_lambda\_arns | List of bless lambda arns | `list` | n/a | yes |
 | iam\_path | IAM path | `string` | `"/"` | no |
 | role\_name | The name for the role | `string` | n/a | yes |
-| source\_account\_id | The source aws account id to allow sts:AssumeRole | `string` | n/a | yes |
+| source\_account\_id | The source aws account id to allow sts:AssumeRole. DEPRECATED: Please use source\_account\_ids | `string` | n/a | yes |
+| source\_account\_ids | The source aws account ids to allow sts:AssumeRole | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -15,7 +15,8 @@ resource "aws_iam_role_policy" "client" {
 module "client" {
   source = "../aws-iam-role-crossacct"
 
-  role_name         = var.role_name
-  iam_path          = var.iam_path
-  source_account_id = var.source_account_id
+  role_name          = var.role_name
+  iam_path           = var.iam_path
+  source_account_id  = var.source_account_id
+  source_account_ids = var.source_account_ids
 }

--- a/aws-iam-role-bless/variables.tf
+++ b/aws-iam-role-bless/variables.tf
@@ -5,7 +5,13 @@ variable "role_name" {
 
 variable "source_account_id" {
   type        = string
-  description = "The source aws account id to allow sts:AssumeRole"
+  description = "The source aws account id to allow sts:AssumeRole. DEPRECATED: Please use source_account_ids"
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source aws account ids to allow sts:AssumeRole"
 }
 
 variable "bless_lambda_arns" {

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -17,7 +17,8 @@ This module will create a role which is granted poweruser control over AWS Cloud
 | role\_name | Name of the role to create | `string` | n/a | yes |
 | s3\_bucket\_prefixes | Limits role permissions to buckets with specific prefixes. Empty for all buckets. | `list` | <pre>[<br>  ""<br>]</pre> | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-cloudfront-poweruser/variables.tf
+++ b/aws-iam-role-cloudfront-poweruser/variables.tf
@@ -20,7 +20,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -31,7 +31,8 @@ module "group" {
 | oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | The name of the role. | `string` | n/a | yes |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -11,7 +11,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -32,7 +32,8 @@ module "ec2-poweruser" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | n/a | yes |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-ec2-poweruser/variables.tf
+++ b/aws-iam-role-ec2-poweruser/variables.tf
@@ -10,7 +10,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -31,7 +31,8 @@ module "ec2-poweruser" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | n/a | yes |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-ecs-poweruser/variables.tf
+++ b/aws-iam-role-ecs-poweruser/variables.tf
@@ -10,7 +10,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -16,7 +16,8 @@ Creates a role useful for running `terraform plan` in CI jobs.
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | `"infraci"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Pleaase use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 | terraform\_state\_lock\_dynamodb\_arns | ARNs of the state file DynamoDB tables | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-infraci/variables.tf
+++ b/aws-iam-role-infraci/variables.tf
@@ -15,7 +15,13 @@ variable "terraform_state_lock_dynamodb_arns" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Pleaase use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -30,7 +30,8 @@ module "group" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | `"poweruser"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]
@@ -38,17 +49,6 @@ resource "aws_iam_role" "poweruser" {
 resource "aws_iam_role_policy_attachment" "poweruser" {
   role       = aws_iam_role.poweruser.name
   policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
-}
-
-data "aws_iam_policy_document" "poweruser" {
-  statement {
-    sid = "misc"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
-    }
-  }
 }
 
 # These are extra permissions we're adding that

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -9,6 +9,12 @@ variable "source_account_id" {
   description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
 }
 
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
+}
+
 variable "saml_idp_arn" {
   type        = string
   default     = ""

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -6,7 +6,7 @@ variable "role_name" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
 }
 
 variable "source_account_ids" {

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -34,7 +34,8 @@ output "role_name" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | `"readonly"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-readonly/variables.tf
+++ b/aws-iam-role-readonly/variables.tf
@@ -10,7 +10,13 @@ variable "role_name" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -31,7 +31,8 @@ module "route53domains-poweruser" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | n/a | `string` | `"route53domains-poweruser"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-route53domains-poweruser/variables.tf
+++ b/aws-iam-role-route53domains-poweruser/variables.tf
@@ -11,7 +11,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -26,7 +26,8 @@ module "group" {
 | iam\_path | n/a | `string` | `"/"` | no |
 | role\_name | The name of this role. | `string` | `"security-audit"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
-| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
+| source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
+| source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -4,7 +4,18 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.source_account_id}:root"]
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.source_account_ids
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
       actions = ["sts:AssumeRole"]
     }
@@ -15,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
     content {
       principals {
         type        = "Federated"
-        identifiers = ["${var.saml_idp_arn}"]
+        identifiers = [statement.value]
       }
 
       actions = ["sts:AssumeRoleWithSAML"]

--- a/aws-iam-role-security-audit/variables.tf
+++ b/aws-iam-role-security-audit/variables.tf
@@ -12,7 +12,13 @@ variable "iam_path" {
 variable "source_account_id" {
   type        = string
   default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided."
+  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
+}
+
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
 variable "saml_idp_arn" {


### PR DESCRIPTION
Adds a source_account_ids field to aws-iam-role-* modules, which will allow multiple accounts' root to assume role, assuming the user/role in the other accounts allow the role assumption.

Either source_account_id or source_account_ids or both work; the intent is to keep backwards compatibility for now, but potentially eliminate source_account_id. Officially document that source_account_id is deprecated.