### PR TITLE
[fix] s3 bucket abort_incomplete_multipart_upload_days should be read from lifecycle

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -64,7 +64,7 @@ resource "aws_s3_bucket" "bucket" {
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)
-      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", 0)
 
       dynamic "expiration" {
         for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -70,7 +70,8 @@ resource "aws_s3_bucket" "bucket" {
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)
-      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", 0)
+      # var.abort_incomplete_multipart_upload_days is 14 by default
+      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", var.abort_incomplete_multipart_upload_days)
 
       dynamic "expiration" {
         for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -31,7 +31,7 @@ variable "enable_versioning" {
 
 variable "abort_incomplete_multipart_upload_days" {
   type        = number
-  description = "Number of days after which an incomplete multipart upload is canceled."
+  description = "Number of days after which an incomplete multipart upload is canceled. The value for this variable is set for all lifecycle rules, to specify the abort_incomplete_multipart_upload_days for each rule, you can specify it in the lifecycle_rules variable."
   default     = 14
 }
 
@@ -54,6 +54,8 @@ variable "lifecycle_rules" {
       noncurrent_version_expiration = {
         days = 365
       }
+      # if abort_incomplete_multipart_upload_days is not specified in the rule, it will use var.abort_incomplete_multipart_upload_days for general cases
+      abort_incomplete_multipart_upload_days = 7
     }
   ]
 }


### PR DESCRIPTION
### Summary

### Test Plan
Tested in LP's terraform repo (PR 553)

### References