### PR TITLE
[fix] Use index when referring to a dependency with a count

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -166,5 +166,5 @@ resource "aws_iam_role_policy_attachment" "misc" {
   count = var.authorize_iam ? 1 : 0
 
   role       = aws_iam_role.poweruser.name
-  policy_arn = aws_iam_policy.misc.arn
+  policy_arn = aws_iam_policy.misc[count.index].arn
 }


### PR DESCRIPTION
### Summary
We're depending on a resource with a count, we need to reflect the index in the dependency as well.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
