### PR TITLE
fix: dependabot no mergebot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 1
-  labels:
-  - bot/merge


### PR DESCRIPTION
Mergebot prevents dependabot from rebasing PRs. Don't tag with mergebot label

