### PR TITLE
Auto merge main branch on update for branches with auto-merge enabled

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,18 @@
+name: Auto-update
+# Auto-update only listens to `push` events.
+# If a pull request is already outdated when enabling auto-merge, manually click on the "Update branch" button a first time to avoid having to wait for another commit to land on the base branch for the pull request to be updated.
+# on: push
+# If pull requests are always based on the same branches, only triggering the workflow when these branches receive new commits will minimize the workflow execution.
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Auto:
+    name: Auto-update
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: tibdex/auto-update@v2.1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds auto-updating of PR branches with the content of the base branch, if the PR branch is marked for auto-merge in Github.

I have examined the Typescript code in https://github.com/tibdex/auto-update/blob/main/src/index.ts for security but have not examined the Javascript that it compiles into, and I have also examined the Github Action that they use to release new Github Actions versions. This PR specifically locks the branch to tag v2.1.2 rather than v2; the underlying release process reassigns the vX and vX.Y tag on minor and patch releases, and this hopefully minimizes (although does not eliminate) the possibility of malicious code being introduce into the action.

Note that we have set up the action to only trigger on pushes to `main` branch; if a PR has a base branch that is not `main`, the action is not triggered automatically. However, the next time main is pushed to, it will run on all branches, including branches where main is not the target.

In the case of merge conflicts, the action will add a comment to the PR and not merge, which should hopefully notify the PR author to take action.

This is intended to be a replacement for the use of CZI's auto-merge bot; the combination of this Github Action and Github auto-merge should fully replace the need for the bot.