### PR TITLE
add tags specified by tftest

### DIFF
--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -19,5 +19,8 @@ module "client" {
   iam_path           = var.iam_path
   source_account_id  = var.source_account_id
   source_account_ids = var.source_account_ids
-  tags               = var.tags
+  env                = var.env
+  owner              = var.owner
+  service            = var.service
+  project            = var.project
 }

--- a/aws-iam-role-bless/module_test.go
+++ b/aws-iam-role-bless/module_test.go
@@ -14,15 +14,21 @@ func TestIAMRoleBless(t *testing.T) {
 			region := tftest.IAMRegion
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return &terraform.Options{
 				TerraformDir: ".",
 
 				Vars: map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 					"bless_lambda_arns": []string{"arn:aws:lambda:us-west-2:111111111111:function:test"},
 				},
 				EnvVars: map[string]string{

--- a/aws-iam-role-bless/variables.tf
+++ b/aws-iam-role-bless/variables.tf
@@ -25,8 +25,22 @@ variable "iam_path" {
   description = "IAM path"
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -43,7 +52,7 @@ data "aws_iam_policy_document" "assume-role" {
 resource "aws_iam_role" "role" {
   name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 data "aws_iam_policy_document" "s3" {

--- a/aws-iam-role-cloudfront-poweruser/module_test.go
+++ b/aws-iam-role-cloudfront-poweruser/module_test.go
@@ -14,6 +14,11 @@ func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 
@@ -21,9 +26,10 @@ func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 					"role_name":         random.UniqueId(),
 					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-cloudfront-poweruser/variables.tf
+++ b/aws-iam-role-cloudfront-poweruser/variables.tf
@@ -35,8 +35,22 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -64,7 +73,7 @@ resource "aws_iam_role" "role" {
   name                 = var.role_name
   path                 = var.iam_path
   assume_role_policy   = data.aws_iam_policy_document.assume-role.json
-  tags                 = var.tags
+  tags                 = local.tags
   max_session_duration = var.max_session_duration
 
   # We have to force detach policies in order to recreate roles.

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -13,15 +13,21 @@ func TestAWSIAMRoleCrossAcct(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -39,12 +39,25 @@ variable oidc {
   description = "A list of AWS OIDC IDPs to establish a trust relationship for this role."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }
 
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
 
 variable max_session_duration {
   type        = number

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -44,7 +53,7 @@ resource "aws_iam_role" "ecs-poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-fullaccess" {

--- a/aws-iam-role-ecs-poweruser/module_test.go
+++ b/aws-iam-role-ecs-poweruser/module_test.go
@@ -13,15 +13,21 @@ func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-ecs-poweruser/variables.tf
+++ b/aws-iam-role-ecs-poweruser/variables.tf
@@ -25,8 +25,22 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -44,7 +53,7 @@ resource "aws_iam_role" "infraci" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "infraci" {

--- a/aws-iam-role-infraci/module_test.go
+++ b/aws-iam-role-infraci/module_test.go
@@ -14,15 +14,21 @@ func TestAWSIAMRoleInfraCI(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
-					"iam_path": fmt.Sprintf("/%s/", random.UniqueId()),
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
+					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 				},
 			)
 		},

--- a/aws-iam-role-infraci/variables.tf
+++ b/aws-iam-role-infraci/variables.tf
@@ -30,8 +30,22 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -65,7 +74,7 @@ resource "aws_iam_role" "poweruser" {
   path                 = var.iam_path
   assume_role_policy   = data.aws_iam_policy_document.assume-role.json
   max_session_duration = var.max_session_duration
-  tags                 = var.tags
+  tags                 = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser" {

--- a/aws-iam-role-poweruser/module_test.go
+++ b/aws-iam-role-poweruser/module_test.go
@@ -13,14 +13,20 @@ func TestAWSIAMRolePowerUser(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -51,8 +51,22 @@ variable max_session_duration {
   description = "The maximum session duration (in seconds) for the role."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -64,7 +73,7 @@ resource "aws_iam_role" "readonly" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {

--- a/aws-iam-role-readonly/module_test.go
+++ b/aws-iam-role-readonly/module_test.go
@@ -14,6 +14,11 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 
@@ -21,9 +26,10 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
 					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-readonly/variables.tf
+++ b/aws-iam-role-readonly/variables.tf
@@ -44,8 +44,22 @@ variable authorize_read_secrets {
   default     = true
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -44,7 +53,7 @@ resource "aws_iam_role" "route53domains-poweruser" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "route53domains-fullaccess" {

--- a/aws-iam-role-route53domains-poweruser/module_test.go
+++ b/aws-iam-role-route53domains-poweruser/module_test.go
@@ -13,15 +13,21 @@ func TestAWSIAMRoleRoute53DomainsPoweruser(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
 				},
 			)
 		},

--- a/aws-iam-role-route53domains-poweruser/variables.tf
+++ b/aws-iam-role-route53domains-poweruser/variables.tf
@@ -26,8 +26,22 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -1,3 +1,12 @@
+locals {
+  tags = {
+    env     = var.env
+    owner   = var.owner
+    service = var.service
+    project = var.project
+  }
+}
+
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
     for_each = compact([var.source_account_id])
@@ -44,7 +53,7 @@ resource "aws_iam_role" "security-audit" {
   name               = var.role_name
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.assume-role.json
-  tags               = var.tags
+  tags               = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "security-audit" {

--- a/aws-iam-role-security-audit/module_test.go
+++ b/aws-iam-role-security-audit/module_test.go
@@ -14,15 +14,21 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 		Setup: func(t *testing.T) *terraform.Options {
 			curAcct := tftest.AWSCurrentAccountID(t)
 
+			project := tftest.UniqueID()
+			env := tftest.UniqueID()
+			service := tftest.UniqueID()
+			owner := tftest.UniqueID()
+
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
 					"role_name":         random.UniqueId(),
 					"source_account_id": curAcct,
-					"tags": map[string]string{
-						"test": random.UniqueId(),
-					},
-					"iam_path": fmt.Sprintf("/%s/", random.UniqueId()),
+					"project":           project,
+					"env":               env,
+					"service":           service,
+					"owner":             owner,
+					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
 				},
 			)
 		},

--- a/aws-iam-role-security-audit/variables.tf
+++ b/aws-iam-role-security-audit/variables.tf
@@ -27,8 +27,22 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
-variable tags {
-  type        = map(string)
-  default     = {}
-  description = "A map of tags to assign this IAM Role."
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }


### PR DESCRIPTION
### Summary
My previous PR was failing because https://github.com/chanzuckerberg/cztack/commit/209f50326c28c9fd05d1a5b5e1a6ac6acdead1fd brought in https://github.com/chanzuckerberg/go-misc/commit/d32d5af6473ec4b5f4e0ad01fea82066a5ff149f which enforces the env/owner/service/project tagging scheme over a `tags` variable. This fixes it for the other modules (it seems the test suite is only configured to run certain module tests when there are changes to those modules), which is why this didn't get picked up earlier. 

### Test Plan
I don't have permissions to run the full test suite, but `make test-ci TEST=./MODULE` seems to make it past the initial Terraform static checks. Let's see if CI tests fully pass. 

### References
(Optional) Additional links to provide more context.