### PR TITLE
[breaking] deprecate source account ID input for its plural var

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -45,7 +45,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
 
 ## Resources
 

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -44,7 +44,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
 
 ## Resources
 

--- a/aws-cloudfront-domain-redirect/README.md
+++ b/aws-cloudfront-domain-redirect/README.md
@@ -45,8 +45,8 @@ module domain-redirect {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-certificate | n/a |
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
+| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-certificate |  |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
 
 ## Resources
 

--- a/aws-cloudfront-logs-bucket/README.md
+++ b/aws-cloudfront-logs-bucket/README.md
@@ -41,7 +41,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket | n/a |
+| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket |  |
 
 ## Resources
 

--- a/aws-cloudwatch-log-retention-manager/README.md
+++ b/aws-cloudwatch-log-retention-manager/README.md
@@ -29,7 +29,7 @@ module log-retention-manager {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
 
 ## Resources
 

--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -34,7 +34,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct | n/a |
+| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct |  |
 
 ## Resources
 
@@ -54,7 +54,6 @@ No requirements.
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name for the role | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source aws account id to allow sts:AssumeRole. DEPRECATED: Please use source\_account\_ids | `string` | n/a | yes |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source aws account ids to allow sts:AssumeRole | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-bless/main.tf
+++ b/aws-iam-role-bless/main.tf
@@ -17,7 +17,6 @@ module "client" {
 
   role_name          = var.role_name
   iam_path           = var.iam_path
-  source_account_id  = var.source_account_id
   source_account_ids = var.source_account_ids
   env                = var.env
   owner              = var.owner

--- a/aws-iam-role-bless/module_test.go
+++ b/aws-iam-role-bless/module_test.go
@@ -17,9 +17,9 @@ func TestIAMRoleBless(t *testing.T) {
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
-					"bless_lambda_arns": []string{"arn:aws:lambda:us-west-2:111111111111:function:test"},
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
+					"bless_lambda_arns":  []string{"arn:aws:lambda:us-west-2:111111111111:function:test"},
 				},
 			)
 		},

--- a/aws-iam-role-bless/variables.tf
+++ b/aws-iam-role-bless/variables.tf
@@ -3,11 +3,6 @@ variable "role_name" {
   description = "The name for the role"
 }
 
-variable "source_account_id" {
-  type        = string
-  description = "The source aws account id to allow sts:AssumeRole. DEPRECATED: Please use source_account_ids"
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -42,7 +42,6 @@ No modules.
 | <a name="input_s3_bucket_prefixes"></a> [s3\_bucket\_prefixes](#input\_s3\_bucket\_prefixes) | Limits role permissions to buckets with specific prefixes. Empty for all buckets. | `list(any)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-cloudfront-poweruser/main.tf
+++ b/aws-iam-role-cloudfront-poweruser/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-cloudfront-poweruser/module_test.go
+++ b/aws-iam-role-cloudfront-poweruser/module_test.go
@@ -19,9 +19,9 @@ func TestAWSIAMRoleCloudfrontPoweruser(t *testing.T) {
 				tftest.IAMRegion,
 
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
-					"source_account_id": curAcct,
+					"role_name":          random.UniqueId(),
+					"iam_path":           fmt.Sprintf("/%s/", random.UniqueId()),
+					"source_account_ids": []string{curAcct},
 				},
 			)
 		},

--- a/aws-iam-role-cloudfront-poweruser/variables.tf
+++ b/aws-iam-role-cloudfront-poweruser/variables.tf
@@ -17,12 +17,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -51,7 +51,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the role. | `string` | n/a | yes |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -9,7 +9,7 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
+    for_each = var.source_account_ids
     content {
       principals {
         type        = "AWS"

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -20,17 +20,6 @@ data "aws_iam_policy_document" "assume-role" {
   }
 
   dynamic "statement" {
-    for_each = var.source_account_ids
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole", "sts:TagSession"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = compact([var.saml_idp_arn])
     content {
       principals {

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -18,8 +18,8 @@ func TestAWSIAMRoleCrossAcct(t *testing.T) {
 				tftest.IAMRegion,
 
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
 				},
 			)
 		},

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -8,12 +8,6 @@ variable "iam_path" {
   description = "The IAM path to put this role in."
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -55,7 +55,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | n/a | yes |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-ec2-poweruser/main.tf
+++ b/aws-iam-role-ec2-poweruser/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-ec2-poweruser/module_test.go
+++ b/aws-iam-role-ec2-poweruser/module_test.go
@@ -17,8 +17,8 @@ func TestAWSIAMRoleEC2Poweruser(t *testing.T) {
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
 				},
 			)
 		},

--- a/aws-iam-role-ec2-poweruser/variables.tf
+++ b/aws-iam-role-ec2-poweruser/variables.tf
@@ -7,12 +7,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -55,7 +55,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | n/a | yes |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-ecs-poweruser/main.tf
+++ b/aws-iam-role-ecs-poweruser/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-ecs-poweruser/module_test.go
+++ b/aws-iam-role-ecs-poweruser/module_test.go
@@ -18,8 +18,8 @@ func TestAWSIAMRoleEcsPoweruser(t *testing.T) {
 				tftest.IAMRegion,
 
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
 				},
 			)
 		},

--- a/aws-iam-role-ecs-poweruser/variables.tf
+++ b/aws-iam-role-ecs-poweruser/variables.tf
@@ -7,12 +7,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -39,8 +39,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | `"infraci"` | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Pleaase use source\_account\_ids. | `string` | `""` | no |
-| <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 | <a name="input_terraform_state_lock_dynamodb_arns"></a> [terraform\_state\_lock\_dynamodb\_arns](#input\_terraform\_state\_lock\_dynamodb\_arns) | ARNs of the state file DynamoDB tables | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-infraci/main.tf
+++ b/aws-iam-role-infraci/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-infraci/module_test.go
+++ b/aws-iam-role-infraci/module_test.go
@@ -18,9 +18,9 @@ func TestAWSIAMRoleInfraCI(t *testing.T) {
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
-					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
+					"iam_path":           fmt.Sprintf("/%s/", random.UniqueId()),
 				},
 			)
 		},

