### PR TITLE
[feature] support auto_minor_version_upgrade

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -46,6 +46,7 @@ No provider.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | apply\_immediately | If false changes will not be applied until next maintenance window. | `string` | `false` | no |
+| auto\_minor\_version\_upgrade | Set the databases to automatically upgrade minor versions. | `bool` | `true` | no |
 | backtrack\_window | Turns on Backgrack for this many seconds. [Doc](https://aws.amazon.com/blogs/aws/amazon-aurora-backtrack-turn-back-time/) | `string` | `0` | no |
 | ca\_cert\_identifier | Identifier for the certificate authority. rds-ca-2019 is the latest available version. | `string` | `"rds-ca-2019"` | no |
 | database\_name | The name of the database to be created in the cluster. | `string` | n/a | yes |

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -20,6 +20,7 @@ module "aurora" {
   performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
   ca_cert_identifier                  = var.ca_cert_identifier
+  auto_minor_version_upgrade          = var.auto_minor_version_upgrade
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -180,3 +180,9 @@ variable ca_cert_identifier {
   description = "Identifier for the certificate authority. rds-ca-2019 is the latest available version."
   default     = "rds-ca-2019"
 }
+
+variable auto_minor_version_upgrade {
+  type        = bool
+  description = "Set the databases to automatically upgrade minor versions."
+  default     = true
+}

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -45,6 +45,7 @@ No provider.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | apply\_immediately | If false changes will not be applied until next maintenance window. | `string` | `false` | no |
+| auto\_minor\_version\_upgrade | Set the databases to automatically upgrade minor versions. | `bool` | `true` | no |
 | ca\_cert\_identifier | Identifier for the certificate authority. | `string` | `"rds-ca-2019"` | no |
 | database\_name | The name of the database to be created in the cluster. | `string` | n/a | yes |
 | database\_password | Password for user that will be created. | `string` | n/a | yes |

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -27,6 +27,7 @@ module "aurora" {
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   performance_insights_enabled        = var.performance_insights_enabled
   ca_cert_identifier                  = var.ca_cert_identifier
+  auto_minor_version_upgrade          = var.auto_minor_version_upgrade
 
   ingress_cidr_blocks     = var.ingress_cidr_blocks
   ingress_security_groups = var.ingress_security_groups

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -124,3 +124,9 @@ variable ca_cert_identifier {
   description = "Identifier for the certificate authority."
   default     = "rds-ca-2019"
 }
+
+variable auto_minor_version_upgrade {
+  type        = bool
+  description = "Set the databases to automatically upgrade minor versions."
+  default     = true
+}

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -20,6 +20,7 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | apply\_immediately | n/a | `bool` | `false` | no |
+| auto\_minor\_version\_upgrade | Set the databases to automatically upgrade minor versions. | `bool` | `true` | no |
 | backtrack\_window | n/a | `number` | `0` | no |
 | ca\_cert\_identifier | Identifier for the certificate authority. Use rds-ca-2019 for anything new. | `string` | `"rds-ca-2019"` | no |
 | database\_name | n/a | `string` | n/a | yes |

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -78,13 +78,14 @@ resource "aws_rds_cluster_instance" "db" {
   engine         = var.engine
   engine_version = var.engine_version
 
-  count                   = var.instance_count
-  identifier              = "${local.name}-${count.index}"
-  cluster_identifier      = aws_rds_cluster.db.id
-  instance_class          = var.instance_class
-  db_subnet_group_name    = var.database_subnet_group
-  db_parameter_group_name = aws_db_parameter_group.db.name
-  ca_cert_identifier      = var.ca_cert_identifier
+  count                      = var.instance_count
+  identifier                 = "${local.name}-${count.index}"
+  cluster_identifier         = aws_rds_cluster.db.id
+  instance_class             = var.instance_class
+  db_subnet_group_name       = var.database_subnet_group
+  db_parameter_group_name    = aws_db_parameter_group.db.name
+  ca_cert_identifier         = var.ca_cert_identifier
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
   publicly_accessible          = var.publicly_accessible
   performance_insights_enabled = var.performance_insights_enabled

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -135,3 +135,9 @@ variable ca_cert_identifier {
   description = "Identifier for the certificate authority. Use rds-ca-2019 for anything new."
   default     = "rds-ca-2019"
 }
+
+variable auto_minor_version_upgrade {
+  type        = bool
+  description = "Set the databases to automatically upgrade minor versions."
+  default     = true
+}


### PR DESCRIPTION
Enable setting auto_minor_version_upgrade on aurora databases.

We have been relying on the default of `true`. This allows you to disable it.


### Test Plan
* CI

### References
* https://www.terraform.io/docs/providers/aws/r/rds_cluster_instance.html#auto_minor_version_upgrade