### PR TITLE
feat: Variablize deletion_protection for aurora-postgres module

### DIFF
--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -4,7 +4,7 @@ locals {
   # name omits the minor version e.g. "aurora-postgresql10". We parse the
   # engine version to distinguish the 2 cases.
   split_engine_version  = split(".", var.engine_version)
-  params_engine_version = local.split_engine_version[0] == "9" ? join(".", slice(local.split_engine_version, 0, 2)) : local.split_engine_version[0]
+  params_engine_version = local.split_engine_version[0] == "9" ? var.engine_version : local.split_engine_version[0]
 }
 
 module "aurora" {

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -22,7 +22,7 @@ module "aurora" {
   database_subnet_group               = var.database_subnet_group
   database_password                   = var.database_password
   database_username                   = var.database_username
-  deletion_protection                 = var.deletion_protection
+  db_deletion_protection              = var.db_deletion_protection
   db_parameters                       = var.db_parameters
   rds_cluster_parameters              = var.rds_cluster_parameters
   iam_database_authentication_enabled = var.iam_database_authentication_enabled

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -22,6 +22,7 @@ module "aurora" {
   database_subnet_group               = var.database_subnet_group
   database_password                   = var.database_password
   database_username                   = var.database_username
+  deletion_protection                 = var.deletion_protection
   db_parameters                       = var.db_parameters
   rds_cluster_parameters              = var.rds_cluster_parameters
   iam_database_authentication_enabled = var.iam_database_authentication_enabled

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -1,10 +1,7 @@
 locals {
-  # For Aurora postgres, the parameter group names before Postgres version 10
-  # are named like "aurora-postgresql9.6", but for version 10 and above the
-  # name omits the minor version e.g. "aurora-postgresql10". We parse the
-  # engine version to distinguish the 2 cases.
+  # For version 10 and above the name omits the minor version e.g. "aurora-postgresql10".
   split_engine_version  = split(".", var.engine_version)
-  params_engine_version = local.split_engine_version[0] == "9" ? var.engine_version : local.split_engine_version[0]
+  params_engine_version = local.split_engine_version[0]
 }
 
 module "aurora" {

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -15,7 +15,7 @@ func TestAWSAuroraPostgresInit(t *testing.T) {
 }
 
 func TestAWSAuroraPostgresDefaults(t *testing.T) {
-	versions := []string{"9.6.22", "10.14", "11.15"}
+	versions := []string{"10.14", "11.15"}
 
 	for _, version := range versions {
 		v := version

--- a/aws-aurora-postgres/module_test.go
+++ b/aws-aurora-postgres/module_test.go
@@ -15,7 +15,7 @@ func TestAWSAuroraPostgresInit(t *testing.T) {
 }
 
 func TestAWSAuroraPostgresDefaults(t *testing.T) {
-	versions := []string{"9.6", "10.12", "11.7"}
+	versions := []string{"9.6.22", "10.14", "11.15"}
 
 	for _, version := range versions {
 		v := version

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -139,5 +139,5 @@ variable "auto_minor_version_upgrade" {
 
 variable "db_deletion_protection" {
   type    = string
-  default = true
+  default = false
 }

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -136,3 +136,8 @@ variable "auto_minor_version_upgrade" {
   description = "Set the databases to automatically upgrade minor versions. WARNING - if this is enabled, make sure engine_version is set to a *prefix* rather that a specific version so that TF won't try to downgrade DB's that have been auto-upgraded. Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version"
   default     = false
 }
+
+variable "db_deletion_protection" {
+  type    = string
+  default = false
+}

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -139,5 +139,5 @@ variable "auto_minor_version_upgrade" {
 
 variable "db_deletion_protection" {
   type    = string
-  default = false
+  default = true
 }


### PR DESCRIPTION
### Summary
Adding deletion_protection as a variable. Before, this defaulted to false because the `aws-aurora` module defaulted this variable to false.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
