### PR TITLE
[feature] Readonly role OIDC federation enabled + kms decrypt optional

### DIFF
--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -35,7 +35,9 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| authorize\_read\_secrets | Should this role also be authorized to decrypt and read secrets. | `bool` | `true` | no |
 | iam\_path | n/a | `string` | `"/"` | no |
+| oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | n/a | `string` | `"readonly"` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "assume-role" {
         type        = "AWS"
         identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
-      actions = ["sts:AssumeRole"]
+      actions = ["sts:AssumeRole", "sts:TagSession"]
     }
   }
 
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume-role" {
         type        = "AWS"
         identifiers = ["arn:aws:iam::${statement.value}:root"]
       }
-      actions = ["sts:AssumeRole"]
+      actions = ["sts:AssumeRole", "sts:TagSession"]
     }
   }
 
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "assume-role" {
         identifiers = [statement.value]
       }
 
-      actions = ["sts:AssumeRoleWithSAML"]
+      actions = ["sts:AssumeRoleWithSAML", "sts:TagSession"]
 
       condition {
         test     = "StringEquals"
@@ -38,6 +38,26 @@ data "aws_iam_policy_document" "assume-role" {
       }
     }
   }
+
+  dynamic "statement" {
+    for_each = var.oidc
+    iterator = oidc
+
+    content {
+      principals {
+        type        = "Federated"
+        identifiers = [oidc.value["idp_arn"]]
+      }
+
+      actions = ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"]
+      condition {
+        test     = "StringEquals"
+        variable = "${oidc.value["provider"]}:aud"
+        values   = oidc.value["client_ids"]
+      }
+    }
+  }
+
 }
 
 resource "aws_iam_role" "readonly" {
@@ -65,6 +85,8 @@ data "aws_iam_policy_document" "secrets" {
 }
 
 resource "aws_iam_role_policy" "secrets" {
+  count = var.authorize_read_secrets ? 1 : 0
+
   name   = "secrets"
   role   = aws_iam_role.readonly.name
   policy = data.aws_iam_policy_document.secrets.json

--- a/aws-iam-role-readonly/variables.tf
+++ b/aws-iam-role-readonly/variables.tf
@@ -24,3 +24,22 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable oidc {
+  type = list(object(
+    {
+      idp_arn : string,          # the AWS IAM IDP arn
+      client_ids : list(string), # a list of oidc client ids
+      provider : string          # your provider url, such as foo.okta.com
+    }
+  ))
+
+  default     = []
+  description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
+}
+
+variable authorize_read_secrets {
+  type        = bool
+  description = "Should this role also be authorized to decrypt and read secrets."
+  default     = true
+}


### PR DESCRIPTION
### Summary
Authorize the readonly role for OIDC federation. Optionally limit kms read permissions.
