### PR TITLE
[feature] make the type for the grant in s3  bucket as configurable

### DIFF
--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -14,16 +14,17 @@ module "s3-bucket" {
   service     = var.component
 
   # optional, defined when using grant ACL, if not defined, the bucket will use the `acl = private` as default
+  # canonical_user_id and uri in each grant should be specified exclusively
+  # Specify canonical_user_id when the type is Group
+  # Specify uri when the type is CanonicalUser
   grants = [
     {
       canonical_user_id : "canonical_user1_id"
       permissions : ["FULL_CONTROL"]
-
     },
     {
-      canonical_user_id : "canonical_user2_id"
+      uri : "uri_address_to_grant"
       permissions : ["WRITE"]
-
     }
   ]
 }
@@ -52,7 +53,7 @@ module "s3-bucket" {
 | cors\_rules | List of maps containing the cors rule configuration objects. | `any` | `[]` | no |
 | enable\_versioning | Keep old versions of overwritten S3 objects. | `bool` | `true` | no |
 | env | n/a | `string` | n/a | yes |
-| grants | A list of canonical user ID to permissions pairs. Used when we want to grant permissions to AWS accounts via the S3 ACL system. | `list(object({ canonical_user_id : string, permissions : list(string) }))` | `[]` | no |
+| grants | A list of objects containing the grant configuration, with `permissions` and either `canonical_user_id` or `uri`. Used when we want to grant permissions to AWS accounts via the S3 ACL system. | `any` | `[]` | no |
 | lifecycle\_rules | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br>  {<br>    "enabled": true,<br>    "expiration": {<br>      "expired_object_delete_marker": true<br>    },<br>    "noncurrent_version_expiration": {<br>      "days": 365<br>    },<br>    "noncurrent_version_transition": {<br>      "days": 30,<br>      "storage_class": "STANDARD_IA"<br>    }<br>  }<br>]</pre> | no |
 | owner | n/a | `string` | n/a | yes |
 | project | n/a | `string` | n/a | yes |

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -75,7 +75,7 @@ variable public_access_block {
 }
 
 variable grants {
-  type        = list(object({ canonical_user_id : string, permissions : list(string) }))
+  type        = any
   default     = []
-  description = "A list of canonical user ID to permissions pairs. Used when we want to grant permissions to AWS accounts via the S3 ACL system."
+  description = "A list of objects containing the grant configurations. Used when we want to grant permissions to AWS accounts via the S3 ACL system."
 }


### PR DESCRIPTION
### Summary
**Motivation:** 
I was importing an s3 bucket into Terraform ([PR](**https://github.com/FB-PLP/terraform-infra-management/pull/543**)) and found that they have a grant in which the type is `Group` there, so I updated this module to support the `Group` type in the grant. 

**Changes in this PR:** 
1. make the user be able to specify either `uri` or `canonical_user_id` with exclusive or relationship, if not exclusive or, then we treat them as invalid inputs
2. if specifying `uri`, then the grant type is `Group`, otherwise, the grant type is `CanonicalUser`

### Test Plan
1. Testing in [PR](**https://github.com/FB-PLP/terraform-infra-management/pull/543**), and importing the bucket worked
2. If we specify both `uri` or `canonical_user_id`, it doesn't create the grant, in this case, the user will then follow up to fix the error in the input 


### References
PR that used this commit: https://github.com/FB-PLP/terraform-infra-management/pull/543