### PR TITLE
Terraform AWS Provider 3.0 compatibility

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -35,7 +35,7 @@ module "db" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0, < 3.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0 |
 
 ## Providers
 
@@ -45,7 +45,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
 
 ## Resources
 

--- a/aws-aurora-mysql/terraform.tf
+++ b/aws-aurora-mysql/terraform.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
     # ca_cert_identifier on RDS was added in 2.44.0
-    aws = ">= 2.44.0, < 3.0.0"
+    aws = ">= 2.44.0"
   }
 }

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -34,7 +34,7 @@ module "db" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0, < 3.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0 |
 
 ## Providers
 
@@ -44,7 +44,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
 
 ## Resources
 
@@ -55,14 +55,14 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | If false changes will not be applied until next maintenance window. | `string` | `false` | no |
-| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Set the databases to automatically upgrade minor versions. WARNING - if this is enabled, make sure engine_version is set to a *prefix* rather that a specific version so that TF won't try to downgrade DB's that have been auto-upgraded. Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version | `bool` | `false` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Set the databases to automatically upgrade minor versions. WARNING - if this is enabled, make sure engine\_version is set to a *prefix* rather that a specific version so that TF won't try to downgrade DB's that have been auto-upgraded. Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version | `bool` | `false` | no |
 | <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Identifier for the certificate authority. | `string` | `"rds-ca-2019"` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database to be created in the cluster. | `string` | n/a | yes |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | Password for user that will be created. | `string` | n/a | yes |
 | <a name="input_database_subnet_group"></a> [database\_subnet\_group](#input\_database\_subnet\_group) | The name of an existing database subnet group to use. | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | Default user to be created. | `string` | n/a | yes |
 | <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Instance) | `list(any)` | `[]` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version of Postgres to use. This should be a *prefix* if auto version upgrades are enabled. (Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version)| `string` | `"10"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version of Postgres to use. This should be a *prefix* if auto version upgrades are enabled. (Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version) | `string` | `"10"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | n/a | `string` | `false` | no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | `list(string)` | `[]` | no |

--- a/aws-aurora-postgres/terraform.tf
+++ b/aws-aurora-postgres/terraform.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
     # ca_cert_identifier on RDS was added in 2.44.0
-    aws = ">= 2.44.0, < 3.0.0"
+    aws = ">= 2.44.0"
   }
 }

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -7,13 +7,13 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0, < 3.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.44.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.44.0, < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.44.0 |
 
 ## Modules
 

--- a/aws-aurora/terraform.tf
+++ b/aws-aurora/terraform.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
     # ca_cert_identifier on RDS was added in 2.44.0
-    aws = ">= 2.44.0, < 3.0.0"
+    aws = ">= 2.44.0"
   }
 }

