### PR TITLE
[feature] aws-s3-private-bucket add canned acl variable

### DIFF
--- a/aws-s3-account-public-access-block/main.tf
+++ b/aws-s3-account-public-access-block/main.tf
@@ -5,8 +5,8 @@ locals {
 
 
   # These only affect new acls and policies by rejecting requests that contain them
-  block_public_acls   = !local.is_none # all or new
-  block_public_policy = !local.is_none # all or new
+  block_public_acls   = ! local.is_none # all or new
+  block_public_policy = ! local.is_none # all or new
 
   # These affect existing buckets, policies, and acls
   ignore_public_acls      = local.is_all

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -2,13 +2,13 @@ locals {
   # If grants are defined, we use `grant` to grant permissions, otherwise it will use the `acl` to grant permissions
   acl = length(var.grants) == 0 ? "private" : null
 
-  # `canonical_user_id` and `uri` shuold be specified exclusively in each grant, so we skip the invalid inputs in grants
+  # `canonical_user_id` and `uri` should be specified exclusively in each grant, so we skip the invalid inputs in grants
   # invalid input is the case that they are both or neither specified
   valid_grants = [for grant in var.grants : {
     canonical_user_id = lookup(grant, "canonical_user_id", null)
     uri               = lookup(grant, "uri", null)
     permissions       = grant.permissions
-    } if !(
+    } if ! (
     (lookup(grant, "canonical_user_id", null) != null && lookup(grant, "uri", null) != null) ||
     (lookup(grant, "canonical_user_id", null) == null && lookup(grant, "uri", null) == null)
     )

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -1,6 +1,6 @@
 locals {
   # If grants are defined, we use `grant` to grant permissions, otherwise it will use the `acl` to grant permissions
-  acl = length(var.grants) == 0 ? "private" : null
+  acl = length(var.grants) == 0 ? var.acl : null
 
   # `canonical_user_id` and `uri` should be specified exclusively in each grant, so we skip the invalid inputs in grants
   # invalid input is the case that they are both or neither specified

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -87,3 +87,9 @@ variable "grants" {
   default     = []
   description = "A list of objects containing the grant configurations. Used when we want to grant permissions to AWS accounts via the S3 ACL system."
 }
+
+variable "acl" {
+  type        = string
+  default     = "private"
+  description = "Canned ACL to use if grants object is not given. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl"
+}


### PR DESCRIPTION
Adds support for passing in a canned acl variable. Defaults to "private"
for backwards compatibility. Canned acl variable is ignored if grants
argument is passed.

While here, fix lint issues and typos.