### PR TITLE
[feature] configure cloudwatch-log-group retention policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         go-version: 1.14.3
     # we can stop this when we move to terraform 0.13 and drop support for 0.12
     - name: Install bless provider
-      run: curl -s https://raw.githubusercontent.com/chanzuckerberg/terraform-provider-bless/master/download.sh | bash -s -- -b $HOME/.terraform.d/plugins/ -d
+      run: curl -s https://raw.githubusercontent.com/chanzuckerberg/terraform-provider-bless/main/download.sh | bash -s -- -b $HOME/.terraform.d/plugins/ -d
     - name: Check bless provider
       run: ls -al $HOME/.terraform.d/plugins/terraform-provider-bless*
     - run: aws configure set aws_access_key_id ${{ secrets.CI1_AWS_ACCESS_KEY_ID }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: clean fmt docs lint test
 
 setup: ## setup development dependencies
 	curl -L https://raw.githubusercontent.com/chanzuckerberg/bff/main/download.sh | sh
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/terraform-provider-bless/master/download.sh | bash -s -- -b $(HOME)/.terraform.d/plugins -d
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/terraform-provider-bless/main/download.sh | bash -s -- -b $(HOME)/.terraform.d/plugins -d
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
 .PHONY: setup

--- a/aws-cloudwatch-log-group/README.md
+++ b/aws-cloudwatch-log-group/README.md
@@ -25,6 +25,7 @@ By default the name is `${var.project}-${var.env}-${var.service}`, but you can o
 | log\_group\_name | Name for the log group. If not set, it will be $project-$env-$service} | `string` | `""` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| retention\_in\_days | N of days you want to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. | `number` | `0` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-cloudwatch-log-group/main.tf
+++ b/aws-cloudwatch-log-group/main.tf
@@ -4,7 +4,8 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "group" {
-  name = local.log_group_name
+  name              = local.log_group_name
+  retention_in_days = var.retention_in_days
 
   tags = {
     Name      = local.name

--- a/aws-cloudwatch-log-group/variables.tf
+++ b/aws-cloudwatch-log-group/variables.tf
@@ -24,3 +24,9 @@ variable "log_group_name" {
 
   default = ""
 }
+
+variable "retention_in_days" {
+  type        = number
+  description = "N of days you want to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0."
+  default     = 0
+}


### PR DESCRIPTION
### Summary
This PR adds the `retention_in_days` parameter to `aws-cloudwatch-log-group` module. 

### Test Plan
Ran `make plan` against project project importing this module

### References
(Optional) Additional links to provide more context.