### PR TITLE
rename test.Options to test.Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To create a new module, copy the `module-template` directory and modify as you s
 A few notes on writing test for this repo. Note that this is new ground for us, so this will be a work in progress.
 
 * To make modules testable, all fields that have a unique constraint need to be parameterizeable. Otherwise concurrent tests will conflict.
-* It is tempting in testing module A to use module B to set up some context, but because terragrunt will just store the statefile locally, you can have a conflict.
+* It is tempting in testing module A to use module B to set up some context, but because terraform will just store the statefile locally, you can have a conflict.
   * We've tried to avoid this for now and set up context more directly
   * And also to not run tests in parrallel
   * and to clean up state files before and after each run
@@ -117,6 +117,7 @@ A few notes on writing test for this repo. Note that this is new ground for us, 
 * AWS IAM is eventually consistent and supposedly is homed in us-east-1, so its probably best to run all tests that use IAM in that region.
 
 #### Test Dependencies
+
 * [go](https://golang.org/doc/install)
 * [terraform](https://www.terraform.io/intro/getting-started/install.html)
 * [terraform-provider-bless](https://github.com/chanzuckerberg/terraform-provider-bless/releases) - Place it in the same directory as your terraform executable. `dirname \`which terraform\``

--- a/aws-acm-cert/module_test.go
+++ b/aws-acm-cert/module_test.go
@@ -19,7 +19,7 @@ func TestAWSACMCertDefaults(t *testing.T) {
 	t.Parallel()
 
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := testutil.UniqueId()

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -12,7 +12,7 @@ func TestAWSAuroraMysqlDefaults(t *testing.T) {
 
 	test := testutil.Test{
 
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := testutil.UniqueId()

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -22,7 +22,7 @@ func TestAWSAuroraPostgresDefaults(t *testing.T) {
 		v := version
 		t.Run(version, func(t *testing.T) {
 			test := testutil.Test{
-				Options: func(t *testing.T) *terraform.Options {
+				Setup: func(t *testing.T) *terraform.Options {
 					project := testutil.UniqueId()
 					env := testutil.UniqueId()
 					service := testutil.UniqueId()

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAWSAurora(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			return testutil.Options(
 				testutil.DefaultRegion,
 				map[string]interface{}{

--- a/aws-cloudfront-logs-bucket/module_test.go
+++ b/aws-cloudfront-logs-bucket/module_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPrivateBucketDefaults(t *testing.T) {
 	test := &testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := testutil.UniqueId()

--- a/aws-cloudwatch-log-group/module_test.go
+++ b/aws-cloudwatch-log-group/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSCloudWatchLogGroup(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			return testutil.Options(
 				testutil.DefaultRegion,
 				map[string]interface{}{

--- a/aws-default-vpc-security/module_test.go
+++ b/aws-default-vpc-security/module_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAWSDefaultVPCSecurity(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			return testutil.Options(
 				testutil.DefaultRegion,
 				map[string]interface{}{},

--- a/aws-efs-volume/module_test.go
+++ b/aws-efs-volume/module_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestEfsVolume(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := testutil.UniqueId()

--- a/aws-iam-group-console-login/module_test.go
+++ b/aws-iam-group-console-login/module_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAWSIAMGroupConsoleLogin(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			return testutil.Options(
 				testutil.IAMRegion,
 

--- a/aws-iam-instance-profile/module_test.go
+++ b/aws-iam-instance-profile/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMInstanceProfile(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			return testutil.Options(
 				testutil.IAMRegion,
 				map[string]interface{}{

--- a/aws-iam-role-bless/module_test.go
+++ b/aws-iam-role-bless/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestIAMRoleBless(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			region := testutil.IAMRegion
 			curAcct := testutil.AWSCurrentAccountId(t)
 

--- a/aws-iam-role-cloudfront-poweruser/module_test.go
+++ b/aws-iam-role-cloudfront-poweruser/module_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMRoleCrossAcct(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-ec2-poweruser/module_test.go
+++ b/aws-iam-role-ec2-poweruser/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-ecs-poweruser/module_test.go
+++ b/aws-iam-role-ecs-poweruser/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-infraci/module_test.go
+++ b/aws-iam-role-infraci/module_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAWSIAMRoleInfraCI(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-poweruser/module_test.go
+++ b/aws-iam-role-poweruser/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMRolePowerUser(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-readonly/module_test.go
+++ b/aws-iam-role-readonly/module_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAWSIAMRoleReadOnly(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-route53domains-poweruser/module_test.go
+++ b/aws-iam-role-route53domains-poweruser/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAWSIAMRoleRoute53DomainsPoweruser(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-role-security-audit/module_test.go
+++ b/aws-iam-role-security-audit/module_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAWSIAMRoleReadOnly(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := testutil.AWSCurrentAccountId(t)
 
 			return testutil.Options(

--- a/aws-iam-secrets-reader-policy/module_test.go
+++ b/aws-iam-secrets-reader-policy/module_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDefaults(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			// vars are all encoded in the test terraform files
 			opt := testutil.Options(
 				testutil.DefaultRegion,

--- a/aws-lambda-function/module_test.go
+++ b/aws-lambda-function/module_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestDefaults(t *testing.T) {
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			// vars are all encoded in the test terraform files
 			opt := testutil.Options(
 				testutil.DefaultRegion,

--- a/aws-redis-node/module_test.go
+++ b/aws-redis-node/module_test.go
@@ -13,7 +13,7 @@ import (
 func TestAWSRedisNode(t *testing.T) {
 	test := testutil.Test{
 
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			privateSubnets := testutil.ListEnvVar("PRIVATE_SUBNETS")
 			log.Printf("subnets %#v\n", privateSubnets)
 			log.Printf("subnets %#v\n", os.Getenv("PRIVATE_SUBNETS"))

--- a/aws-s3-private-bucket/module_test.go
+++ b/aws-s3-private-bucket/module_test.go
@@ -15,7 +15,7 @@ func TestPrivateBucketDefaults(t *testing.T) {
 	t.Parallel()
 
 	test := &testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := testutil.UniqueId()

--- a/bless-ca/test/module_test.go
+++ b/bless-ca/test/module_test.go
@@ -22,7 +22,7 @@ func TestBlessCAInitAndApply(t *testing.T) {
 	region := testutil.IAMRegion
 
 	test := testutil.Test{
-		Options: func(t *testing.T) *terraform.Options {
+		Setup: func(t *testing.T) *terraform.Options {
 			project := testutil.UniqueId()
 			env := testutil.UniqueId()
 			service := "bless" // other components in the name are random so keep this to identify

--- a/module-template/module_test.go
+++ b/module-template/module_test.go
@@ -10,7 +10,7 @@ import (
 func TestModule(t *testing.T) {
 	t.Skip("remove this for real tests")
 	test := testutil.Test{
-		Options:  func(t *testing.T) *terraform.Options { return nil },
+		Setup:    func(t *testing.T) *terraform.Options { return nil },
 		Validate: func(t *testing.T, options *terraform.Options) {},
 	}
 

--- a/testutil/test.go
+++ b/testutil/test.go
@@ -19,7 +19,7 @@ const (
 )
 
 type Test struct {
-	Options  func(*testing.T) *terraform.Options
+	Setup    func(*testing.T) *terraform.Options
 	Validate func(*testing.T, *terraform.Options)
 	Cleanup  func(*testing.T, *terraform.Options)
 
@@ -30,8 +30,8 @@ type Test struct {
 }
 
 func (tt *Test) validate() error {
-	if tt.Options == nil {
-		return errors.New("Options must be set")
+	if tt.Setup == nil {
+		return errors.New("Setup must be set")
 	}
 
 	if tt.Validate == nil {
@@ -113,7 +113,7 @@ func (tt *Test) Run(t *testing.T) {
 			t.Log("options file exists, skipping generation")
 			return
 		}
-		options := tt.Options(t)
+		options := tt.Setup(t)
 		test_structure.SaveTerraformOptions(t, terraformDirectory, options)
 	})
 


### PR DESCRIPTION
Rename to make the purpose of this test stage more clear - it is for
setting up test context. It still returns a terraform.Options (for use
in applying and validating code).

After some use, 'options' just felt like the wrong name.

### Test Plan
* CI

### References