### PR TITLE
support slow start for fargate.

### DIFF
--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -217,6 +217,7 @@ No requirements.
 | <a name="input_registry_secretsmanager_arn"></a> [registry\_secretsmanager\_arn](#input\_registry\_secretsmanager\_arn) | ARN for AWS Secrets Manager secret for credentials to private registry | `string` | `null` | no |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | Zone in which to create an alias record to the ALB. | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
+| <a name="input_slow_start"></a> [slow\_start](#input\_slow\_start) | Seconds for targets to warm up before the load balancer sends them a full share of requests. 30-900 seconds or 0 to disable. | `number` | `60` | no |
 | <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | ELB policy to determine which SSL/TLS encryption protocols are enabled. Probably don't touch this. | `string` | `null` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain in the zone. Final domain name will be subdomain.zone | `string` | n/a | yes |
 | <a name="input_tag_service"></a> [tag\_service](#input\_tag\_service) | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | `bool` | `true` | no |

--- a/aws-ecs-service-fargate/alb.tf
+++ b/aws-ecs-service-fargate/alb.tf
@@ -15,6 +15,7 @@ resource "aws_lb_target_group" "service" {
   target_type = "ip"
 
   deregistration_delay = 60
+  slow_start           = var.slow_start
 
   health_check {
     path     = var.health_check_path

--- a/aws-ecs-service-fargate/variables.tf
+++ b/aws-ecs-service-fargate/variables.tf
@@ -208,3 +208,9 @@ variable "volumes" {
   default     = []
   description = "Volumes defined per the efs task definition [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#volume)"
 }
+
+variable "slow_start" {
+  description = "Seconds for targets to warm up before the load balancer sends them a full share of requests. 30-900 seconds or 0 to disable."
+  type        = number
+  default     = 60
+}


### PR DESCRIPTION
### Summary
Support a slow start parameter for Fargate services to bring their configuration to parity with EC2 services

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
