### PR TITLE
Fix typo in aws-cloudwatch-log-retention-manager

### DIFF
--- a/aws-cloudwatch-log-retention-manager/main.tf
+++ b/aws-cloudwatch-log-retention-manager/main.tf
@@ -49,7 +49,7 @@ data archive_file lambda {
               # Add or replace existing retention to match policy.
               cloudwatch.put_retention_policy(
                 log_group_name: log_group.log_group_name,
-                retention_in_days: DEFAUT_MAX_RETENTION
+                retention_in_days: MAXIMUM_RETENTION
               )
               print "Result: Fixed\n"
             end


### PR DESCRIPTION
Another typo. This has not been my best work.

Test Plan:
put up PR
use commit hash as ref to apply module in terraform
manually run lambda from aws console
see that there are no syntax or runtime errors