### PR TITLE
[feature] Optionally disable poweruser role iam actions

### DIFF
--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -31,6 +31,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| authorize\_iam | Indicates if we should augment the PoserUserAccess policy with certain IAM actions. | `bool` | `true` | no |
 | iam\_path | n/a | `string` | `"/"` | no |
 | oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | n/a | `string` | `"poweruser"` | no |

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -31,7 +31,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| authorize\_iam | Indicates if we should augment the PoserUserAccess policy with certain IAM actions. | `bool` | `true` | no |
+| authorize\_iam | Indicates if we should augment the PowerUserAccess policy with certain IAM actions. | `bool` | `true` | no |
 | iam\_path | n/a | `string` | `"/"` | no |
 | oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | n/a | `string` | `"poweruser"` | no |

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -154,6 +154,8 @@ data "aws_iam_policy_document" "misc" {
 }
 
 resource "aws_iam_policy" "misc" {
+  count = var.authorize_iam ? 1 : 0
+
   name        = "${var.role_name}-misc"
   path        = var.iam_path
   description = "Extra permissions we're granting that PowerUserAccess lacks"
@@ -161,6 +163,8 @@ resource "aws_iam_policy" "misc" {
 }
 
 resource "aws_iam_role_policy_attachment" "misc" {
+  count = var.authorize_iam ? 1 : 0
+
   role       = aws_iam_role.poweruser.name
   policy_arn = aws_iam_policy.misc.arn
 }

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -38,3 +38,9 @@ variable oidc {
   default     = []
   description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
 }
+
+variable authorize_iam {
+  type        = bool
+  default     = true
+  description = "Indicates if we should augment the PoserUserAccess policy with certain IAM actions."
+}

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -42,5 +42,5 @@ variable oidc {
 variable authorize_iam {
   type        = bool
   default     = true
-  description = "Indicates if we should augment the PoserUserAccess policy with certain IAM actions."
+  description = "Indicates if we should augment the PowerUserAccess policy with certain IAM actions."
 }


### PR DESCRIPTION
### Summary
Occasionally we might want to disable the extra iam actions in poweruser role, make it configurable.