### PR TITLE
Allow lambda@edge in aws-lambda-function module

### DIFF
--- a/aws-lambda-function/README.md
+++ b/aws-lambda-function/README.md
@@ -36,6 +36,7 @@ module lambda {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| at\_edge | Is this lambda going to be used with a Cloufront distribution? If you set this, you will not have control over log retention, and you cannot include environment variables. | `bool` | `false` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | environment | Map of environment variables. | `map(string)` | `{}` | no |
 | filename | n/a | `string` | `null` | no |
@@ -63,6 +64,7 @@ module lambda {
 | function\_name | n/a |
 | invoke\_arn | n/a |
 | log\_group\_name | n/a |
+| qualified\_arn | If the lambda function is published, the qualified\_arn points at the latest version number. |
 | role\_id | n/a |
 | role\_name | n/a |
 

--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -40,26 +40,24 @@ resource aws_lambda_function lambda {
   tags = local.tags
 }
 
+data aws_iam_policy_document lambda_role_policy {
+  statement {
+    principals {
+      type = "Service"
+      identifiers = compact([
+        "lambda.amazonaws.com",
+        var.at_edge ? "edgelambda.amazonaws.com" : ""
+      ])
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
 
 resource aws_iam_role role {
   name = local.name
   path = var.lambda_role_path
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = data.aws_iam_policy_document.lambda_role_policy.json
 
   tags = local.tags
 }
@@ -72,36 +70,38 @@ resource aws_cloudwatch_log_group log {
 data aws_region current {}
 data aws_caller_identity current {}
 
+# TODO scope this policy down
+#
+# I would love to use "${aws_cloudwatch_log_group.log.arn}", as the
+# resource here, but the provider returns an ARN that looks like:
+#   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar:*
+# Unfortunately you need to use an ARN like:
+#   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar
+# to match operations on the log group(like creating a new stream.) So instead we construct one
+# without the colon before the *, so that we can match both log groups and log streams.
+data aws_iam_policy_document lambda_logging_policy {
+  statement {
+    effect = "Allow"
+    actions = compact([
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      var.at_edge ? "logs:CreateLogGroup" : ""
+    ])
+
+    resources = [
+      var.at_edge ?
+      "*" :
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.log.name}*",
+    ]
+  }
+}
+
 resource aws_iam_policy lambda_logging {
   name_prefix = "${local.name}-lambda-logging"
   path        = "/"
   description = "IAM policy for logging from the ${local.name} lambda."
 
-  # TODO scope this policy down
-  #
-  # I would love to use "${aws_cloudwatch_log_group.log.arn}", as the
-  # resource here, but the provider returns an ARN that looks like:
-  #   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar:*
-  # Unfortunately you need to use an ARN like:
-  #   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar
-  # to match operations on the log group(like creating a new stream.) So instead we construct one
-  # without the colon before the *, so that we can match both log groups and log streams.
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.log.name}*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-
+  policy = data.aws_iam_policy_document.lambda_logging_policy.json
 }
 
 resource aws_iam_role_policy_attachment lambda_logs {

--- a/aws-lambda-function/outputs.tf
+++ b/aws-lambda-function/outputs.tf
@@ -2,6 +2,11 @@ output arn {
   value = aws_lambda_function.lambda.arn
 }
 
+output qualified_arn {
+  description = "If the lambda function is published, the qualified_arn points at the latest version number."
+  value       = aws_lambda_function.lambda.qualified_arn
+}
+
 output invoke_arn {
   value = aws_lambda_function.lambda.invoke_arn
 }

--- a/aws-lambda-function/variables.tf
+++ b/aws-lambda-function/variables.tf
@@ -96,3 +96,9 @@ variable lambda_role_path {
   description = "The path to the IAM role for lambda."
   default     = null
 }
+
+variable at_edge {
+  type        = bool
+  description = "Is this lambda going to be used with a Cloufront distribution? If you set this, you will not have control over log retention, and you cannot include environment variables."
+  default     = false
+}


### PR DESCRIPTION
I want to use this module to create lambdas for cloudfront. That
requires supporting lambda@Edge. The two main changes here are:
1. Adding edgelambda as an authorized service for the role
2. granting permission create/update permission on * log groups.

The second is I suppose slightly controversial. because its an edge
lambda, we would have to precreate the log groups in every single aws
region, and I have no clue how to do that. I think this is an okay
tradeoff for now, and tried to document that in the description.

Test Plan:
wait for CI
use it in stacked TF and see if it works.