### PR TITLE
Expose the cluster endpoint in the aurora module

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -71,6 +71,7 @@ No provider.
 | Name | Description |
 |------|-------------|
 | database\_name | n/a |
+| db\_parameter\_group\_name | n/a |
 | endpoint | n/a |
 | rds\_cluster\_id | n/a |
 | reader\_endpoint | n/a |

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -57,6 +57,7 @@ No provider.
 | instance\_count | Number of instances to create in this cluster. | `string` | `1` | no |
 | kms\_key\_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | `string` | `""` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
+| params\_engine\_version | n/a | `string` | `"5.7"` | no |
 | performance\_insights\_enabled | n/a | `string` | `false` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | publicly\_accessible | Avoid doing this - it gives access to the open internet. | `string` | `false` | no |
@@ -71,6 +72,7 @@ No provider.
 |------|-------------|
 | database\_name | n/a |
 | endpoint | n/a |
+| rds\_cluster\_id | n/a |
 | reader\_endpoint | n/a |
 
 <!-- END -->

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -48,7 +48,7 @@ No provider.
 | database\_username | Default user to be created. | `string` | n/a | yes |
 | db\_deletion\_protection | n/a | `string` | `false` | no |
 | db\_parameters | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Instance) | `list` | <pre>[<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "general_log",<br>    "value": 1<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "slow_query_log",<br>    "value": "1"<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "long_query_time",<br>    "value": "0"<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "log_output",<br>    "value": "file"<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "log_queries_not_using_indexes",<br>    "value": "1"<br>  }<br>]</pre> | no |
-| engine\_version | n/a | `string` | `"5.7"` | no |
+| engine\_version | The version of the engine to be used for aurora-mysql. | `string` | `"5.7"` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | iam\_database\_authentication\_enabled | n/a | `string` | `false` | no |
 | ingress\_cidr\_blocks | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | `list(string)` | `[]` | no |
@@ -57,7 +57,7 @@ No provider.
 | instance\_count | Number of instances to create in this cluster. | `string` | `1` | no |
 | kms\_key\_id | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | `string` | `""` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
-| params\_engine\_version | n/a | `string` | `"5.7"` | no |
+| params\_engine\_version | The engine version to be appended to the parameter group family. | `string` | `"5.7"` | no |
 | performance\_insights\_enabled | n/a | `string` | `false` | no |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | publicly\_accessible | Avoid doing this - it gives access to the open internet. | `string` | `false` | no |

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -73,6 +73,7 @@ No provider.
 | database\_name | n/a |
 | db\_parameter\_group\_name | n/a |
 | endpoint | n/a |
+| engine | n/a |
 | rds\_cluster\_id | n/a |
 | reader\_endpoint | n/a |
 

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -2,7 +2,7 @@ module "aurora" {
   source                = "../aws-aurora"
   engine                = "aurora-mysql"
   engine_version        = var.engine_version
-  params_engine_version = var.engine_version
+  params_engine_version = var.params_engine_version
 
   project = var.project
   env     = var.env

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -13,3 +13,7 @@ output "reader_endpoint" {
 output "rds_cluster_id" {
   value = module.aurora.rds_cluster_id
 }
+
+output "db_parameter_group_name" {
+  value = module.aurora.db_parameter_group_name
+}

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -1,3 +1,7 @@
+output "engine" {
+  value = "aurora-mysql"
+}
+
 output "database_name" {
   value = module.aurora.database_name
 }

--- a/aws-aurora-mysql/outputs.tf
+++ b/aws-aurora-mysql/outputs.tf
@@ -9,3 +9,7 @@ output "endpoint" {
 output "reader_endpoint" {
   value = module.aurora.reader_endpoint
 }
+
+output "rds_cluster_id" {
+  value = module.aurora.rds_cluster_id
+}

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -164,13 +164,15 @@ variable "db_deletion_protection" {
 }
 
 variable "engine_version" {
-  type    = string
-  default = "5.7"
+  type        = string
+  description = "The version of the engine to be used for aurora-mysql."
+  default     = "5.7"
 }
 
 variable "params_engine_version" {
-  type    = string
-  default = "5.7"
+  type        = string
+  description = "The engine version to be appended to the parameter group family."
+  default     = "5.7"
 }
 
 variable ca_cert_identifier {

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -168,6 +168,11 @@ variable "engine_version" {
   default = "5.7"
 }
 
+variable "params_engine_version" {
+  type    = string
+  default = "5.7"
+}
+
 variable ca_cert_identifier {
   type        = string
   description = "Identifier for the certificate authority. rds-ca-2019 is the latest available version."

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -50,6 +50,7 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | database\_name | n/a |
 | endpoint | n/a |
 | port | n/a |
+| rds\_cluster\_id | n/a |
 | reader\_endpoint | n/a |
 
 <!-- END -->

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -48,6 +48,7 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | Name | Description |
 |------|-------------|
 | database\_name | n/a |
+| db\_parameter\_group\_name | n/a |
 | endpoint | n/a |
 | port | n/a |
 | rds\_cluster\_id | n/a |

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -13,3 +13,7 @@ output "reader_endpoint" {
 output "port" {
   value = var.port
 }
+
+output "rds_cluster_id" {
+  value = aws_rds_cluster.db.id
+}

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -17,3 +17,7 @@ output "port" {
 output "rds_cluster_id" {
   value = aws_rds_cluster.db.id
 }
+
+output "db_parameter_group_name" {
+  value = aws_db_parameter_group.db.name
+}


### PR DESCRIPTION
### Summary
- Exposing the aurora cluster endpoint so that we can attach a different class of instance to the cluster.
- Exposing the `db_parameter_group_name` which is also required when externally creating a new instance.
- Fix a bug where the module was passing the `engine_version` was being passed as the `params_engine_version` as well. This works when they're both `5.7` or some other select values but not always. For example, if version is `5.7.28` or any other minor version, that would be considered an invalid `params_engine_version` value.

### Test Plan
Tested this code directly by pulling this module into my existing source.