### PR TITLE
Initial updates for supporting s3 bucket logging targets.

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -110,11 +110,13 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  # TODO
-  #   logging {
-  #   target_bucket = ""
-  #   target_prefix = ""
-  # }
+  dynamic "logging" {
+    for_each = var.logging_bucket == null ? [] : [var.logging_bucket]
+    content {
+      target_bucket = var.logging_bucket.name
+      target_prefix = var.logging_bucket.prefix
+    }
+  }
 
   server_side_encryption_configuration {
     rule {

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -71,8 +71,8 @@ variable "transfer_acceleration" {
   default = false
 }
 
-variable logging_bucket {
-  type        = object({name = string, prefix = string})
+variable "logging_bucket" {
+  type        = object({ name = string, prefix = string })
   description = "Log bucket name and prefix to enable logs for this bucket"
   default     = null
 }

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -71,6 +71,12 @@ variable transfer_acceleration {
   default = false
 }
 
+variable logging_bucket {
+  type        = object({name = string, prefix = string})
+  description = "Log bucket name and prefix to enable logs for this bucket"
+  default     = null
+}
+
 variable public_access_block {
   type    = bool
   default = true


### PR DESCRIPTION
### Summary
Add support for logging S3 access to another bucket or prefix to the private bucket module.

### Test Plan
I generated a tf file that created two buckets (a content bucket, and a logging bucket) and set the logging config of one bucket to refer to the other. The logging config in the plan had logging enabled for the content bucket and disabled for the logging bucket.

Tests pass.

### References
(Optional) Additional links to provide more context.
