### PR TITLE
[feature] add access advisor permissions to poweruser

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -98,6 +98,7 @@ data "aws_iam_policy_document" "misc" {
       "iam:GetPolicyVersion",
       "iam:GetRole",
       "iam:GetRolePolicy",
+      "iam:GetServiceLastAccessedDetails",
       "iam:ListAccessKeys",
       "iam:ListAccountAliases",
       "iam:ListAttachedGroupPolicies",


### PR DESCRIPTION
### Summary
Motivation: 
I am working on removing a number of unused IAM policies in the summitps AWS account.  It would be cool to have the permissions to use the access advisor to see how and when those policies were used. (also suggested by this [article](https://aws.amazon.com/blogs/security/remove-unnecessary-permissions-in-your-iam-policies-by-using-service-last-accessed-data/)). poweruser currently doesn’t have the `iam:GetServiceLastAccessedDetails` permissions (together with iam:generate-service-last-accessed-details, and both are for read permissions). 

See the thread link in slack in LP's terraform repo PR 573. (not linking here as it will be public) 


### Test Plan
See LP's terraform repo PR 573.