### PR TITLE
[fix] remove ssm:DescribeParameters permission from SSM reader policy

### DIFF
--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -29,14 +29,15 @@ data "aws_iam_policy_document" "policy" {
     actions   = ["kms:Decrypt"]
     resources = [data.aws_kms_alias.parameter_store_key.target_key_arn]
   }
-  # To use this reader policy with chamber, we need to give blanket ssm:DescribeParameters perms
+  # Note (aku): To use this reader policy with chamber, we need to give blanket ssm:DescribeParameters perms
   # https://github.com/segmentio/chamber/blob/53baa2b77bb1ed279bea346533d50f4fb1c01ed1/store/ssmstore.go#L214-L217
-  # This should be okay because this is a list option and the permission won't allow you to read the contents
-  # Otherwise, we'd get this error: The actions in your policy do not support resource-level permissions and require you to choose All resources
+  # This should be okay because this is a list option and the permission won't allow you to read the secret values
+  # Without this, we'd get this error: The actions in your policy do not support resource-level permissions and require you to choose All resources
   statement {
     sid = "ChamberSSMReadRequirement"
     actions   = ["ssm:DescribeParameters"]
     resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
+    
   }
 }
 

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -20,7 +20,6 @@ data "aws_iam_policy_document" "policy" {
       "ssm:GetParametersByPath",
       "ssm:GetParameter",
       "ssm:GetParameterHistory",
-      "ssm:DescribeParameters",
     ]
 
     resources = local.param_resources

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "policy" {
   }
   statement {
     actions = ["ssm:DescribeParameters"]
+    resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
   }
 }
 

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -29,7 +29,12 @@ data "aws_iam_policy_document" "policy" {
     actions   = ["kms:Decrypt"]
     resources = [data.aws_kms_alias.parameter_store_key.target_key_arn]
   }
+  # To use this reader policy with chamber, we need to give blanket ssm:DescribeParameters perms
+  # https://github.com/segmentio/chamber/blob/53baa2b77bb1ed279bea346533d50f4fb1c01ed1/store/ssmstore.go#L214-L217
+  # This should be okay because this is a list option and the permission won't allow you to read the contents
+  # Otherwise, we'd get this error: The actions in your policy do not support resource-level permissions and require you to choose All resources
   statement {
+    sid = "ChamberSSMReadRequirement"
     actions   = ["ssm:DescribeParameters"]
     resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
   }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "policy" {
   # This should be okay because this is a list option and the permission won't allow you to read the secret values
   # Without this, we'd get this error: The actions in your policy do not support resource-level permissions and require you to choose All resources
   statement {
-    sid = "ChamberSSMReadRequirement"
+    sid       = "ChamberSSMReadRequirement"
     actions   = ["ssm:DescribeParameters"]
     resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
   }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -37,7 +37,6 @@ data "aws_iam_policy_document" "policy" {
     sid = "ChamberSSMReadRequirement"
     actions   = ["ssm:DescribeParameters"]
     resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
-    
   }
 }
 

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "policy" {
     resources = [data.aws_kms_alias.parameter_store_key.target_key_arn]
   }
   statement {
-    actions = ["ssm:DescribeParameters"]
+    actions   = ["ssm:DescribeParameters"]
     resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/*"]
   }
 }

--- a/aws-params-reader-policy/main.tf
+++ b/aws-params-reader-policy/main.tf
@@ -29,6 +29,9 @@ data "aws_iam_policy_document" "policy" {
     actions   = ["kms:Decrypt"]
     resources = [data.aws_kms_alias.parameter_store_key.target_key_arn]
   }
+  statement {
+    actions = ["ssm:DescribeParameters"]
+  }
 }
 
 resource "aws_iam_role_policy" "policy" {


### PR DESCRIPTION
When trying to use the `ssm:DescribeParameters` permission, I keep getting this warning: 
```
The actions in your policy do not support resource-level permissions and require you to choose All resources
```
The warning is right--I wasn't able to run `ssm:DescribeParameters` for a specific subpath in SSM.  