### PR TITLE
Upgrade Snowflake modules to TF 0.13

### DIFF
--- a/scripts/snowflake_generate_grant_all/main.go
+++ b/scripts/snowflake_generate_grant_all/main.go
@@ -26,7 +26,7 @@ const (
 	perPrivTypeVarName string = "per_privilege_grants"
 
 	// TODO(el): grab this version directly from the provider
-	snowflakeProviderVersion string = "> 0.18.0"
+	snowflakeProviderVersion string = "0.19.0"
 )
 
 type Variable struct {
@@ -44,14 +44,13 @@ type ModuleTemplate struct {
 	Resources map[string]map[string]map[string]interface{} `json:"resource,omitempty"`
 
 	// required_providers: provider_name: version
-	Terraform map[string]map[string]string `json:"terraform,omitempty"`
+	Terraform map[string]map[string]map[string]string `json:"terraform,omitempty"`
 }
 
 func main() {
 	err := exec()
 	if err != nil {
 		logrus.Fatal(err)
-		return
 	}
 }
 
@@ -117,9 +116,12 @@ func generateModule(name string, grant *resources.TerraformGrantResource) ([]byt
 		Locals: map[string]interface{}{
 			"privileges": privileges,
 		},
-		Terraform: map[string]map[string]string{
+		Terraform: map[string]map[string]map[string]string{
 			"required_providers": {
-				"snowflake": snowflakeProviderVersion,
+				"snowflake": map[string]string{
+					"source":  "chanzuckerberg/snowflake",
+					"version": snowflakeProviderVersion,
+				},
 			},
 		},
 	}

--- a/snowflake-account-grant-all/main.tf.json
+++ b/snowflake-account-grant-all/main.tf.json
@@ -42,7 +42,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-database-grant-all/main.tf.json
+++ b/snowflake-database-grant-all/main.tf.json
@@ -52,7 +52,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-integration-grant-all/main.tf.json
+++ b/snowflake-integration-grant-all/main.tf.json
@@ -41,7 +41,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-resource-monitor-grant-all/main.tf.json
+++ b/snowflake-resource-monitor-grant-all/main.tf.json
@@ -41,7 +41,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-schema-grant-all/main.tf.json
+++ b/snowflake-schema-grant-all/main.tf.json
@@ -75,7 +75,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-stage-grant-all/main.tf.json
+++ b/snowflake-stage-grant-all/main.tf.json
@@ -61,7 +61,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-table-grant-all/main.tf.json
+++ b/snowflake-table-grant-all/main.tf.json
@@ -69,7 +69,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-view-grant-all/main.tf.json
+++ b/snowflake-view-grant-all/main.tf.json
@@ -64,7 +64,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }

--- a/snowflake-warehouse-grant-all/main.tf.json
+++ b/snowflake-warehouse-grant-all/main.tf.json
@@ -44,7 +44,10 @@
   },
   "terraform": {
     "required_providers": {
-      "snowflake": "\u003e 0.18.0"
+      "snowflake": {
+        "source": "chanzuckerberg/snowflake",
+        "version": "0.19.0"
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary
Moving the Snowflake grant ALL modules to TF 0.13 syntax.
See "Use Provider" at the top right of https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest

### Test Plan


### References