### PR TITLE
[feature] Grant poweruser the permissions to view IAM user details

### DIFF
--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -99,6 +99,8 @@ data "aws_iam_policy_document" "misc" {
       "iam:GetRole",
       "iam:GetRolePolicy",
       "iam:GetServiceLastAccessedDetails",
+      "iam:GetUser",
+      "iam:GetUserPolicy",
       "iam:ListAccessKeys",
       "iam:ListAccountAliases",
       "iam:ListAttachedGroupPolicies",


### PR DESCRIPTION
### Summary
This will enable to poweruser to see the details of the IAM user and their inline policy. 

We already have the ability for `iam:GetRole` and `iam:GetRolePolicy`, so I think the permissions for IAM user should be grated similarly. 
(This will also facilitate LP in importing some IAM users into TF.)

### Test Plan
To be tested in LP's repo. 

### References