### PR TITLE
[fix] Various fixes for TF AWS 3.0 compatibility

### DIFF
--- a/aws-acm-certificate/README.md
+++ b/aws-acm-certificate/README.md
@@ -58,16 +58,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_route53_zone_id"></a> [aws\_route53\_zone\_id](#input\_aws\_route53\_zone\_id) | n/a | `string` | n/a | yes |
+| <a name="input_aws_route53_zone_id"></a> [aws\_route53\_zone\_id](#input\_aws\_route53\_zone\_id) | Default Route 53 zone to create validation records in | `string` | n/a | yes |
 | <a name="input_cert_domain_name"></a> [cert\_domain\_name](#input\_cert\_domain\_name) | Like www.foo.bar.com or *.foo.bar.com | `string` | n/a | yes |
 | <a name="input_cert_subject_alternative_names"></a> [cert\_subject\_alternative\_names](#input\_cert\_subject\_alternative\_names) | A map of <alternative\_domain:route53\_zone\_id> | `map(string)` | `{}` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to certificate | `map(string)` | `{}` | no |
-| <a name="input_validation_record_ttl"></a> [validation\_record\_ttl](#input\_validation\_record\_ttl) | n/a | `string` | `60` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to certificate | `object({ project : string, env : string, service : string, owner : string, managedBy : string })` | n/a | yes |
+| <a name="input_validation_record_ttl"></a> [validation\_record\_ttl](#input\_validation\_record\_ttl) | TTL value of DNS validation records | `string` | `60` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
-| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_arn"></a> [arn](#output\_arn) | AWS ARN of the certificate |
+| <a name="output_id"></a> [id](#output\_id) | ID of the certificate |
 <!-- END -->

--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -81,6 +81,7 @@ No resources.
 | <a name="input_rds_cluster_parameters"></a> [rds\_cluster\_parameters](#input\_rds\_cluster\_parameters) | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.Parameters.Cluster) | `list(any)` | <pre>[<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "character_set_server",<br>    "value": "utf8"<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "character_set_client",<br>    "value": "utf8"<br>  }<br>]</pre> | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | When you destroy a database RDS will, by default, take snapshot. Set this to skip that step. | `string` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the existing VPC in which this cluster should be created. | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -77,6 +77,7 @@ No resources.
 | <a name="input_rds_cluster_parameters"></a> [rds\_cluster\_parameters](#input\_rds\_cluster\_parameters) | Cluster params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Cluster) | `list(any)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | When you destroy a database RDS will, by default, take snapshot. Set this to skip that step. | `string` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the existing VPC in which this cluster should be created. | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_rds_cluster_parameters"></a> [rds\_cluster\_parameters](#input\_rds\_cluster\_parameters) | n/a | `list(any)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | n/a | `bool` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -158,8 +158,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb-sg"></a> [alb-sg](#module\_alb-sg) | terraform-aws-modules/security-group/aws | 3.11.0 |
-| <a name="module_container-sg"></a> [container-sg](#module\_container-sg) | terraform-aws-modules/security-group/aws | 3.11.0 |
+| <a name="module_alb-sg"></a> [alb-sg](#module\_alb-sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
+| <a name="module_container-sg"></a> [container-sg](#module\_container-sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
 
 ## Resources
 

--- a/aws-ecs-service-fargate/alb.tf
+++ b/aws-ecs-service-fargate/alb.tf
@@ -29,7 +29,7 @@ resource "aws_lb_target_group" "service" {
 resource "aws_lb" "service" {
   name            = local.name
   internal        = var.internal_lb
-  security_groups = [module.alb-sg.this_security_group_id]
+  security_groups = [module.alb-sg.security_group_id]
   subnets         = var.lb_subnets
   idle_timeout    = var.lb_idle_timeout_seconds
 
@@ -80,7 +80,7 @@ resource "aws_lb_listener" "https" {
 
 module "alb-sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.11.0"
+  version     = "4.3.0"
   name        = "${local.name}-alb"
   description = "Security group for ${var.internal_lb ? "internal" : "internet facing"} ALB"
   vpc_id      = var.vpc_id
@@ -106,7 +106,7 @@ module "alb-sg" {
       to_port                  = var.container_port
       protocol                 = "tcp"
       description              = "Container port"
-      source_security_group_id = module.container-sg.this_security_group_id
+      source_security_group_id = module.container-sg.security_group_id
     },
   ]
 }

--- a/aws-ecs-service-fargate/outputs.tf
+++ b/aws-ecs-service-fargate/outputs.tf
@@ -13,7 +13,7 @@ output "ecs_task_definition_family" {
 
 output "container_security_group_id" {
   description = "Security group id for the container."
-  value       = module.container-sg.this_security_group_id
+  value       = module.container-sg.security_group_id
 }
 
 output "private_service_discovery_domain" {

--- a/aws-ecs-service-fargate/service.tf
+++ b/aws-ecs-service-fargate/service.tf
@@ -6,7 +6,7 @@ locals {
 
 module "container-sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.11.0"
+  version     = "4.3.0"
   name        = local.name
   description = "ECS ingress port"
   vpc_id      = var.vpc_id
@@ -18,7 +18,7 @@ module "container-sg" {
       to_port                  = var.container_port
       protocol                 = "tcp"
       description              = "Container port"
-      source_security_group_id = module.alb-sg.this_security_group_id
+      source_security_group_id = module.alb-sg.security_group_id
     },
   ]
 
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "job" {
 
   network_configuration {
     subnets         = var.task_subnets
-    security_groups = [module.container-sg.this_security_group_id]
+    security_groups = [module.container-sg.security_group_id]
   }
 
   load_balancer {
@@ -91,7 +91,7 @@ resource "aws_ecs_service" "unmanaged-job" {
 
   network_configuration {
     subnets         = var.task_subnets
-    security_groups = [module.container-sg.this_security_group_id]
+    security_groups = [module.container-sg.security_group_id]
   }
 
   load_balancer {

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -150,8 +150,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb-sg"></a> [alb-sg](#module\_alb-sg) | terraform-aws-modules/security-group/aws | 3.11.0 |
-| <a name="module_container-sg"></a> [container-sg](#module\_container-sg) | terraform-aws-modules/security-group/aws | 3.11.0 |
+| <a name="module_alb-sg"></a> [alb-sg](#module\_alb-sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
+| <a name="module_container-sg"></a> [container-sg](#module\_container-sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
 
 ## Resources
 

--- a/aws-ecs-service/alb.tf
+++ b/aws-ecs-service/alb.tf
@@ -30,7 +30,7 @@ resource "aws_lb_target_group" "service" {
 resource "aws_lb" "service" {
   name            = local.name
   internal        = var.internal_lb
-  security_groups = [module.alb-sg.this_security_group_id]
+  security_groups = [module.alb-sg.security_group_id]
   subnets         = var.lb_subnets
   idle_timeout    = var.lb_idle_timeout_seconds
 
@@ -81,7 +81,7 @@ resource "aws_lb_listener" "https" {
 
 module "alb-sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.11.0"
+  version     = "4.3.0"
   name        = "${local.name}-alb"
   description = "Security group for ${var.internal_lb ? "internal" : "internet facing"} ALB"
   vpc_id      = var.vpc_id
@@ -114,7 +114,7 @@ module "alb-sg" {
       to_port                  = var.container_port
       protocol                 = "tcp"
       description              = "Container port"
-      source_security_group_id = module.container-sg.this_security_group_id
+      source_security_group_id = module.container-sg.security_group_id
     },
   ]
 }

--- a/aws-ecs-service/outputs.tf
+++ b/aws-ecs-service/outputs.tf
@@ -13,7 +13,7 @@ output "ecs_task_definition_family" {
 
 output "container_security_group_id" {
   description = "Security group id for the container."
-  value       = module.container-sg.this_security_group_id
+  value       = module.container-sg.security_group_id
 }
 
 output "private_service_discovery_domain" {

--- a/aws-ecs-service/service.tf
+++ b/aws-ecs-service/service.tf
@@ -6,7 +6,7 @@ locals {
 
 module "container-sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.11.0"
+  version     = "4.3.0"
   create      = var.awsvpc_network_mode
   name        = local.name
   description = "ECS ingress port"
@@ -19,7 +19,7 @@ module "container-sg" {
       to_port                  = var.container_port
       protocol                 = "tcp"
       description              = "Container port"
-      source_security_group_id = module.alb-sg.this_security_group_id
+      source_security_group_id = module.alb-sg.security_group_id
     },
   ]
 
@@ -52,7 +52,7 @@ resource "aws_ecs_service" "job" {
     for_each = compact([var.awsvpc_network_mode ? "present" : ""])
     content {
       subnets         = var.task_subnets
-      security_groups = [module.container-sg.this_security_group_id]
+      security_groups = [module.container-sg.security_group_id]
     }
   }
 
@@ -95,7 +95,7 @@ resource "aws_ecs_service" "unmanaged-job" {
     for_each = compact([var.awsvpc_network_mode ? "present" : ""])
     content {
       subnets         = var.task_subnets
-      security_groups = [module.container-sg.this_security_group_id]
+      security_groups = [module.container-sg.security_group_id]
     }
   }
 

--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -81,14 +81,6 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 # TODO scope this policy down
-#
-# I would love to use "${aws_cloudwatch_log_group.log.arn}", as the
-# resource here, but the provider returns an ARN that looks like:
-#   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar:*
-# Unfortunately you need to use an ARN like:
-#   arn:aws:logs:us-west-2:123456789:log-group:/foo/bar
-# to match operations on the log group(like creating a new stream.) So instead we construct one
-# without the colon before the *, so that we can match both log groups and log streams.
 data "aws_iam_policy_document" "lambda_logging_policy" {
   statement {
     effect = "Allow"
@@ -101,7 +93,7 @@ data "aws_iam_policy_document" "lambda_logging_policy" {
     resources = [
       var.at_edge ?
       "*" :
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.log.name}*",
+      "${aws_cloudwatch_log_group.log.arn}:*"
     ]
   }
 }

--- a/aws-redis-node/README.md
+++ b/aws-redis-node/README.md
@@ -18,7 +18,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | terraform-aws-modules/security-group/aws | 3.12.0 |
+| <a name="module_sg"></a> [sg](#module\_sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
 
 ## Resources
 

--- a/aws-redis-node/main.tf
+++ b/aws-redis-node/main.tf
@@ -13,7 +13,7 @@ locals {
 
 module "sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.12.0"
+  version     = "4.3.0"
   name        = local.name
   description = "Allow traffic to Redis."
   vpc_id      = var.vpc_id
@@ -56,7 +56,7 @@ resource "aws_elasticache_cluster" "default" {
   num_cache_nodes      = 1
   parameter_group_name = var.parameter_group_name
   subnet_group_name    = aws_elasticache_subnet_group.default.name
-  security_group_ids   = [module.sg.this_security_group_id]
+  security_group_ids   = [module.sg.security_group_id]
   apply_immediately    = var.apply_immediately
   availability_zone    = var.availability_zone
   tags                 = local.tags

--- a/aws-redis-replication-group/README.md
+++ b/aws-redis-replication-group/README.md
@@ -18,7 +18,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | terraform-aws-modules/security-group/aws | 3.12.0 |
+| <a name="module_sg"></a> [sg](#module\_sg) | terraform-aws-modules/security-group/aws | 4.3.0 |
 
 ## Resources
 

--- a/aws-redis-replication-group/main.tf
+++ b/aws-redis-replication-group/main.tf
@@ -13,7 +13,7 @@ locals {
 
 module "sg" {
   source      = "terraform-aws-modules/security-group/aws"
-  version     = "3.12.0"
+  version     = "4.3.0"
   name        = local.name
   description = "Allow traffic to Redis."
   vpc_id      = var.vpc_id
@@ -47,7 +47,7 @@ resource "aws_elasticache_replication_group" "default" {
   number_cache_clusters         = var.number_cache_clusters
   parameter_group_name          = var.parameter_group_name
   subnet_group_name             = aws_elasticache_subnet_group.default.name
-  security_group_ids            = [module.sg.this_security_group_id]
+  security_group_ids            = [module.sg.security_group_id]
   apply_immediately             = var.apply_immediately
   at_rest_encryption_enabled    = var.at_rest_encryption_enabled
   transit_encryption_enabled    = var.transit_encryption_enabled

--- a/aws-single-page-static-site/main.tf
+++ b/aws-single-page-static-site/main.tf
@@ -87,7 +87,7 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 module "security_headers_lambda" {
   source = "../aws-lambda-edge-add-security-headers"
 
-  function_name = replace("${local.website_fqdn}-static-site-security-headers", ".", "-")
+  function_name = replace("${local.website_fqdn}-headers", ".", "-")
 
   project = var.project
   owner   = var.owner

--- a/aws-single-page-static-site/providers.tf
+++ b/aws-single-page-static-site/providers.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"

--- a/aws-ssm-params/README.md
+++ b/aws-ssm-params/README.md
@@ -8,7 +8,7 @@ You can use [our secrets setup module](../aws-params-secrets-setup/README.md) to
 
 ```hcl
 module "secret" {
-  source = "github.com/chanzuckerberg/cztack/aws-ssm-params-secret?ref=v0.18.2"
+  source = "github.com/chanzuckerberg/cztack//aws-ssm-params?ref=v0.40.0"
 
   project = "acme"
   env     = "staging"

--- a/github-webhooks-to-s3/README.md
+++ b/github-webhooks-to-s3/README.md
@@ -92,5 +92,5 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | S3 bucket that Github webhooks are streamed into |
 <!-- END -->


### PR DESCRIPTION
* Shorten static site lambda name
* Remove unneeded bare aws provider from static site
* Fix aws-ssm-params readme
* Upgrade terraform-aws-modules/security-group/aws for TF 3.0 compatiblity (and update since new version renames output this_security_group_id to security_group_id)
* aws-lambda-functionaws_cloudwatch_log_group use ARN instead of manually
      constructing since ARN is fixed in TF AWS 3.0
* Update readmes via make docs