### PR TITLE
Run log retention lambda every 12 hours.

### DIFF
--- a/aws-cloudwatch-log-retention-manager/main.tf
+++ b/aws-cloudwatch-log-retention-manager/main.tf
@@ -80,7 +80,7 @@ module lambda {
 
 resource aws_cloudwatch_event_rule trigger {
   name                = "${var.project}-${var.env}-${var.service}-retention-trigger"
-  schedule_expression = "rate(5 minutes)"
+  schedule_expression = "rate(12 hours)"
   tags                = local.tags
 }
 


### PR DESCRIPTION
Oops, I forgot to change the rate back to a reasonable timer after
testing. This definitely doesn't need to run every 5 minutes, even every
12 hours is probably too much, but I'd rather it run frequently so we
might find the failures sooner too.

Test Plan: inspection