### PR TITLE
[breaking] aws-acm-cert: Require users to explicitly pass the number of SANs

### DIFF
--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -49,7 +49,7 @@ module "cert" {
 | aws\_route53\_zone\_id | n/a | `string` | n/a | yes |
 | cert\_domain\_name | Like www.foo.bar.com or \*.foo.bar.com | `string` | n/a | yes |
 | cert\_subject\_alternative\_names | A map of <alternative\_domain:route53\_zone\_id> | `map(string)` | `{}` | no |
-| cert\_subject\_alternative\_names\_count | The size of var.cert\_subject\_alternative\_names. Since var.cert\_subject\_alternative\_names can have dynamic keys/values we must hint terraform on its size. If you have no SANs then this should be 0. | `number` | n/a | yes |
+| cert\_subject\_alternative\_names\_count | The size of var.cert\_subject\_alternative\_names. Since var.cert\_subject\_alternative\_names can have dynamic keys/values we must hint terraform on its size. If you have no SANs then this should be 0. | `number` | `0` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -49,7 +49,7 @@ module "cert" {
 | aws\_route53\_zone\_id | n/a | `string` | n/a | yes |
 | cert\_domain\_name | Like www.foo.bar.com or \*.foo.bar.com | `string` | n/a | yes |
 | cert\_subject\_alternative\_names | A map of <alternative\_domain:route53\_zone\_id> | `map(string)` | `{}` | no |
-| cert\_subject\_alternative\_names\_count | The size of var.cert\_subject\_alternative\_names. Since var.cert\_subject\_alternative\_names can have dynamic keys/values we must hint terraform on its size. | `number` | n/a | yes |
+| cert\_subject\_alternative\_names\_count | The size of var.cert\_subject\_alternative\_names. Since var.cert\_subject\_alternative\_names can have dynamic keys/values we must hint terraform on its size. If you have no SANs then this should be 0. | `number` | n/a | yes |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-acm-cert/README.md
+++ b/aws-acm-cert/README.md
@@ -31,13 +31,15 @@ module "cert" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 
@@ -47,6 +49,7 @@ No requirements.
 | aws\_route53\_zone\_id | n/a | `string` | n/a | yes |
 | cert\_domain\_name | Like www.foo.bar.com or \*.foo.bar.com | `string` | n/a | yes |
 | cert\_subject\_alternative\_names | A map of <alternative\_domain:route53\_zone\_id> | `map(string)` | `{}` | no |
+| cert\_subject\_alternative\_names\_count | The size of var.cert\_subject\_alternative\_names. Since var.cert\_subject\_alternative\_names can have dynamic keys/values we must hint terraform on its size. | `number` | n/a | yes |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -7,7 +7,7 @@ locals {
     managedBy = "terraform"
   }
 
-  cert_validation_count = length(var.cert_subject_alternative_names) + 1
+  cert_validation_count = var.cert_subject_alternative_names_count + 1
 }
 
 resource "aws_acm_certificate" "cert" {

--- a/aws-acm-cert/module_test.go
+++ b/aws-acm-cert/module_test.go
@@ -49,10 +49,11 @@ func TestAWSACMCertDefaults(t *testing.T) {
 					"service": service,
 					"owner":   owner,
 
-					"cert_domain_name":               certDomainName,
-					"aws_route53_zone_id":            route53ZoneID,
-					"validation_record_ttl":          5,
-					"cert_subject_alternative_names": alternativeNames,
+					"cert_domain_name":                     certDomainName,
+					"aws_route53_zone_id":                  route53ZoneID,
+					"validation_record_ttl":                5,
+					"cert_subject_alternative_names":       alternativeNames,
+					"cert_subject_alternative_names_count": len(alternativeNames),
 				},
 			)
 		},

