### PR TITLE
Update assume_role_policy in aws_iam_role

### DIFF
--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -51,6 +51,7 @@ module iam-role {
 | project | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | role\_description | IAM role description. | `string` | `null` | no |
 | role\_name | IAM role name. | `string` | n/a | yes |
+| saml\_idp\_arn | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | service | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-iam-role/main.tf
+++ b/aws-iam-role/main.tf
@@ -19,6 +19,24 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
     actions = ["sts:AssumeRole"]
   }
+
+  dynamic statement {
+    for_each = compact([var.saml_idp_arn])
+    content {
+      principals {
+        type        = "Federated"
+        identifiers = [statement.value]
+      }
+
+      actions = ["sts:AssumeRoleWithSAML"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "SAML:aud"
+        values   = ["https://signin.aws.amazon.com/saml"]
+      }
+    }
+  }
 }
 
 resource "aws_iam_role" "role" {

--- a/aws-iam-role/variables.tf
+++ b/aws-iam-role/variables.tf
@@ -29,6 +29,12 @@ variable principals {
   description = "AWS IAM Principals which will be able to assume this role."
 }
 
+variable saml_idp_arn {
+  type        = string
+  default     = ""
+  description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
+}
+
 variable role_name {
   type        = string
   description = "IAM role name."


### PR DESCRIPTION
### Summary
This adds a dynamic statement to the `aws_iam_role` module's `assume_role_policy`, allowing the role to `sts:AssumeRoleWithSAML`. 

### Test Plan
This is used in https://github.com/FB-PLP/terraform-infra-management/pull/900 (its TF plan can be found [here](https://si.prod.tfe.czi.technology/app/lp-infra/accounts-summitps/runs/run-CT4Efqe37bAXbNK5))

### References
(Optional) Additional links to provide more context.