### PR TITLE
Include TagSession privilege for assumed roles.

### DIFF
--- a/aws-iam-group-assume-role/main.tf
+++ b/aws-iam-group-assume-role/main.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "assume-role" {
   statement {
     sid       = "assume0"
     resources = local.account_arns
-    actions   = ["sts:AssumeRole"]
+    actions   = ["sts:AssumeRole", "sts:TagSession"]
   }
 }
 

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "assume-role" {
         type        = "AWS"
         identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
-      actions = ["sts:AssumeRole"]
+      actions = ["sts:AssumeRole", "sts:TagSession"]
     }
   }
 
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume-role" {
         type        = "AWS"
         identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
-      actions = ["sts:AssumeRole"]
+      actions = ["sts:AssumeRole", "sts:TagSession"]
     }
   }
 
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "assume-role" {
         identifiers = [statement.value]
       }
 
-      actions = ["sts:AssumeRoleWithSAML"]
+      actions = ["sts:AssumeRoleWithSAML", "sts:TagSession"]
 
       condition {
         test     = "StringEquals"
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "assume-role" {
         identifiers = [oidc.value["idp_arn"]]
       }
 
-      actions = ["sts:AssumeRoleWithWebIdentity"]
+      actions = ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"]
       condition {
         test     = "StringEquals"
         variable = "${oidc.value["provider"]}:aud"


### PR DESCRIPTION
### Summary
I'm working with GitHub Actions - its canonical AWS credentials action requires that 'sts:TagSession' permissions be granted for role assumption:
https://github.com/aws-actions/configure-aws-credentials#permissions-for-assuming-a-role

I'm not sure if we have a policy reason for denying this permission (if so, I can look into alternative auth methods) but it seemed like a minor behavior change.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
This change enables a pretty straighforward ECR build&push pipeline via GHA: https://github.com/chanzuckerberg/tfe-docker/blob/actiontest/.github/workflows/daily-rebuild.yml