### PR TITLE
remove vestiges of interpolation syntax that was deprecated in TF v0.12+

### DIFF
--- a/aws-acm-cert/main.tf
+++ b/aws-acm-cert/main.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "cert_validation" {
   name    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
   type    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
   zone_id = lookup(var.cert_subject_alternative_names, lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "domain_name"), var.aws_route53_zone_id)
-  records = ["${lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")}"]
+  records = [lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")]
   ttl     = var.validation_record_ttl
 
   allow_overwrite = var.allow_validation_record_overwrite

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -54,13 +54,13 @@ resource "aws_rds_cluster" "db" {
   database_name                       = var.database_name
   master_username                     = var.database_username
   master_password                     = var.database_password
-  vpc_security_group_ids              = ["${aws_security_group.rds.id}"]
+  vpc_security_group_ids              = [aws_security_group.rds.id]
   db_subnet_group_name                = var.database_subnet_group
   storage_encrypted                   = true
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   backup_retention_period             = 28
-  final_snapshot_identifier           = "${local.name}-snapshot"
-  skip_final_snapshot                 = var.skip_final_snapshot
+  final_snapshot_identifier             = "${local.name}-snapshot"
+  skip_final_snapshot                  = var.skip_final_snapshot
   backtrack_window                    = var.backtrack_window
   kms_key_id                          = var.kms_key_id
   port                                = var.port

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -59,8 +59,8 @@ resource "aws_rds_cluster" "db" {
   storage_encrypted                   = true
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   backup_retention_period             = 28
-  final_snapshot_identifier             = "${local.name}-snapshot"
-  skip_final_snapshot                  = var.skip_final_snapshot
+  final_snapshot_identifier           = "${local.name}-snapshot"
+  skip_final_snapshot                 = var.skip_final_snapshot
   backtrack_window                    = var.backtrack_window
   kms_key_id                          = var.kms_key_id
   port                                = var.port

--- a/aws-default-vpc-security/main.tf
+++ b/aws-default-vpc-security/main.tf
@@ -20,7 +20,7 @@ resource "aws_default_vpc" "default" {
 data "aws_internet_gateway" "default" {
   filter {
     name   = "attachment.vpc-id"
-    values = ["${aws_default_vpc.default.id}"]
+    values = [aws_default_vpc.default.id]
   }
 }
 

--- a/aws-iam-policy-cwlogs/main.tf
+++ b/aws-iam-policy-cwlogs/main.tf
@@ -20,6 +20,6 @@ resource "aws_iam_policy" "logs-policy" {
 
 resource "aws_iam_policy_attachment" "attach-logs" {
   name       = "logs-attachment"
-  roles      = ["${var.role_name}"]
+  roles      = [var.role_name]
   policy_arn = aws_iam_policy.logs-policy.arn
 }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "policy" {
 
   statement {
     actions   = ["kms:Decrypt"]
-    resources = ["${data.aws_kms_alias.parameter_store_key.target_key_arn}"]
+    resources = [data.aws_kms_alias.parameter_store_key.target_key_arn]
   }
 }
 

--- a/aws-single-page-static-site/main.tf
+++ b/aws-single-page-static-site/main.tf
@@ -12,7 +12,7 @@ locals {
   bucket_name  = var.bucket_name != "" ? var.bucket_name : local.website_fqdn
 
   aliases = [
-    "${local.website_fqdn}",
+    local.website_fqdn,
     "www.${local.website_fqdn}",
   ]
 }
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
   }
 
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
   }
 }

--- a/bless-ca/iam.tf
+++ b/bless-ca/iam.tf
@@ -19,13 +19,13 @@ data "aws_iam_policy_document" "lambda" {
       "kms:Decrypt",
     ]
 
-    resources = ["${aws_kms_key.bless.arn}"]
+    resources = [aws_kms_key.bless.arn]
   }
 
   statement {
     sid       = "describekey"
     actions   = ["kms:DescribeKey"]
-    resources = ["${aws_kms_key.bless_kms_auth.arn}"]
+    resources = [aws_kms_key.bless_kms_auth.arn]
   }
 
   statement {
@@ -35,12 +35,12 @@ data "aws_iam_policy_document" "lambda" {
       "kms:Decrypt",
     ]
 
-    resources = ["${aws_kms_key.bless_kms_auth.arn}"]
+    resources = [aws_kms_key.bless_kms_auth.arn]
 
     condition {
       test     = "StringEquals"
       variable = "kms:EncryptionContext:to"
-      values   = ["${local.name}"]
+      values   = [local.name]
     }
   }
 

--- a/bless-ca/kms.tf
+++ b/bless-ca/kms.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "kmsauth" {
     condition {
       test     = "StringEquals"
       variable = "kms:EncryptionContext:to"
-      values   = ["${local.name}"]
+      values   = [local.name]
     }
 
     condition {

--- a/bless-ca/test/main.tf
+++ b/bless-ca/test/main.tf
@@ -18,7 +18,7 @@ module "bless" {
   owner   = var.owner
 
   iam_path                      = var.iam_path
-  authorized_users              = ["${aws_iam_user.bless-test.arn}"]
+  authorized_users              = [aws_iam_user.bless-test.arn]
   kmsauth_iam_group_name_format = var.kmsauth_iam_group_name_format
   bless_logging_level           = var.bless_logging_level
 }

--- a/github-webhooks-to-s3/firehose.tf
+++ b/github-webhooks-to-s3/firehose.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "firehose-to-s3" {
     ]
 
     resources = [
-      "${module.bucket.arn}",
+      module.bucket.arn,
       "${module.bucket.arn}/*",
     ]
   }
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "firehose-to-s3" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.firehose.arn}",
+      aws_cloudwatch_log_group.firehose.arn,
       "${aws_cloudwatch_log_group.firehose.arn}/*",
     ]
   }

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "firehose-write" {
       "firehose:PutRecord",
     ]
 
-    resources = ["${aws_kinesis_firehose_delivery_stream.firehose.arn}"]
+    resources = [aws_kinesis_firehose_delivery_stream.firehose.arn]
   }
 }
 


### PR DESCRIPTION
### Summary
As modules in this repository are intended for use with Terraform 0.12 or later, it's safe to remove remaining instances of deprecated interpolation-only strings of the form `"${foo}"`. This should reduce the noise from deprecation warnings in downstream configurations.

### Test Plan
unittests
