### PR TITLE
[feature] AWS Poweruser role allows OIDC sts:AssumeRoleWithWebIdentity

### DIFF
--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -32,6 +32,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | iam\_path | n/a | `string` | `"/"` | no |
+| oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | n/a | `string` | `"poweruser"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -25,3 +25,16 @@ variable "iam_path" {
   type    = string
   default = "/"
 }
+
+variable oidc {
+  type = list(object(
+    {
+      idp_arn : string,          # the AWS IAM IDP arn
+      client_ids : list(string), # a list of oidc client ids
+      provider : string          # your provider url, such as foo.okta.com
+    }
+  ))
+
+  default     = []
+  description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
+}


### PR DESCRIPTION
### Summary
We optionally enable the poweruser role for sts:AssumeRoleWithWebIdentity. 

### Test Plan
Follows convention of the cross-act role.