### PR TITLE
[feature] aws-iam-role-crossacct: Allow tagging

### DIFF
--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -46,7 +46,7 @@ No requirements.
 | allow\_validation\_record\_overwrite | Allow the overwrite of validation records. This is needed if you are creating certificates in multiple regions. | `string` | `true` | no |
 | aws\_route53\_zone\_id | n/a | `string` | n/a | yes |
 | cert\_domain\_name | Like www.foo.bar.com or \*.foo.bar.com | `string` | n/a | yes |
-| cert\_subject\_alternative\_names | A map of <alternative\_domain:route53\_zone\_id> | `map` | `{}` | no |
+| cert\_subject\_alternative\_names | A map of <alternative\_domain:route53\_zone\_id> | `map(string)` | `{}` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -34,6 +34,7 @@ No requirements.
 | iam\_path | The IAM path to put this role in. | `string` | `"/"` | no |
 | oidc | A list of AWS OIDC IDPs to establish a trust relationship for this role. | <pre>list(object(<br>    {<br>      idp_arn : string,          # the AWS IAM IDP arn<br>      client_ids : list(string), # a list of oidc client ids<br>      provider : string          # your provider url, such as foo.okta.com<br>    }<br>  ))</pre> | `[]` | no |
 | role\_name | The name of the role. | `string` | n/a | yes |
+| role\_tags | A map of tags to assign this IAM Role. | `map(string)` | `{}` | no |
 | saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | source\_account\_id | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | source\_account\_ids | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -64,6 +64,7 @@ resource "aws_iam_role" "role" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
+  tags = var.tags
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -64,7 +64,7 @@ resource "aws_iam_role" "role" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags = var.tags
+  tags = var.role_tags
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -64,7 +64,7 @@ resource "aws_iam_role" "role" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags = var.role_tags
+  tags               = var.role_tags
 
   # We have to force detach policies in order to recreate roles.
   # The other option would be to use name_prefix and create_before_destroy, but that

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -17,6 +17,9 @@ func TestAWSIAMRoleCrossAcct(t *testing.T) {
 		map[string]interface{}{
 			"role_name":         random.UniqueId(),
 			"source_account_id": curAcct,
+			"role_tags": map[string]string{
+				"test": random.UniqueId(),
+			},
 		},
 	)
 

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -38,3 +38,9 @@ variable oidc {
   default     = []
   description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
 }
+
+variable role_tags {
+  type = map(string)
+  default = {}
+  description = "A map of tags to assign this IAM Role."
+}

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -40,7 +40,7 @@ variable oidc {
 }
 
 variable role_tags {
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
   description = "A map of tags to assign this IAM Role."
 }


### PR DESCRIPTION
### Summary
Want to give us the ability to tag this IAM role.

### Test Plan
unittests

### References
https://github.com/chanzuckerberg/aws-oidc/pull/26