### PR TITLE
[feature] setting lambda cloudwatch log retention

### DIFF
--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -62,7 +62,8 @@ EOF
 }
 
 resource aws_cloudwatch_log_group log {
-  name = "/aws/lambda/${local.name}"
+  name              = "/aws/lambda/${local.name}"
+  retention_in_days = var.log_retention_in_days
 }
 
 data aws_region current {}

--- a/aws-lambda-function/module_test.go
+++ b/aws-lambda-function/module_test.go
@@ -107,6 +107,14 @@ func TestDefaults(t *testing.T) {
 			})
 			r.NoError(err)
 			r.True(found)
+
+			// log retention
+			out, err := cw.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
+				LogGroupNamePrefix: &data.LogGroupName,
+			})
+			r.NoError(err)
+			r.Len(out.LogGroups, 1)
+			r.Equal(int64(1), *out.LogGroups[0].RetentionInDays)
 		},
 	}
 

--- a/aws-lambda-function/test/main.tf
+++ b/aws-lambda-function/test/main.tf
@@ -19,6 +19,8 @@ module lambda {
   filename         = data.archive_file.notifier.output_path
   source_code_hash = data.archive_file.notifier.output_base64sha256
 
+  log_retention_in_days = 1
+
   project = random_string.random.result
   env     = random_string.random.result
   service = random_string.random.result

--- a/aws-lambda-function/variables.tf
+++ b/aws-lambda-function/variables.tf
@@ -67,3 +67,8 @@ variable filename {
   type    = string
   default = null
 }
+
+variable log_retention_in_days {
+  type    = number
+  default = null
+}


### PR DESCRIPTION
Enable setting log retention parameter for the cloud watch log groups
attached to lambdas.

### Test Plan
* CI

### References