### PR TITLE
[fix] aws-lambda-edge-security-headers: permanently dirty plan

### DIFF
--- a/aws-lambda-edge-add-security-headers/main.tf
+++ b/aws-lambda-edge-add-security-headers/main.tf
@@ -20,7 +20,7 @@ module lambda {
 
   function_name    = var.function_name != null ? var.function_name : replace("${var.project}-${var.env}-${var.service}-security-headers", ".", "-")
   filename         = data.archive_file.lambda.output_path
-  source_code_hash = data.archive_file.lambda.output_sha
+  source_code_hash = data.archive_file.lambda.output_base64sha256
   handler          = "index.handler"
   runtime          = "nodejs10.x"
   at_edge          = true


### PR DESCRIPTION
This was using the wrong hash function for the lambda source_code_hash.
THis means that every plan suggested a change, but no change actually
happened. The only problem was that the hash function was different, so
the comparison always had a difference.

Test Plan: plan is clean when using this ref