### PR TITLE
[feature] Add 'snapshot_identifier' to all aws-aurora modules

### DIFF
--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -32,6 +32,7 @@ module "aurora" {
   instance_count = var.instance_count
 
   backtrack_window    = var.backtrack_window
+  snapshot_identifier = var.snapshot_identifier
   skip_final_snapshot = var.skip_final_snapshot
 
   kms_key_id = var.kms_key_id

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -57,6 +57,11 @@ variable "project" {
   description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }
 
+variable "snapshot_identifier" {
+  type    = string
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+}
+
 variable "skip_final_snapshot" {
   type        = string
   description = "When you destroy a database RDS will, by default, take snapshot. Set this to skip that step."

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -58,8 +58,9 @@ variable "project" {
 }
 
 variable "snapshot_identifier" {
-  type    = string
+  type        = string
   description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+  default     = null
 }
 
 variable "skip_final_snapshot" {

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -40,6 +40,7 @@ module "aurora" {
 
   # backtrack_window not supported yet
   backtrack_window    = 0
+  snapshot_identifier = var.snapshot_identifier
   skip_final_snapshot = var.skip_final_snapshot
   kms_key_id          = var.kms_key_id
   apply_immediately   = var.apply_immediately

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -73,6 +73,11 @@ variable "publicly_accessible" {
   default     = false
 }
 
+variable "snapshot_identifier" {
+  type    = string
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+}
+
 variable "skip_final_snapshot" {
   type        = string
   description = "When you destroy a database RDS will, by default, take snapshot. Set this to skip that step."

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -74,8 +74,9 @@ variable "publicly_accessible" {
 }
 
 variable "snapshot_identifier" {
-  type    = string
+  type        = string
   description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+  default     = null
 }
 
 variable "skip_final_snapshot" {

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -59,6 +59,7 @@ resource "aws_rds_cluster" "db" {
   storage_encrypted                   = true
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   backup_retention_period             = 28
+  snapshot_identifier                 = var.snapshot_identifier
   final_snapshot_identifier           = "${local.name}-snapshot"
   skip_final_snapshot                 = var.skip_final_snapshot
   backtrack_window                    = var.backtrack_window

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -54,7 +54,7 @@ variable "project" {
 variable "snapshot_identifier" {
   type        = string
   description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
-  default     = ""
+  default     = null
 }
 
 variable "skip_final_snapshot" {

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -51,6 +51,11 @@ variable "project" {
   description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"
 }
 
+variable "snapshot_identifier" {
+  type    = string
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+}
+
 variable "skip_final_snapshot" {
   default = false
 }

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -52,8 +52,9 @@ variable "project" {
 }
 
 variable "snapshot_identifier" {
-  type    = string
+  type        = string
   description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+  default     = ""
 }
 
 variable "skip_final_snapshot" {


### PR DESCRIPTION
This will support creating a new RDS cluster from an existing snapshot, e.g. for data mirroring to a different env.

If snapshot_identifier not provided, should revert to original behavior.

This takes functionality from a side branch of @atolopko-czi  and puts it into the main branch, since there is already code that relies on this functionality.