### PR TITLE
fix: release-please version pin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v2.33.0
         with:
           release-type: simple
           package-name: release-please-action


### PR DESCRIPTION
### Summary
This PR adds a version pin to the release-please action because I have noticed a bug in the main branch a few times. As a way to make sure we don't have flaky changelog, pinning a known working version should make that more stable.
