### PR TITLE
[feature] aws-s3-public-bucket require https, allow disabling versioning

### DIFF
--- a/aws-s3-public-bucket/main.tf
+++ b/aws-s3-public-bucket/main.tf
@@ -37,22 +37,25 @@ data "aws_iam_policy_document" "bucket_policy" {
   # Deny access to bucket if it's not accessed through HTTPS
   source_json = var.bucket_policy
 
-  statement {
-    sid       = "EnforceTLS"
-    actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+  dynamic statement {
+    for_each = var.require_tls ? ["enabled"] : []
+    content {
+      sid       = "EnforceTLS"
+      actions   = ["s3:GetObject"]
+      resources = ["arn:aws:s3:::${local.bucket_name}/*"]
 
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
 
-    effect = "Deny"
+      effect = "Deny"
 
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
+      condition {
+        test     = "Bool"
+        variable = "aws:SecureTransport"
+        values   = ["false"]
+      }
     }
   }
 

--- a/aws-s3-public-bucket/main.tf
+++ b/aws-s3-public-bucket/main.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "bucket" {
   policy = data.aws_iam_policy_document.bucket_policy.json
 
   versioning {
-    enabled = true
+    enabled = var.enable_versioning
   }
 
   server_side_encryption_configuration {
@@ -36,6 +36,25 @@ resource "aws_s3_bucket" "bucket" {
 data "aws_iam_policy_document" "bucket_policy" {
   # Deny access to bucket if it's not accessed through HTTPS
   source_json = var.bucket_policy
+
+  statement {
+    sid       = "EnforceTLS"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    effect = "Deny"
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 
   statement {
     sid       = "AllowPublicRead"

--- a/aws-s3-public-bucket/variables.tf
+++ b/aws-s3-public-bucket/variables.tf
@@ -50,3 +50,9 @@ variable "enable_versioning" {
   description = "Keep old versions of objects in this bucket."
   default     = true
 }
+
+variable "require_tls" {
+  type        = bool
+  description = "Require TLS to read objects from this bucket."
+  default     = true
+}

--- a/aws-s3-public-bucket/variables.tf
+++ b/aws-s3-public-bucket/variables.tf
@@ -44,3 +44,9 @@ variable "public_read_justification" {
   type        = string
   description = "Describe why this bucket must be public and what it is being used for."
 }
+
+variable "enable_versioning" {
+  type        = bool
+  description = "Keep old versions of objects in this bucket."
+  default     = true
+}


### PR DESCRIPTION
### Summary
Adds functionality from CZI's private version of this module.

* Add ability to disable versioning by default on public S3 buckets.
  Leaves default behavior of enabling versioning intact
* Optionally require TLS for every get object. Default to true.