### PR TITLE
fix: remove dep on buildbot token

### DIFF
--- a/.github/workflows/mods.yml
+++ b/.github/workflows/mods.yml
@@ -4,9 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
           go-version: '1.15.2'


### PR DESCRIPTION
### Summary
This PR removes the dependency on the buildbot token. I don't think it is needed anymore and by default will use the GITHUB_TOKEN.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
