### PR TITLE
feat(aws-iam-role): Allow configuring SAML IDPs and SAML:aud

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -45,7 +45,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
 
 ## Resources
 

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -44,7 +44,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora |  |
+| <a name="module_aurora"></a> [aurora](#module\_aurora) | ../aws-aurora | n/a |
 
 ## Resources
 

--- a/aws-cloudfront-domain-redirect/README.md
+++ b/aws-cloudfront-domain-redirect/README.md
@@ -45,8 +45,8 @@ module domain-redirect {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-certificate |  |
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
+| <a name="module_cert"></a> [cert](#module\_cert) | ../aws-acm-certificate | n/a |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
 
 ## Resources
 

--- a/aws-cloudfront-logs-bucket/README.md
+++ b/aws-cloudfront-logs-bucket/README.md
@@ -41,7 +41,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket |  |
+| <a name="module_aws-cloudfront-logs-bucket"></a> [aws-cloudfront-logs-bucket](#module\_aws-cloudfront-logs-bucket) | ../aws-s3-private-bucket | n/a |
 
 ## Resources
 

--- a/aws-cloudwatch-log-retention-manager/README.md
+++ b/aws-cloudwatch-log-retention-manager/README.md
@@ -29,7 +29,7 @@ module log-retention-manager {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/aws-iam-role-admin/README.md
+++ b/aws-iam-role-admin/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_role"></a> [role](#module\_role) | ../aws-iam-role-crossacct |  |
+| <a name="module_role"></a> [role](#module\_role) | ../aws-iam-role-crossacct | n/a |
 
 ## Resources
 

--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -34,7 +34,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct |  |
+| <a name="module_client"></a> [client](#module\_client) | ../aws-iam-role-crossacct | n/a |
 
 ## Resources
 

--- a/aws-iam-role-ci-user-manager/README.md
+++ b/aws-iam-role-ci-user-manager/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -17,7 +17,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -31,7 +31,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -33,7 +33,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -32,7 +32,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -17,7 +17,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -31,7 +31,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -35,7 +35,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -32,7 +32,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -27,7 +27,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy |  |
+| <a name="module_assume_role_policy"></a> [assume\_role\_policy](#module\_assume\_role\_policy) | ../aws-assume-role-policy | n/a |
 
 ## Resources
 

--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -64,6 +64,7 @@ No modules.
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM role description. | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name. | `string` | n/a | yes |
 | <a name="input_saml_idp_arns"></a> [saml\_idp\_arns](#input\_saml\_idp\_arns) | The AWS SAML IDP arns to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| <a name="input_saml_idps"></a> [saml\_idps](#input\_saml\_idps) | The AWS SAML IDPs to establish a trust relationship. Ignored if empty or missing. | <pre>list(object({<br>    saml_idp_arns : list(string),<br>    saml_auds : list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -64,7 +64,7 @@ No modules.
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM role description. | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name. | `string` | n/a | yes |
 | <a name="input_saml_idp_arns"></a> [saml\_idp\_arns](#input\_saml\_idp\_arns) | The AWS SAML IDP arns to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
-| <a name="input_saml_idps"></a> [saml\_idps](#input\_saml\_idps) | The AWS SAML IDPs to establish a trust relationship. Ignored if empty or missing. | <pre>list(object({<br>    saml_idp_arns : list(string),<br>    saml_auds : list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_saml_idps"></a> [saml\_idps](#input\_saml\_idps) | The AWS SAML IDPs to establish a trust relationship.<br>  Ignored if empty or missing."<br>  If unsure, saml\_auds would typically be ["https://signin.aws.amazon.com/saml"]. | <pre>list(object({<br>    saml_idp_arns : list(string),<br>    saml_auds : list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 
 ## Outputs

--- a/aws-iam-role/variables.tf
+++ b/aws-iam-role/variables.tf
@@ -47,8 +47,12 @@ variable "saml_idps" {
     saml_auds : list(string)
   }))
   default     = []
-  description = "The AWS SAML IDPs to establish a trust relationship. Ignored if empty or missing."
+  description = <<EOF
+  The AWS SAML IDPs to establish a trust relationship.
+  Ignored if empty or missing."
+  If unsure, saml_auds would typically be ["https://signin.aws.amazon.com/saml"].
 
+  EOF
 }
 
 variable "role_name" {

--- a/aws-iam-role/variables.tf
+++ b/aws-iam-role/variables.tf
@@ -35,10 +35,20 @@ variable "max_session_duration" {
   default     = 3600
 }
 
+// DEPRECATED: use saml_idps instead
 variable "saml_idp_arns" {
   type        = set(string)
   default     = []
   description = "The AWS SAML IDP arns to establish a trust relationship. Ignored if empty or not provided."
+}
+variable "saml_idps" {
+  type = list(object({
+    saml_idp_arns : list(string),
+    saml_auds : list(string)
+  }))
+  default     = []
+  description = "The AWS SAML IDPs to establish a trust relationship. Ignored if empty or missing."
+
 }
 
 variable "role_name" {

--- a/aws-lambda-edge-add-security-headers/README.md
+++ b/aws-lambda-edge-add-security-headers/README.md
@@ -49,7 +49,7 @@ resource aws_cloudfront_distribution cf {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/aws-single-page-static-site/README.md
+++ b/aws-single-page-static-site/README.md
@@ -54,7 +54,7 @@ module "site" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers |  |
+| <a name="module_security_headers_lambda"></a> [security\_headers\_lambda](#module\_security\_headers\_lambda) | ../aws-lambda-edge-add-security-headers | n/a |
 
 ## Resources
 

--- a/aws-sns-lambda/README.md
+++ b/aws-sns-lambda/README.md
@@ -62,7 +62,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
 
 ## Resources
 

--- a/bless-ca/README.md
+++ b/bless-ca/README.md
@@ -110,8 +110,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function |  |
-| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs |  |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | ../aws-lambda-function | n/a |
+| <a name="module_logs_policy"></a> [logs\_policy](#module\_logs\_policy) | ../aws-iam-policy-cwlogs | n/a |
 
 ## Resources
 

--- a/github-webhooks-to-s3/README.md
+++ b/github-webhooks-to-s3/README.md
@@ -39,9 +39,9 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs |  |
-| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket |  |
-| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params |  |
+| <a name="module_attach-logs"></a> [attach-logs](#module\_attach-logs) | ../aws-iam-policy-cwlogs | n/a |
+| <a name="module_bucket"></a> [bucket](#module\_bucket) | ../aws-s3-private-bucket | n/a |
+| <a name="module_github_secret"></a> [github\_secret](#module\_github\_secret) | ../aws-ssm-params | n/a |
 
 ## Resources
 


### PR DESCRIPTION
aws-iam-role: Allow specifying the SAML:aud condition on SAML IDPs. We typically want this in situations where we can do credentials passthrough.


There are also a bunch of stalre READMEs that got updated