--- a/aws-acm-cert/variables.tf
+++ b/aws-acm-cert/variables.tf
@@ -53,4 +53,5 @@ variable "subject_alternative_names_order" {
 variable "cert_subject_alternative_names_count" {
   type        = number
   description = "The size of var.cert_subject_alternative_names. Since var.cert_subject_alternative_names can have dynamic keys/values we must hint terraform on its size. If you have no SANs then this should be 0."
+  default     = 0
 }

--- a/aws-acm-cert/variables.tf
+++ b/aws-acm-cert/variables.tf
@@ -52,5 +52,5 @@ variable "subject_alternative_names_order" {
 
 variable "cert_subject_alternative_names_count" {
   type        = number
-  description = "The size of var.cert_subject_alternative_names. Since var.cert_subject_alternative_names can have dynamic keys/values we must hint terraform on its size."
+  description = "The size of var.cert_subject_alternative_names. Since var.cert_subject_alternative_names can have dynamic keys/values we must hint terraform on its size. If you have no SANs then this should be 0."
 }

--- a/aws-acm-cert/variables.tf
+++ b/aws-acm-cert/variables.tf
@@ -49,3 +49,8 @@ variable "subject_alternative_names_order" {
   description = "Order to list the subject alternative names in the ACM cert. Workaround for https://github.com/terraform-providers/terraform-provider-aws/issues/8531"
   default     = null
 }
+
+variable "cert_subject_alternative_names_count" {
+  type        = number
+  description = "The size of var.cert_subject_alternative_names. Since var.cert_subject_alternative_names can have dynamic keys/values we must hint terraform on its size."
+}

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -35,7 +35,7 @@ module "db" {
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.44.0 |
+| aws | >= 2.44.0, < 3.0.0 |
 
 ## Providers
 

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -34,7 +34,7 @@ module "db" {
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.44.0 |
+| aws | >= 2.44.0, < 3.0.0 |
 
 ## Providers
 

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -7,13 +7,13 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.44.0 |
+| aws | >= 2.44.0, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.44.0 |
+| aws | >= 2.44.0, < 3.0.0 |
 
 ## Inputs
 

--- a/aws-cloudfront-logs-bucket/README.md
+++ b/aws-cloudfront-logs-bucket/README.md
@@ -29,13 +29,15 @@ module "s3-bucket" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-cloudwatch-log-group/README.md
+++ b/aws-cloudwatch-log-group/README.md
@@ -7,13 +7,15 @@ By default the name is `${var.project}-${var.env}-${var.service}`, but you can o
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-default-vpc-security/README.md
+++ b/aws-default-vpc-security/README.md
@@ -38,13 +38,15 @@ You will need to invoke this module with a properly configured provider for ever
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -25,13 +25,15 @@ Since changing a service to use the new ARN requires destroying and recreating t
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ecs-job/README.md
+++ b/aws-ecs-job/README.md
@@ -26,13 +26,15 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -146,13 +146,15 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -138,13 +138,15 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-efs-volume/README.md
+++ b/aws-efs-volume/README.md
@@ -1,13 +1,15 @@
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-ecs-task-role/README.md
+++ b/aws-iam-ecs-task-role/README.md
@@ -23,13 +23,15 @@ output "ecs-role-arn" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-group-assume-role/README.md
+++ b/aws-iam-group-assume-role/README.md
@@ -26,13 +26,15 @@ output "group_name" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-group-console-login/README.md
+++ b/aws-iam-group-console-login/README.md
@@ -20,13 +20,15 @@ output "group_name" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -31,13 +31,15 @@ resource "aws_instance" "instance" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-password-policy/README.md
+++ b/aws-iam-password-policy/README.md
@@ -13,13 +13,15 @@ module "password-policy" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-policy-cwlogs/README.md
+++ b/aws-iam-policy-cwlogs/README.md
@@ -20,13 +20,15 @@ module "policy" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -22,13 +22,15 @@ output "..." {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -5,13 +5,15 @@ This module will create a role which is granted poweruser control over AWS Cloud
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -19,13 +19,15 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -21,13 +21,15 @@ module "ec2-poweruser" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -20,13 +20,15 @@ module "ec2-poweruser" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -5,13 +5,15 @@ Creates a role useful for running `terraform plan` in CI jobs.
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -19,13 +19,15 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -23,13 +23,15 @@ output "role_name" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -20,13 +20,15 @@ module "route53domains-poweruser" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -15,13 +15,15 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-iam-secrets-reader-policy/README.md
+++ b/aws-iam-secrets-reader-policy/README.md
@@ -19,13 +19,15 @@ module "policy" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-lambda-function/README.md
+++ b/aws-lambda-function/README.md
@@ -22,13 +22,15 @@ module lambda {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 
@@ -39,20 +41,23 @@ No requirements.
 | filename | n/a | `string` | `null` | no |
 | handler | Name of the lambda handler. | `string` | n/a | yes |
 | kms\_key\_arn | KMS key used to encrypt environment variables. | `string` | `null` | no |
+| log\_retention\_in\_days | n/a | `number` | `null` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| role\_arn | AWS IAM Role the lambda should use. | `string` | n/a | yes |
 | runtime | Lambda language runtime. | `string` | n/a | yes |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | source\_code\_hash | n/a | `string` | `null` | no |
 | source\_s3\_bucket | Bucket holding lambda source code. | `string` | `null` | no |
 | source\_s3\_key | Key identifying location of code. | `string` | `null` | no |
-| timeout | Execution timeout for the lambda. | `number` | n/a | yes |
+| timeout | Execution timeout for the lambda. | `number` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | arn | n/a |
+| invoke\_arn | n/a |
+| log\_group\_name | n/a |
+| role\_name | n/a |
 
 <!-- END -->

--- a/aws-param/README.md
+++ b/aws-param/README.md
@@ -28,13 +28,15 @@ output "secret" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-params-reader-policy/README.md
+++ b/aws-params-reader-policy/README.md
@@ -5,13 +5,15 @@ Creates a policy to access encrypted parameters in Parameter Store for a given s
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-params-secrets-setup/README.md
+++ b/aws-params-secrets-setup/README.md
@@ -8,13 +8,15 @@ Currently that just means creating an KMS key for encrypting the parameters stor
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-params-writer/README.md
+++ b/aws-params-writer/README.md
@@ -15,13 +15,15 @@ in the [Terraform docs](https://www.terraform.io/docs/state/sensitive-data.html)
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-redis-node/README.md
+++ b/aws-redis-node/README.md
@@ -6,13 +6,15 @@ parameters.
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -32,13 +32,15 @@ module "s3-bucket" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-single-page-static-site/README.md
+++ b/aws-single-page-static-site/README.md
@@ -40,13 +40,15 @@ module "site" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ssm-params-writer/README.md
+++ b/aws-ssm-params-writer/README.md
@@ -13,13 +13,15 @@ in the [Terraform docs](https://www.terraform.io/docs/state/sensitive-data.html)
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/aws-ssm-params/README.md
+++ b/aws-ssm-params/README.md
@@ -26,13 +26,15 @@ output "secret" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 

--- a/bless-ca/README.md
+++ b/bless-ca/README.md
@@ -96,13 +96,15 @@ You can read more about Bless and SSH certificates here:
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 | bless | n/a |
 | random | n/a |
 

--- a/github-webhooks-to-s3/README.md
+++ b/github-webhooks-to-s3/README.md
@@ -27,13 +27,15 @@ module "archiver" {
 <!-- START -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 3.0.0 |
 
 ## Inputs
 


### PR DESCRIPTION
### Summary
`var.cert_subject_alternative_names` is a map with potentially dynamic key/value pairs (eg: could be something derived from data sources. This gives us the `count cannot be computed` category of errors. 

Therefore we ask users to let us know explicitly the number of SANs for the certificate.

@ryanking @mbarrien maybe you have better ideas here than I do

### Test Plan
unittests

### References
NA