### PR TITLE
[fix] add block for bucket policy to fix the not up to date behavior inthe bucket policy when import

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -41,8 +41,6 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  policy = data.aws_iam_policy_document.bucket_policy.json
-
   versioning {
     enabled = var.enable_versioning
   }
@@ -70,7 +68,8 @@ resource "aws_s3_bucket" "bucket" {
       prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
       tags                                   = lookup(lifecycle_rule.value, "tags", null)
       enabled                                = lookup(lifecycle_rule.value, "enabled", false)
-      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
+      # var.abort_incomplete_multipart_upload_days is 14 by default
+      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", var.abort_incomplete_multipart_upload_days)
 
       dynamic "expiration" {
         for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]
@@ -163,4 +162,9 @@ data "aws_iam_policy_document" "bucket_policy" {
       values   = ["false"]
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.bucket_policy.json
 }

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -31,7 +31,7 @@ variable "enable_versioning" {
 
 variable "abort_incomplete_multipart_upload_days" {
   type        = number
-  description = "Number of days after which an incomplete multipart upload is canceled."
+  description = "Number of days after which an incomplete multipart upload is canceled. The value for this variable is set for all lifecycle rules, to specify the abort_incomplete_multipart_upload_days for each rule, you can specify it in the lifecycle_rules variable."
   default     = 14
 }
 
@@ -54,6 +54,8 @@ variable "lifecycle_rules" {
       noncurrent_version_expiration = {
         days = 365
       }
+      # if abort_incomplete_multipart_upload_days is not specified in the rule, it will use var.abort_incomplete_multipart_upload_days for general cases
+      abort_incomplete_multipart_upload_days = 7
     }
   ]
 }


### PR DESCRIPTION
### Summary
the bucket policy when import: In the current  version, after I do an import the `module.aws-s3-private-bucket.aws_s3_bucket.bucket `  in FB-PLP/terraform-infra-management#553, it will show that 
```
# module.aws-s3-private-bucket.aws_s3_bucket.bucket will be updated in-place
  ~ resource "aws_s3_bucket" "bucket" {
      + acceleration_status         = "Suspended"
      + acl                         = "private"
        arn                         = "arn:aws:s3:::pdocs-private"
        bucket                      = "pdocs-private"
        bucket_domain_name          = "pdocs-private.s3.amazonaws.com"
        bucket_regional_domain_name = "pdocs-private.s3.amazonaws.com"
      + force_destroy               = false
        hosted_zone_id              = "Z3AQBSTGFYJSTF"
        id                          = "pdocs-private"
      + policy                      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:DeleteObject"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "s3.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::pdocs-private/*"
                      + Sid       = ""
                    },
                  + {
                      + Action    = "*"
                      + Condition = {
                          + Bool = {
                              + aws:SecureTransport = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = "*"
                      + Resource  = [
                          + "arn:aws:s3:::pdocs-private/*",
                          + "arn:aws:s3:::pdocs-private",
                        ]
                      + Sid       = "EnforceTLS"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
        region                      = "us-east-1"
        request_payer               = "BucketOwner"
      ~ tags                        = {
          + "env"       = "production"
          + "managedBy" = "terraform"
          + "owner"     = "lp-infra@chanzuckerberg.com"
          + "project"   = "dev-infra-project"
          + "service"   = "s3-pdocs-private"
        }

        cors_rule {
            allowed_headers = [
                "Authorization",
            ]
            allowed_methods = [
                "GET",
            ]
            allowed_origins = [
                "*",
            ]
            expose_headers  = []
            max_age_seconds = 3000
        }
        cors_rule {
            allowed_headers = [
                "*",
            ]
            allowed_methods = [
                "HEAD",
                "GET",
                "PUT",
                "POST",
            ]
            allowed_origins = [
                "*",
            ]
            expose_headers  = []
            max_age_seconds = 3000
        }

        lifecycle_rule {
            abort_incomplete_multipart_upload_days = 0
            enabled                                = true
            id                                     = "deletion_policy_old_versions_of_docs"
            tags                                   = {}

            expiration {
                days                         = 0
                expired_object_delete_marker = true
            }

            noncurrent_version_expiration {
                days = 180
            }
        }
        lifecycle_rule {
            abort_incomplete_multipart_upload_days = 7
            enabled                                = true
            id                                     = "deletion_policy_cache_expiration"
            prefix                                 = "regular_shrine/cache"
            tags                                   = {}

            expiration {
                days                         = 20
                expired_object_delete_marker = false
            }

            noncurrent_version_expiration {
                days = 1
            }
        }

        server_side_encryption_configuration {
            rule {
                apply_server_side_encryption_by_default {
                    sse_algorithm = "AES256"
                }
            }
        }

        versioning {
            enabled    = true
            mfa_delete = false
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

this indicates that the policy was not imported with the bucket, and if I accidentally have an error in the policy variable (eg. the `principals` here should be "*" instead of `type: service`, it will not know it or reflect it, so it would be necessary to import the policy as well. 

**Changes in this PR**: 
- add the `aws_s3_bucket_policy` following `aws_iam_policy_document` and remove the `policy` in the `aws_s3_bucket`

(Other changes are in https://github.com/chanzuckerberg/cztack/pull/233, I want to separate the PR for different changes, but want to facilitate my testing in FB-PLP/terraform-infra-management#553)


### Test Plan
Tested in FB-PLP/terraform-infra-management#553
- I can import the policy correctly,  it doesn't show the changes for adding policy as in the plan above
- if we have unsynced changes in the code with the  bucket policy, it will be detected in make plan


