### PR TITLE
aws-cloudwatch-logs-retention-manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           aws-cloudfront-domain-redirect,
           aws-cloudfront-logs-bucket,
           aws-cloudwatch-log-group,
+          aws-cloudwatch-log-retention-manager,
           aws-default-vpc-security,
           aws-ecs-job-fargate,
           aws-ecs-job,

--- a/aws-cloudwatch-log-retention-manager/README.md
+++ b/aws-cloudwatch-log-retention-manager/README.md
@@ -1,0 +1,43 @@
+# aws-cloudwatch-log-retention-manager
+
+This module schedules a lambda to do a daily scan through all cloudwatch logs groups, in all regions, and enforce a maximum retention policy. You can exempt individual log groups by setting the `ExemptFromMaxRetentionPolicy` tag to true.
+
+## Example
+
+```hcl
+module log-retention-manager {
+  source            = "github.com/chanzuckerberg/cztack/aws-cloudwatch-log-retention-manager
+  maximum_retention = 30
+}
+```
+
+<!-- START -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| archive | ~> 2.0 |
+| aws | < 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| archive | ~> 2.0 |
+| aws | < 3.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| env | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| maximum\_retention | The default days of retention to apply to untagged Cloudwatch Log Groups. | `number` | n/a | yes |
+| owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| service | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+
+## Outputs
+
+No output.
+
+<!-- END -->

--- a/aws-cloudwatch-log-retention-manager/main.tf
+++ b/aws-cloudwatch-log-retention-manager/main.tf
@@ -1,0 +1,117 @@
+locals {
+  tags = {
+    managedBy = "terraform"
+    env       = var.env
+    project   = var.project
+    service   = var.service
+    owner     = var.owner
+  }
+
+  lambda_name = "${var.project}-${var.env}-${var.service}-cloudwatch-retention"
+}
+
+data archive_file lambda {
+  type        = "zip"
+  output_path = "${path.module}/build/lambda.zip"
+  source {
+    filename = "function.rb"
+    content  = <<-EOF
+      require 'aws-sdk-ec2'
+      require 'aws-sdk-cloudwatchlogs'
+      MAXIMUM_RETENTION = ${var.maximum_retention}
+
+      def handler(event:, context:)
+        regions = Aws::EC2::Client.new.describe_regions.regions.map(&:region_name)
+        regions.each do |region|
+          puts "Processing Region: #{region}"
+          cloudwatch = Aws::CloudWatchLogs::Client.new(region: region)
+          cloudwatch.describe_log_groups.each do |log_group_batch|
+            log_group_batch.log_groups.each do |log_group|
+              name = log_group.log_group_name
+              retention = log_group.retention_in_days
+
+              print "Region: #{region}, LogGroup: #{name}, Retention: #{retention || 'None'}, "
+
+              # If retention is set, and less than the required maximum, skip.
+              if retention && retention <= MAXIMUM_RETENTION
+                print "Result: Compliant\n"
+                next
+              end
+
+              # Specific log groups may be exempt from the maximum retention policy.
+              tags = cloudwatch.list_tags_log_group(log_group_name: log_group.log_group_name).tags
+              exempt = tags["ExemptFromMaxRetentionPolicy"] == "true"
+              if exempt
+                print "Result: Exempt\n"
+                next
+              end
+
+              # Add or replace existing retention to match policy.
+              cloudwatch.put_retention_policy(
+                log_group_name: log_group.log_group_name,
+                retention_in_days: DEFAUT_MAX_RETENTION
+              )
+              print "Result: Fixed\n"
+            end
+          end
+        end
+      end
+    EOF
+  }
+}
+
+module lambda {
+  source = "../aws-lambda-function"
+
+  function_name    = local.lambda_name
+  filename         = data.archive_file.lambda.output_path
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+  handler          = "function.handler"
+  runtime          = "ruby2.7"
+
+  timeout               = 300
+  log_retention_in_days = var.maximum_retention
+
+  env     = var.env
+  owner   = var.owner
+  project = var.project
+  service = var.service
+}
+
+resource aws_cloudwatch_event_rule trigger {
+  name                = "${var.project}-${var.env}-${var.service}-retention-trigger"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource aws_cloudwatch_event_target trigger {
+  rule = aws_cloudwatch_event_rule.trigger.id
+  arn  = module.lambda.arn
+}
+
+resource aws_lambda_permission permission {
+  statement_id  = "AllowScheduledLambdaExecution"
+  action        = "lambda:InvokeFunction"
+  function_name = local.lambda_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.trigger.arn
+}
+
+data aws_iam_policy_document policy {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeRegions",
+      "logs:DescribeLogGroups",
+      "logs:ListTagsLogGroup",
+      "logs:PutRetentionPolicy",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource aws_iam_role_policy policy {
+  name   = "allow-managing-log-groups"
+  role   = module.lambda.role_id
+  policy = data.aws_iam_policy_document.policy.json
+}

--- a/aws-cloudwatch-log-retention-manager/module_test.go
+++ b/aws-cloudwatch-log-retention-manager/module_test.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/chanzuckerberg/go-misc/tftest"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestModule(t *testing.T) {
+	test := tftest.Test{
+		// just run init, swtich to Plan or Apply when you can
+		Mode: tftest.Init,
+
+		Setup: func(t *testing.T) *terraform.Options {
+			return tftest.Options(
+				tftest.DefaultRegion,
+				map[string]interface{}{
+					"project": tftest.UniqueID(),
+					"env":     tftest.UniqueID(),
+					"service": tftest.UniqueID(),
+					"owner":   tftest.UniqueID(),
+
+					"function_name": tftest.UniqueID(),
+				},
+			)
+		},
+		Validate: func(t *testing.T, options *terraform.Options) {},
+	}
+
+	test.Run(t)
+}

--- a/aws-cloudwatch-log-retention-manager/terraform.tf
+++ b/aws-cloudwatch-log-retention-manager/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws     = "< 3.0.0"
+    archive = "~> 2.0"
+  }
+}

--- a/aws-cloudwatch-log-retention-manager/variables.tf
+++ b/aws-cloudwatch-log-retention-manager/variables.tf
@@ -1,0 +1,24 @@
+variable project {
+  type        = string
+  description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable env {
+  type        = string
+  description = "Env for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable service {
+  type        = string
+  description = "Service for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable owner {
+  type        = string
+  description = "Owner for tagging and naming. See [doc](../README.md#consistent-tagging)"
+}
+
+variable maximum_retention {
+  type        = number
+  description = "The default days of retention to apply to untagged Cloudwatch Log Groups."
+}


### PR DESCRIPTION
Create a scheduled lambda function to iterate through all Cloudwatch Log
Groups and enforce a maximum retention. This is particularly useful for
deletion efforts on the Education team, because Lambda@Edge functions
(amongst others) can log PII, but have no way to control retention via
Terraform.

It's a good question whether we want this to be:
- Opt-out: Applies to all log groups unless specified otherwise.
- Opt-in: Only applies to specific prefixes.

I think there's probably not much downside in the opt-out approach. It's
the safest in terms of deletion requirements, and its rare for us to have logs
that we would consider "permanent", since any of them could potentially
contain PII.

Test Plan: Dry runs in the console with the `put_retention_policy`
commented out.