### PR TITLE
[feature] Add CIDR blocks based security group to Redis

### DIFF
--- a/aws-redis-node/README.md
+++ b/aws-redis-node/README.md
@@ -25,6 +25,7 @@ parameters.
 | engine\_version | The version of Redis to run. See [supported versions](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) | `string` | `"5.0.5"` | no |
 | env | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | ingress\_security\_group\_ids | Source security groups which should be able to contact this instance. | `list(string)` | n/a | yes |
+| ingress\_security\_group\_cidr_blocks | CIDR blocks which should be able to contact this instance. | `list(string)` | [] | no |
 | instance\_type | The type of instance to run. See [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) | `string` | `"cache.m5.large"` | no |
 | owner | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | parameter\_group\_name | Parameter group to use for this Redis cache. | `string` | `"default.redis5.0"` | no |

--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -29,6 +29,16 @@ module "sg" {
     }
   ]
 
+  ingress_with_cidr_blocks = [
+    for cidr_block in var.ingress_security_group_cidr : {
+      from_port   = var.port
+      to_port     = var.port
+      protocol    = "tcp"
+      description = "Redis port"
+      cidr_blocks = cidr_block
+    }
+  ]
+
   egress_rules = ["all-all"]
 }
 

--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -30,7 +30,7 @@ module "sg" {
   ]
 
   ingress_with_cidr_blocks = [
-    for cidr_block in var.ingress_security_group_cidr : {
+    for cidr_block in var.ingress_security_group_cidr_blocks : {
       from_port   = var.port
       to_port     = var.port
       protocol    = "tcp"

--- a/aws-redis-node/variables.tf
+++ b/aws-redis-node/variables.tf
@@ -35,6 +35,12 @@ variable "ingress_security_group_ids" {
   description = "Source security groups which should be able to contact this instance."
 }
 
+variable "ingress_security_group_cidr_blocks" {
+  type        = list(string)
+  description = "Source CIDR blocks which should be able to contact this instance."
+  default     = []
+}
+
 variable "port" {
   type        = number
   description = "Port to host Redis on."


### PR DESCRIPTION
### Summary
Allows CIDR-based security group to Redis, in addition to source based security groups. The new variable is marked as optional, so this shouldn't be a breaking PR.

### Test Plan
The current unit test for this module doesn't seem to test anything (the Validate step is empty?), but I am happy to expand it. I might need some guidance though.