### PR TITLE
[feature] standard tags for IAM roles

### DIFF
--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -39,6 +39,7 @@ No requirements.
 | role\_name | The name for the role | `string` | n/a | yes |
 | source\_account\_id | The source aws account id to allow sts:AssumeRole. DEPRECATED: Please use source\_account\_ids | `string` | n/a | yes |
 | source\_account\_ids | The source aws account ids to allow sts:AssumeRole | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -19,4 +19,5 @@ module "client" {
   iam_path           = var.iam_path
   source_account_id  = var.source_account_id
   source_account_ids = var.source_account_ids
+  tags               = var.tags
 }

--- a/aws-iam-role-bless/module_test.go
+++ b/aws-iam-role-bless/module_test.go
@@ -19,6 +19,9 @@ func TestIAMRoleBless(t *testing.T) {
 		Vars: map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 			"bless_lambda_arns": []string{"arn:aws:lambda:us-west-2:111111111111:function:test"},
 		},
 		EnvVars: map[string]string{

--- a/aws-iam-role-bless/variables.tf
+++ b/aws-iam-role-bless/variables.tf
@@ -24,3 +24,9 @@ variable "iam_path" {
   default     = "/"
   description = "IAM path"
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -23,6 +23,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "assume-role" {
 resource "aws_iam_role" "role" {
   name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "s3" {

--- a/aws-iam-role-cloudfront-poweruser/module_test.go
+++ b/aws-iam-role-cloudfront-poweruser/module_test.go
@@ -19,6 +19,9 @@ func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 			"role_name":         random.UniqueId(),
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-cloudfront-poweruser/variables.tf
+++ b/aws-iam-role-cloudfront-poweruser/variables.tf
@@ -34,3 +34,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -34,10 +34,10 @@ No requirements.
 | iam\_path | The IAM path to put this role in. | `string` | `"/"` | no |
 | oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | The name of the role. | `string` | n/a | yes |
-| role\_tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -64,7 +64,7 @@ resource "aws_iam_role" "role" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.role_tags
+  tags               = var.tags
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -17,7 +17,7 @@ func TestAWSIAMRoleCrossAcct(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
-			"role_tags": map[string]string{
+			"tags": map[string]string{
 				"test": random.UniqueId(),
 			},
 		},

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -39,7 +39,7 @@ variable oidc {
   description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
 }
 
-variable role_tags {
+variable tags {
   type        = map(string)
   default     = {}
   description = "A map of tags to assign this IAM Role."

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -38,6 +38,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "ec2-poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "ec2" {

--- a/aws-iam-role-ec2-poweruser/module_test.go
+++ b/aws-iam-role-ec2-poweruser/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-ec2-poweruser/variables.tf
+++ b/aws-iam-role-ec2-poweruser/variables.tf
@@ -24,3 +24,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -37,6 +37,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "ecs-poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-fullaccess" {

--- a/aws-iam-role-ecs-poweruser/module_test.go
+++ b/aws-iam-role-ecs-poweruser/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-ecs-poweruser/variables.tf
+++ b/aws-iam-role-ecs-poweruser/variables.tf
@@ -24,3 +24,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -22,6 +22,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Pleaase use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 | terraform\_state\_lock\_dynamodb\_arns | ARNs of the state file DynamoDB tables | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "infraci" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "infraci" {

--- a/aws-iam-role-infraci/module_test.go
+++ b/aws-iam-role-infraci/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleInfraCI(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 		},
 	)

--- a/aws-iam-role-infraci/variables.tf
+++ b/aws-iam-role-infraci/variables.tf
@@ -29,3 +29,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -38,6 +38,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -64,6 +64,7 @@ resource "aws_iam_role" "poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser" {

--- a/aws-iam-role-poweruser/module_test.go
+++ b/aws-iam-role-poweruser/module_test.go
@@ -16,6 +16,9 @@ func TestAWSIAMRolePowerUser(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -44,3 +44,9 @@ variable authorize_iam {
   default     = true
   description = "Indicates if we should augment the PowerUserAccess policy with certain IAM actions."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -42,6 +42,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -64,6 +64,7 @@ resource "aws_iam_role" "readonly" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {

--- a/aws-iam-role-readonly/module_test.go
+++ b/aws-iam-role-readonly/module_test.go
@@ -19,6 +19,9 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-readonly/variables.tf
+++ b/aws-iam-role-readonly/variables.tf
@@ -43,3 +43,9 @@ variable authorize_read_secrets {
   description = "Should this role also be authorized to decrypt and read secrets."
   default     = true
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -37,6 +37,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "route53domains-poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "route53domains-fullaccess" {

--- a/aws-iam-role-route53domains-poweruser/module_test.go
+++ b/aws-iam-role-route53domains-poweruser/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleRoute53DomainsPoweruser(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-route53domains-poweruser/variables.tf
+++ b/aws-iam-role-route53domains-poweruser/variables.tf
@@ -25,3 +25,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -32,6 +32,7 @@ No requirements.
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "security-audit" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "security-audit" {

--- a/aws-iam-role-security-audit/module_test.go
+++ b/aws-iam-role-security-audit/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 		},
 	)

--- a/aws-iam-role-security-audit/variables.tf
+++ b/aws-iam-role-security-audit/variables.tf
@@ -26,3 +26,9 @@ variable "saml_idp_arn" {
   default     = ""
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign this IAM Role."
+}


### PR DESCRIPTION
Adds ability to add standard AWS tags to IAM roles. Tag arguments may be omitted for backwards compatibility.