--- a/aws-cloudfront-domain-redirect/README.md
+++ b/aws-cloudfront-domain-redirect/README.md
@@ -33,20 +33,20 @@ module domain-redirect {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-cert |  |
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
+| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-certificate | n/a |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
 
 ## Resources
 

--- a/aws-cloudfront-domain-redirect/main.tf
+++ b/aws-cloudfront-domain-redirect/main.tf
@@ -1,9 +1,10 @@
 locals {
   tags = {
-    env     = var.env
-    owner   = var.owner
-    service = var.service
-    project = var.project
+    env       = var.env
+    owner     = var.owner
+    service   = var.service
+    project   = var.project
+    managedBy = "terraform"
   }
 }
 
@@ -26,14 +27,10 @@ module "security_headers_lambda" {
 }
 
 module "cert" {
-  source              = "../aws-acm-cert"
+  source              = "../aws-acm-certificate"
   cert_domain_name    = var.source_domain
   aws_route53_zone_id = var.source_domain_zone_id
-
-  project = var.project
-  owner   = var.owner
-  env     = var.env
-  service = var.service
+  tags                = local.tags
 }
 
 resource "aws_cloudfront_distribution" "cf" {

--- a/aws-cloudfront-domain-redirect/terraform.tf
+++ b/aws-cloudfront-domain-redirect/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
+  # Uses aws-acm-certificate module, which needs AWS provider >3.0
   required_providers {
-    aws = "< 3.0.0"
+    aws = ">= 3.0.0"
   }
 }

--- a/aws-cloudfront-logs-bucket/README.md
+++ b/aws-cloudfront-logs-bucket/README.md
@@ -29,21 +29,19 @@ module "s3-bucket" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket |  |
+| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket | n/a |
 
 ## Resources
 

--- a/aws-cloudfront-logs-bucket/terraform.tf
+++ b/aws-cloudfront-logs-bucket/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-cloudwatch-log-group/README.md
+++ b/aws-cloudwatch-log-group/README.md
@@ -7,15 +7,13 @@ By default the name is `${var.project}-${var.env}-${var.service}`, but you can o
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-cloudwatch-log-group/terraform.tf
+++ b/aws-cloudwatch-log-group/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-cloudwatch-log-retention-manager/README.md
+++ b/aws-cloudwatch-log-retention-manager/README.md
@@ -17,20 +17,19 @@ module log-retention-manager {
 | Name | Version |
 |------|---------|
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/aws-cloudwatch-log-retention-manager/terraform.tf
+++ b/aws-cloudwatch-log-retention-manager/terraform.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    aws     = "< 3.0.0"
     archive = "~> 2.0"
   }
 }

