### PR TITLE
chore: adding release-please to cztack

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          release-type: simple
+          package-name: release-please-action
+          token: ${{secrets.PRODSEC_RELEASE_KEY_1PASS}} # find this secret in the ProdSec 1password


### PR DESCRIPTION
### Summary
This PR adds the release-please Github action to the repo. The release-please action will take care of all releases by creating a release PR that can be merged whenever a release is ready to be made.

#### Features

- It finds the commit messages to main and adds them to the changelog automatically
- It versions the repo based on the types of conventional commits
- It automatically publishes a release when the release PR is merged
- It is run by the prodsec github user whose credentials can be found in 1password in the prodsec vault

### References
* [Release-please](https://github.com/googleapis/release-please)