--- a/aws-iam-role-infraci/variables.tf
+++ b/aws-iam-role-infraci/variables.tf
@@ -18,6 +18,12 @@ variable "saml_idp_arn" {
   description = "The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided."
 }
 
+variable "source_account_ids" {
+  type        = set(string)
+  default     = []
+  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
+}
+
 variable "project" {
   type        = string
   description = "Project for tagging and naming. See [doc](../README.md#consistent-tagging)"

--- a/aws-iam-role-infraci/variables.tf
+++ b/aws-iam-role-infraci/variables.tf
@@ -12,18 +12,6 @@ variable "terraform_state_lock_dynamodb_arns" {
   description = "ARNs of the state file DynamoDB tables"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Pleaase use source_account_ids."
-}
-
-variable "source_account_ids" {
-  type        = set(string)
-  default     = []
-  description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
-}
-
 variable "saml_idp_arn" {
   type        = string
   default     = ""

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -56,7 +56,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | `"poweruser"` | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-poweruser/main.tf
+++ b/aws-iam-role-poweruser/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole", "sts:TagSession"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-poweruser/variables.tf
+++ b/aws-iam-role-poweruser/variables.tf
@@ -3,12 +3,6 @@ variable "role_name" {
   default = "poweruser"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -58,7 +58,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | `"readonly"` | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-readonly/main.tf
+++ b/aws-iam-role-readonly/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole", "sts:TagSession"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-readonly/variables.tf
+++ b/aws-iam-role-readonly/variables.tf
@@ -7,12 +7,6 @@ variable "role_name" {
   default = "readonly"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -52,7 +52,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | `"route53domains-poweruser"` | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-route53domains-poweruser/main.tf
+++ b/aws-iam-role-route53domains-poweruser/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-route53domains-poweruser/variables.tf
+++ b/aws-iam-role-route53domains-poweruser/variables.tf
@@ -8,12 +8,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -46,7 +46,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of this role. | `string` | `"security-audit"` | no |
 | <a name="input_saml_idp_arn"></a> [saml\_idp\_arn](#input\_saml\_idp\_arn) | The AWS SAML IDP arn to establish a trust relationship. Ignored if empty or not provided. | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_source_account_id"></a> [source\_account\_id](#input\_source\_account\_id) | The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source\_account\_ids. | `string` | `""` | no |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws-iam-role-security-audit/main.tf
+++ b/aws-iam-role-security-audit/main.tf
@@ -9,17 +9,6 @@ locals {
 
 data "aws_iam_policy_document" "assume-role" {
   dynamic "statement" {
-    for_each = compact([var.source_account_id])
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-      actions = ["sts:AssumeRole"]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.source_account_ids
     content {
       principals {

--- a/aws-iam-role-security-audit/module_test.go
+++ b/aws-iam-role-security-audit/module_test.go
@@ -17,9 +17,9 @@ func TestAWSIAMRoleReadOnly(t *testing.T) {
 			return tftest.Options(
 				tftest.IAMRegion,
 				map[string]interface{}{
-					"role_name":         random.UniqueId(),
-					"source_account_id": curAcct,
-					"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
+					"role_name":          random.UniqueId(),
+					"source_account_ids": []string{curAcct},
+					"iam_path":           fmt.Sprintf("/%s/", random.UniqueId()),
 				},
 			)
 		},

--- a/aws-iam-role-security-audit/variables.tf
+++ b/aws-iam-role-security-audit/variables.tf
@@ -9,12 +9,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "source_account_id" {
-  type        = string
-  default     = ""
-  description = "The source AWS account to establish a trust relationship. Ignored if empty or not provided. DEPRECATED: Please use source_account_ids."
-}
-
 variable "source_account_ids" {
   type        = set(string)
   default     = []

--- a/aws-lambda-edge-add-security-headers/README.md
+++ b/aws-lambda-edge-add-security-headers/README.md
@@ -49,7 +49,7 @@ resource aws_cloudfront_distribution cf {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
 
 ## Resources
 

--- a/aws-params-reader-policy/module_test.go
+++ b/aws-params-reader-policy/module_test.go
@@ -22,9 +22,9 @@ func TestAWSParamsSecretReaderPolicy(t *testing.T) {
 	setupTerraformOptions := tftest.Options(
 		tftest.IAMRegion,
 		map[string]interface{}{
-			"role_name":         random.UniqueId(),
-			"iam_path":          fmt.Sprintf("/%s/", random.UniqueId()),
-			"source_account_id": curAcct,
+			"role_name":          random.UniqueId(),
+			"iam_path":           fmt.Sprintf("/%s/", random.UniqueId()),
+			"source_account_ids": []string{curAcct},
 		},
 	)
 	setupTerraformOptions.TerraformDir = "../aws-iam-role-crossacct"

--- a/aws-single-page-static-site/README.md
+++ b/aws-single-page-static-site/README.md
@@ -54,7 +54,7 @@ module "site" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
 
 ## Resources
 

--- a/aws-single-page-static-site/module_test.go
+++ b/aws-single-page-static-site/module_test.go
@@ -16,7 +16,7 @@ func TestAwsSinglePageStaticSite(t *testing.T) {
 			route53ZoneID := tftest.EnvVar(tftest.EnvRoute53ZoneID)
 
 			options := tftest.Options(
-				tftest.DefaultRegion, // us-east-1
+				"us-east-1", // tftest.DefaultRegion is us-west-2, so we have to hardcode this value
 				map[string]interface{}{
 					"subdomain":           subdomain,
 					"aws_route53_zone_id": route53ZoneID,

--- a/aws-sns-lambda/README.md
+++ b/aws-sns-lambda/README.md
@@ -62,7 +62,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
 
 ## Resources
 

--- a/bless-ca/README.md
+++ b/bless-ca/README.md
@@ -110,8 +110,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
-| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs | n/a |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs |  |
 
 ## Resources
 

--- a/github-webhooks-to-s3/README.md
+++ b/github-webhooks-to-s3/README.md
@@ -39,9 +39,9 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs | n/a |
-| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket | n/a |
-| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params | n/a |
+| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs |  |
+| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket |  |
+| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params |  |
 
 ## Resources
 


### PR DESCRIPTION
This variable duplication confused me while I was debugging PR #320 . I think we're ready to deprecate it.

This PR changes 3 things:
* TF Module definition
* golang setup tests
* README.md files