### PR TITLE
[fix] s3-private-bucket more lenient aws provider version

### DIFF
--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -35,13 +35,13 @@ module "s3-bucket" {
 
 | Name | Version |
 |------|---------|
-| aws | < 3.0.0 |
+| aws | >= 2.60.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | < 3.0.0 |
+| aws | >= 2.60.0 |
 
 ## Inputs
 

--- a/aws-s3-private-bucket/terraform.tf
+++ b/aws-s3-private-bucket/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    aws = "< 3.0.0"
+    aws = ">= 2.60.0"
   }
 }


### PR DESCRIPTION
### Summary
Adding more flexibility to provider versions for s3 private bucket module. https://aws.amazon.com/fr/about-aws/whats-new/2021/02/amazon-s3-now-supports-aws-privatelink/ caused a breaking change in https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/571 which triggered an upgrade to aws provider 3.X as the only viable upgrade path.

I am not sure >=2.60.0 is the "right" choice here but it seemed "reasonable enough"

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.