### PR TITLE
restrict codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ryanking @edulo91
+* @ryanking @edulop91

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chanzuckerberg/czi-shared-infra
+* @ryanking @edulo91


### PR DESCRIPTION
As part of our efforts to improve testing and consistency across the
cztack modules, code owners is going to be restricted to a smaller
group.