--- a/aws-default-vpc-security/README.md
+++ b/aws-default-vpc-security/README.md
@@ -38,15 +38,13 @@ You will need to invoke this module with a properly configured provider for ever
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-default-vpc-security/terraform.tf
+++ b/aws-default-vpc-security/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -25,15 +25,13 @@ Since changing a service to use the new ARN requires destroying and recreating t
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ecs-job-fargate/terraform.tf
+++ b/aws-ecs-job-fargate/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ecs-job/README.md
+++ b/aws-ecs-job/README.md
@@ -26,15 +26,13 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ecs-job/terraform.tf
+++ b/aws-ecs-job/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -146,15 +146,13 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ecs-service-fargate/terraform.tf
+++ b/aws-ecs-service-fargate/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -138,15 +138,13 @@ service = false` argument can be removed.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ecs-service/terraform.tf
+++ b/aws-ecs-service/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-efs-volume/README.md
+++ b/aws-efs-volume/README.md
@@ -1,15 +1,13 @@
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-efs-volume/terraform.tf
+++ b/aws-efs-volume/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-ecs-task-role/README.md
+++ b/aws-iam-ecs-task-role/README.md
@@ -23,15 +23,13 @@ output "ecs-role-arn" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-ecs-task-role/terraform.tf
+++ b/aws-iam-ecs-task-role/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-group-assume-role/README.md
+++ b/aws-iam-group-assume-role/README.md
@@ -26,15 +26,13 @@ output "group_name" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-group-assume-role/terraform.tf
+++ b/aws-iam-group-assume-role/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-group-console-login/README.md
+++ b/aws-iam-group-console-login/README.md
@@ -20,15 +20,13 @@ output "group_name" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-group-console-login/terraform.tf
+++ b/aws-iam-group-console-login/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -31,15 +31,13 @@ resource "aws_instance" "instance" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-instance-profile/terraform.tf
+++ b/aws-iam-instance-profile/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-password-policy/README.md
+++ b/aws-iam-password-policy/README.md
@@ -13,15 +13,13 @@ module "password-policy" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-password-policy/terraform.tf
+++ b/aws-iam-password-policy/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-policy-cwlogs/README.md
+++ b/aws-iam-policy-cwlogs/README.md
@@ -20,15 +20,13 @@ module "policy" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-policy-cwlogs/terraform.tf
+++ b/aws-iam-policy-cwlogs/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -22,21 +22,19 @@ output "..." {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct |  |
+| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct | n/a |
 
 ## Resources
 

--- a/aws-iam-role-bless/terraform.tf
+++ b/aws-iam-role-bless/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -5,15 +5,13 @@ This module will create a role which is granted poweruser control over AWS Cloud
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-cloudfront-poweruser/terraform.tf
+++ b/aws-iam-role-cloudfront-poweruser/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -19,15 +19,13 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.60.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-crossacct/terraform.tf
+++ b/aws-iam-role-crossacct/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = ">= 2.60.0"
-  }
-}

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -21,15 +21,13 @@ module "ec2-poweruser" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-ec2-poweruser/terraform.tf
+++ b/aws-iam-role-ec2-poweruser/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -20,15 +20,13 @@ module "ec2-poweruser" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-ecs-poweruser/terraform.tf
+++ b/aws-iam-role-ecs-poweruser/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -5,15 +5,13 @@ Creates a role useful for running `terraform plan` in CI jobs.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-infraci/terraform.tf
+++ b/aws-iam-role-infraci/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -19,15 +19,13 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-poweruser/terraform.tf
+++ b/aws-iam-role-poweruser/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -23,15 +23,13 @@ output "role_name" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-readonly/terraform.tf
+++ b/aws-iam-role-readonly/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -20,15 +20,13 @@ module "route53domains-poweruser" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-route53domains-poweruser/terraform.tf
+++ b/aws-iam-role-route53domains-poweruser/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -15,15 +15,13 @@ module "group" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role-security-audit/terraform.tf
+++ b/aws-iam-role-security-audit/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -28,15 +28,13 @@ module iam-role {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-role/terraform.tf
+++ b/aws-iam-role/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-iam-secrets-reader-policy/README.md
+++ b/aws-iam-secrets-reader-policy/README.md
@@ -18,15 +18,13 @@ module "policy" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-iam-secrets-reader-policy/terraform.tf
+++ b/aws-iam-secrets-reader-policy/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-lambda-edge-add-security-headers/README.md
+++ b/aws-lambda-edge-add-security-headers/README.md
@@ -38,7 +38,6 @@ resource aws_cloudfront_distribution cf {
 | Name | Version |
 |------|---------|
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
 
 ## Providers
 
@@ -50,7 +49,7 @@ resource aws_cloudfront_distribution cf {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/aws-lambda-edge-add-security-headers/terraform.tf
+++ b/aws-lambda-edge-add-security-headers/terraform.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    aws     = "< 3.0.0"
     archive = "~> 2.0"
   }
 }

--- a/aws-lambda-function/README.md
+++ b/aws-lambda-function/README.md
@@ -4,7 +4,7 @@
 
 ```hcl
 module lambda {
-  source = "github.com/chanzuckerberg/cztack/aws-lambda-function?ref=v0.14.0"
+  source = "github.com/chanzuckerberg/cztack/aws-lambda-function?ref=tf-aws-3.0"
 
   filename         = "file.zip"
   handler          = "handle"
@@ -24,13 +24,13 @@ module lambda {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.60.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0.0 |
 
 ## Modules
 

--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -11,8 +11,7 @@ locals {
   }
 }
 
-
-resource "aws_lambda_function" "lambda" {
+resource aws_lambda_function lambda {
   s3_bucket = var.source_s3_bucket
   s3_key    = var.source_s3_key
 
@@ -53,7 +52,7 @@ resource "aws_lambda_function" "lambda" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "lambda_role_policy" {
+data aws_iam_policy_document lambda_role_policy {
   statement {
     principals {
       type = "Service"
@@ -66,13 +65,11 @@ data "aws_iam_policy_document" "lambda_role_policy" {
   }
 }
 
-resource "aws_iam_role" "role" {
-  name = local.name
-  path = var.lambda_role_path
-
+resource aws_iam_role role {
+  name               = local.name
+  path               = var.lambda_role_path
   assume_role_policy = data.aws_iam_policy_document.lambda_role_policy.json
-
-  tags = local.tags
+  tags               = local.tags
 }
 
 resource "aws_cloudwatch_log_group" "log" {
@@ -113,8 +110,7 @@ resource "aws_iam_policy" "lambda_logging" {
   name_prefix = "${local.name}-lambda-logging"
   path        = "/"
   description = "IAM policy for logging from the ${local.name} lambda."
-
-  policy = data.aws_iam_policy_document.lambda_logging_policy.json
+  policy      = data.aws_iam_policy_document.lambda_logging_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {

--- a/aws-lambda-function/terraform.tf
+++ b/aws-lambda-function/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_providers {
-    aws = ">= 2.60.0"
+    # Depends on aws_cloudwatch_log_group.log.arn not returning trailing ":*" starting in 3.0.0
+    aws = ">= 3.0.0"
   }
 }

--- a/aws-param/README.md
+++ b/aws-param/README.md
@@ -28,15 +28,13 @@ output "secret" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-param/terraform.tf
+++ b/aws-param/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-params-reader-policy/README.md
+++ b/aws-params-reader-policy/README.md
@@ -5,15 +5,13 @@ Creates a policy to access encrypted parameters in Parameter Store for a given s
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-params-reader-policy/terraform.tf
+++ b/aws-params-reader-policy/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-params-secrets-setup/README.md
+++ b/aws-params-secrets-setup/README.md
@@ -8,15 +8,13 @@ Currently that just means creating an KMS key for encrypting the parameters stor
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-params-secrets-setup/terraform.tf
+++ b/aws-params-secrets-setup/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-params-writer/README.md
+++ b/aws-params-writer/README.md
@@ -15,15 +15,13 @@ in the [Terraform docs](https://www.terraform.io/docs/state/sensitive-data.html)
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-params-writer/terraform.tf
+++ b/aws-params-writer/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-redis-node/README.md
+++ b/aws-redis-node/README.md
@@ -6,15 +6,13 @@ parameters.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-redis-node/terraform.tf
+++ b/aws-redis-node/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-redis-replication-group/README.md
+++ b/aws-redis-replication-group/README.md
@@ -6,15 +6,13 @@ a replication group with the given parameters.
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-redis-replication-group/terraform.tf
+++ b/aws-redis-replication-group/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -33,15 +33,13 @@ module "s3-bucket" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.60.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-s3-private-bucket/terraform.tf
+++ b/aws-s3-private-bucket/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = ">= 2.60.0"
-  }
-}

--- a/aws-s3-public-bucket/README.md
+++ b/aws-s3-public-bucket/README.md
@@ -1,15 +1,13 @@
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-s3-public-bucket/terraform.tf
+++ b/aws-s3-public-bucket/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-single-page-static-site/README.md
+++ b/aws-single-page-static-site/README.md
@@ -22,7 +22,7 @@ This module is specifically designed for Single Page Applications– In order to
 
 ```hcl
 module "site" {
-  source = "github.com/chanzuckerberg/cztack//aws-single-page-static-site?ref=v0.36.0"
+  source = "github.com/chanzuckerberg/cztack//aws-single-page-static-site?ref=v0.40.0"
 
   cert_domain_name               = "..."
   cert_subject_alternative_names = "..."
@@ -42,19 +42,19 @@ module "site" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
 
 ## Resources
 
@@ -80,7 +80,7 @@ module "site" {
 | <a name="input_aws_route53_zone_id"></a> [aws\_route53\_zone\_id](#input\_aws\_route53\_zone\_id) | A route53 zone ID used to write records. | `string` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the bucket to created. If not given, it will use the domain name. | `string` | `""` | no |
 | <a name="input_cloudfront_price_class"></a> [cloudfront\_price\_class](#input\_cloudfront\_price\_class) | Cloudfront [price class](https://aws.amazon.com/cloudfront/pricing/). | `string` | `"PriceClass_100"` | no |
-| <a name="input_custom_error_response_codes"></a> [custom\_error\_response\_codes](#input\_custom\_error\_response\_codes) | The http response codes for which to return the default index page. | `list(number)` | <pre>[<br>  404,<br>  403,<br>  503<br>]</pre> | no |
+| <a name="input_custom_error_response_codes"></a> [custom\_error\_response\_codes](#input\_custom\_error\_response\_codes) | The http response codes for which to return the default index page. Defaults to [404, 403, 503] | `list(number)` | `null` | no |
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_index_document_path"></a> [index\_document\_path](#input\_index\_document\_path) | The path to the index document of your site. | `string` | `"index.html"` | no |
 | <a name="input_minimum_tls_version"></a> [minimum\_tls\_version](#input\_minimum\_tls\_version) | Minimum TLS version to accept. | `string` | `"TLSv1.1_2016"` | no |

--- a/aws-single-page-static-site/main.tf
+++ b/aws-single-page-static-site/main.tf
@@ -7,7 +7,7 @@ locals {
     managedBy = "terraform"
   }
 
-  domain       = replace(data.aws_route53_zone.zone.name, "/\\.$/", "")
+  domain       = data.aws_route53_zone.zone.name
   website_fqdn = "${var.subdomain}.${local.domain}"
   bucket_name  = var.bucket_name != "" ? var.bucket_name : local.website_fqdn
 
@@ -15,6 +15,8 @@ locals {
     local.website_fqdn,
     "www.${local.website_fqdn}",
   ]
+
+  default_custom_error_response_codes = [404, 403, 503]
 }
 
 data "aws_route53_zone" "zone" {
@@ -185,7 +187,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
   # This is error handling logic for single page applications
   dynamic "custom_error_response" {
-    for_each = var.custom_error_response_codes
+    for_each = coalesce(var.custom_error_response_codes, local.default_custom_error_response_codes)
     content {
       error_code         = custom_error_response.value
       response_code      = 200

--- a/aws-single-page-static-site/terraform.tf
+++ b/aws-single-page-static-site/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_providers {
-    aws = "< 3.0.0"
+    # Depends on aws_route53_zone.zone.name not returning trailing "." starting in 3.0.0
+    aws = ">= 3.0.0"
   }
 }

--- a/aws-single-page-static-site/test/main.tf
+++ b/aws-single-page-static-site/test/main.tf
@@ -22,7 +22,7 @@ data "aws_route53_zone" "zone" {
 }
 
 locals {
-  domain       = replace(data.aws_route53_zone.zone.name, "/\\.$/", "")
+  domain       = data.aws_route53_zone.zone.name
   website_fqdn = "${var.subdomain}.${local.domain}"
   aliases = [
     "www.${local.website_fqdn}",
@@ -39,17 +39,19 @@ provider "aws" {
 }
 
 module "cert" {
-  source = "../../aws-acm-cert"
+  source = "../../aws-acm-certificate"
 
-  cert_domain_name                     = local.website_fqdn
-  aws_route53_zone_id                  = var.aws_route53_zone_id
-  cert_subject_alternative_names       = { for a in local.aliases : a => var.aws_route53_zone_id }
-  cert_subject_alternative_names_count = length(local.aliases)
+  cert_domain_name               = local.website_fqdn
+  aws_route53_zone_id            = var.aws_route53_zone_id
+  cert_subject_alternative_names = { for a in local.aliases : a => var.aws_route53_zone_id }
 
-  project = var.project
-  env     = var.env
-  service = var.service
-  owner   = var.owner
+  tags = {
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
+    managedBy = "terraform"
+  }
 
   providers = {
     aws = aws.us-east-1

--- a/aws-single-page-static-site/variables.tf
+++ b/aws-single-page-static-site/variables.tf
@@ -71,7 +71,7 @@ variable "path_pattern" {
 
 variable "custom_error_response_codes" {
   type        = list(number)
-  description = "The http response codes for which to return the default index page."
-  default     = [404, 403, 503]
+  description = "The http response codes for which to return the default index page. Defaults to [404, 403, 503]"
+  default     = null
 }
 

--- a/aws-sns-lambda/README.md
+++ b/aws-sns-lambda/README.md
@@ -50,21 +50,19 @@ data "archive_file" "lambda_archive" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/aws-sns-lambda/terraform.tf
+++ b/aws-sns-lambda/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ssm-params-writer/README.md
+++ b/aws-ssm-params-writer/README.md
@@ -13,15 +13,13 @@ in the [Terraform docs](https://www.terraform.io/docs/state/sensitive-data.html)
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ssm-params-writer/terraform.tf
+++ b/aws-ssm-params-writer/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/aws-ssm-params/README.md
+++ b/aws-ssm-params/README.md
@@ -26,15 +26,13 @@ output "secret" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/aws-ssm-params/terraform.tf
+++ b/aws-ssm-params/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/bless-ca/README.md
+++ b/bless-ca/README.md
@@ -96,15 +96,13 @@ You can read more about Bless and SSH certificates here:
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_bless"></a> [bless](#provider\_bless) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
@@ -112,8 +110,8 @@ You can read more about Bless and SSH certificates here:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
-| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
+| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs | n/a |
 
 ## Resources
 

--- a/bless-ca/terraform.tf
+++ b/bless-ca/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/github-webhooks-to-s3/README.md
+++ b/github-webhooks-to-s3/README.md
@@ -10,7 +10,7 @@ This module will configure an aggregator for GitHub webhooks. It sets up an API 
 ```hcl
 module "archiver" {
   // Replace with latest cztack stable release https://github.com/chanzuckerberg/cztack/releases
-  source = "github.com/chanzuckerberg/cztack//github-webhooks-to-s3?ref=v0.36.0"
+  source = "github.com/chanzuckerberg/cztack//github-webhooks-to-s3?ref=v0.40.0"
 
   env     = "${var.env}"
   project = "${var.project}"
@@ -27,23 +27,21 @@ module "archiver" {
 <!-- START -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 3.0.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs |  |
-| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket |  |
-| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params |  |
+| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs | n/a |
+| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket | n/a |
+| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params | n/a |
 
 ## Resources
 
@@ -92,5 +90,7 @@ module "archiver" {
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
 <!-- END -->

--- a/github-webhooks-to-s3/firehose.tf
+++ b/github-webhooks-to-s3/firehose.tf
@@ -58,10 +58,7 @@ data "aws_iam_policy_document" "firehose-to-s3" {
       "logs:GetLogEvents",
     ]
 
-    resources = [
-      aws_cloudwatch_log_group.firehose.arn,
-      "${aws_cloudwatch_log_group.firehose.arn}/*",
-    ]
+    resources = ["${aws_cloudwatch_log_group.firehose.arn}:*"]
   }
 }
 

--- a/github-webhooks-to-s3/main.tf
+++ b/github-webhooks-to-s3/main.tf
@@ -4,8 +4,8 @@ locals {
   tags = {
     managedBy = "terraform"
     Name      = local.name
+    project   = var.project
     env       = var.env
-    owner     = var.owner
     service   = var.service
     owner     = var.owner
   }

--- a/github-webhooks-to-s3/outputs.tf
+++ b/github-webhooks-to-s3/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket" {
+  value       = module.bucket.id
+  description = "S3 bucket that Github webhooks are streamed into"
+}

--- a/github-webhooks-to-s3/terraform.tf
+++ b/github-webhooks-to-s3/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}

--- a/module-template/terraform.tf
+++ b/module-template/terraform.tf
@@ -1,5 +1,0 @@
-terraform {
-  required_providers {
-    aws = "< 3.0.0"
-  }
-}


### PR DESCRIPTION
* Internally use the new aws-acm-certificate module that is compatible with TF AWS Provider 3.0 (in aws-cloudfront-domain-redirect and aws-single-page-static-site)
* Adapt to the new ARN format return by aws_cloudwatch_log_group arn, due to removal of arn wildcard suffix: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_cloudwatch_log_group
* aws-single-page-static-site no longer strip off trailing dot from data.aws_route53_zone name, since new provider version guarantees its removal: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#removal-of-trailing-period-in-name-argument-1
* aws-single-page-static-site make custom_error_response_codes nullable, default from internal implementation.
* Export bucket name from github-webhooks-to-s3
* Remove Terraform provider version restrictions