### PR TITLE
[breaking] Replace attached_policies_arns in aws_iam_role with map

### DIFF
--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -42,7 +42,7 @@ module iam-role {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| attached\_policies\_arns | List of policies ARNs to be attached to the IAM role. | `list(string)` | `[]` | no |
+| attached\_policies\_names\_arns | Map of policy names to the respective ARNs to be attached to the IAM role. | `map(string)` | `{}` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | iam\_path | The IAM path under which the IAM role will be created. | `string` | `null` | no |
 | inline\_policies | List of inline policies to be associated with the IAM role. | `list(object({ name = string, policy = string }))` | `[]` | no |

--- a/aws-iam-role/main.tf
+++ b/aws-iam-role/main.tf
@@ -56,7 +56,7 @@ resource "aws_iam_role_policy" "policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "policy_attachment" {
-  for_each   = toset(var.attached_policies_arns)
+  for_each   = var.attached_policies_names_arns
   role       = aws_iam_role.role.id
   policy_arn = each.value
 }

--- a/aws-iam-role/main.tf
+++ b/aws-iam-role/main.tf
@@ -1,8 +1,4 @@
 locals {
-  # Slight hack so Terraform can get the size statically during the plan. 
-  # Simply passing the list to `for_each` throws an Invalid for_each argument
-  attached_policies_names_arns = zipmap(var.attached_policies_arns, var.attached_policies_arns)
-
   tags = {
     project   = var.project
     env       = var.env
@@ -60,7 +56,7 @@ resource "aws_iam_role_policy" "policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "policy_attachment" {
-  for_each   = local.attached_policies_names_arns
+  for_each   = toset(var.attached_policies_arns)
   role       = aws_iam_role.role.id
   policy_arn = each.value
 }

--- a/aws-iam-role/variables.tf
+++ b/aws-iam-role/variables.tf
@@ -52,8 +52,8 @@ variable inline_policies {
   default     = []
 }
 
-variable attached_policies_arns {
-  type        = list(string)
-  description = "List of policies ARNs to be attached to the IAM role."
-  default     = []
+variable attached_policies_names_arns {
+  type        = map(string)
+  description = "Map of policy names to the respective ARNs to be attached to the IAM role."
+  default     = {}
 }


### PR DESCRIPTION
## Summary
This is a resubmission of https://github.com/chanzuckerberg/cztack/pull/274. I tried to incorporate some feedback about making it backwards compatible, but that didn't work. I didn't notice that my TF plan completed unsuccessfully, hence me merging a bit too early. This PR reverts that and submits the change as we discussed. 

Sorry for the extra review request! 


#### Original Summary:
In situations where you were appending new resources to attached_policies_arns that didn't exist yet, Terraform would throw the following error:
```
Error: Invalid for_each argument

  on .terraform/modules/aws-role-devserver-restart/aws-iam-role/main.tf line 41, in resource "aws_iam_role_policy_attachment" "policy_attachment":
  41:   for_each   = toset(var.attached_policies_arns)

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.
```
This PR replaces the list with a map so that Terraform can get the size statically during the plan.


### Test Plan
Tested in the original PR

### References
(Optional) Additional links to provide more context.