### PR TITLE
feat: Update `aws-aurora` module to not use `params_engine_version`

### DIFF
--- a/aws-aurora-mysql/README.md
+++ b/aws-aurora-mysql/README.md
@@ -74,7 +74,6 @@ No resources.
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create in this cluster. | `string` | `1` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | If provided, storage will be encrypted with this key, otherwise an AWS-managed key is used. (Encryption is always on). | `string` | `""` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
-| <a name="input_params_engine_version"></a> [params\_engine\_version](#input\_params\_engine\_version) | The engine version to be appended to the parameter group family. | `string` | `"5.7"` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | n/a | `string` | `false` | no |
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Avoid doing this - it gives access to the open internet. | `string` | `false` | no |

--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -1,8 +1,7 @@
 module "aurora" {
-  source                = "../aws-aurora"
-  engine                = "aurora-mysql"
-  engine_version        = var.engine_version
-  params_engine_version = var.params_engine_version
+  source         = "../aws-aurora"
+  engine         = "aurora-mysql"
+  engine_version = var.engine_version
 
   project = var.project
   env     = var.env

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -24,7 +24,7 @@ func TestAWSAuroraMysqlDefaults(t *testing.T) {
 			return tftest.Options(
 				tftest.DefaultRegion,
 				map[string]interface{}{
-
+					"engine_version":        "10.7",
 					"vpc_id":                vpc,
 					"database_subnet_group": databaseSubnetGroup,
 					"database_password":     databasePassword,

--- a/aws-aurora-mysql/module_test.go
+++ b/aws-aurora-mysql/module_test.go
@@ -24,7 +24,6 @@ func TestAWSAuroraMysqlDefaults(t *testing.T) {
 			return tftest.Options(
 				tftest.DefaultRegion,
 				map[string]interface{}{
-					"engine_version":        "10.7",
 					"vpc_id":                vpc,
 					"database_subnet_group": databaseSubnetGroup,
 					"database_password":     databasePassword,

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -175,12 +175,6 @@ variable "engine_version" {
   default     = "5.7"
 }
 
-variable "params_engine_version" {
-  type        = string
-  description = "The engine version to be appended to the parameter group family."
-  default     = "5.7"
-}
-
 variable "ca_cert_identifier" {
   type        = string
   description = "Identifier for the certificate authority. rds-ca-2019 is the latest available version."

--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -61,7 +61,7 @@ No resources.
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | Password for user that will be created. | `string` | n/a | yes |
 | <a name="input_database_subnet_group"></a> [database\_subnet\_group](#input\_database\_subnet\_group) | The name of an existing database subnet group to use. | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | Default user to be created. | `string` | n/a | yes |
-| <a name="input_db_deletion_protection"></a> [db\_deletion\_protection](#input\_db\_deletion\_protection) | n/a | `string` | `false` | no |
+| <a name="input_db_deletion_protection"></a> [db\_deletion\_protection](#input\_db\_deletion\_protection) | If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true | `string` | `false` | no |
 | <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | Instance params you can set. [Doc](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.html#AuroraPostgreSQL.Reference.Parameters.Instance) | `list(any)` | `[]` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version of Postgres to use. This should be a *prefix* if auto version upgrades are enabled. (Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version) | `string` | `"10"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -5,10 +5,9 @@ locals {
 }
 
 module "aurora" {
-  source                = "../aws-aurora"
-  engine                = "aurora-postgresql"
-  engine_version        = var.engine_version
-  params_engine_version = local.params_engine_version
+  source         = "../aws-aurora"
+  engine         = "aurora-postgresql"
+  engine_version = var.engine_version
 
   project = var.project
   env     = var.env

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -138,6 +138,7 @@ variable "auto_minor_version_upgrade" {
 }
 
 variable "db_deletion_protection" {
-  type    = string
-  default = false
+  type        = string
+  description = "If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true"
+  default     = false
 }

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -47,14 +47,13 @@ No modules.
 | <a name="input_engine"></a> [engine](#input\_engine) | n/a | `string` | n/a | yes |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
-| <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | n/a | `string` | `true` | no |
+| <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specifies whether or not mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. | `string` | `true` | no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | A list of CIDR blocks that should be allowed to communicate with this Aurora cluster. | `list(string)` | `[]` | no |
 | <a name="input_ingress_security_groups"></a> [ingress\_security\_groups](#input\_ingress\_security\_groups) | A list of security groups that should be allowed to communicate with this Aurora cluster. | `list(string)` | `[]` | no |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | n/a | `string` | `"db.t2.small"` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | n/a | `string` | `1` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | If supplied, RDS will use this key to encrypt data at rest. Empty string means that RDS will use an AWS-managed key. Encryption is always on with this module. | `string` | `""` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
-| <a name="input_params_engine_version"></a> [params\_engine\_version](#input\_params\_engine\_version) | n/a | `string` | n/a | yes |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | n/a | `string` | `true` | no |
 | <a name="input_port"></a> [port](#input\_port) | n/a | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -9,6 +9,10 @@ locals {
     service   = var.service
     owner     = var.owner
   }
+
+  # For version 10 and above the name omits the minor version e.g. "aurora-postgresql10".
+  split_engine_version  = split(".", var.engine_version)
+  params_engine_version = local.split_engine_version[0]
 }
 
 resource "aws_security_group" "rds" {
@@ -98,7 +102,7 @@ resource "aws_rds_cluster_instance" "db" {
 
 resource "aws_rds_cluster_parameter_group" "db" {
   name        = local.name
-  family      = "${var.engine}${var.params_engine_version}"
+  family      = "${var.engine}${local.params_engine_version}"
   description = "RDS default cluster parameter group"
 
   dynamic "parameter" {
@@ -115,7 +119,7 @@ resource "aws_rds_cluster_parameter_group" "db" {
 
 resource "aws_db_parameter_group" "db" {
   name   = local.name
-  family = "${var.engine}${var.params_engine_version}"
+  family = "${var.engine}${local.params_engine_version}"
 
   dynamic "parameter" {
     for_each = var.db_parameters

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -12,7 +12,7 @@ locals {
 
   # For version 10 and above the name omits the minor version e.g. "aurora-postgresql10".
   split_engine_version  = split(".", var.engine_version)
-  params_engine_version = local.split_engine_version[0]
+  params_engine_version = var.engine != "aurora-mysql" ? local.split_engine_version[0] : var.engine_version
 }
 
 resource "aws_security_group" "rds" {

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -13,10 +13,11 @@ func TestAWSAurora(t *testing.T) {
 			return tftest.Options(
 				tftest.DefaultRegion,
 				map[string]interface{}{
-					"database_name": tftest.UniqueID(),
-					"port":          "5432",
-					"engine":        "aurora-postgresql",
-					"vpc_id":        "vpc-12345",
+					"database_name":  tftest.UniqueID(),
+					"engine_version": "8.0",
+					"port":           "5432",
+					"engine":         "aurora-postgresql",
+					"vpc_id":         "vpc-12345",
 
 					"project":               tftest.UniqueID(),
 					"service":               tftest.UniqueID(),

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -14,7 +14,7 @@ func TestAWSAurora(t *testing.T) {
 				tftest.DefaultRegion,
 				map[string]interface{}{
 					"database_name":  tftest.UniqueID(),
-					"engine_version": "8.0",
+					"engine_version": "10.7",
 					"port":           "5432",
 					"engine":         "aurora-postgresql",
 					"vpc_id":         "vpc-12345",

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -13,12 +13,11 @@ func TestAWSAurora(t *testing.T) {
 			return tftest.Options(
 				tftest.DefaultRegion,
 				map[string]interface{}{
-					"database_name":         tftest.UniqueID(),
-					"engine_version":        "10.7",
-					"params_engine_version": "10",
-					"port":                  "5432",
-					"engine":                "aurora-postgresql",
-					"vpc_id":                "vpc-12345",
+					"database_name":  tftest.UniqueID(),
+					"engine_version": "10.7",
+					"port":           "5432",
+					"engine":         "aurora-postgresql",
+					"vpc_id":         "vpc-12345",
 
 					"project":               tftest.UniqueID(),
 					"service":               tftest.UniqueID(),

--- a/aws-aurora/module_test.go
+++ b/aws-aurora/module_test.go
@@ -13,11 +13,10 @@ func TestAWSAurora(t *testing.T) {
 			return tftest.Options(
 				tftest.DefaultRegion,
 				map[string]interface{}{
-					"database_name":  tftest.UniqueID(),
-					"engine_version": "10.7",
-					"port":           "5432",
-					"engine":         "aurora-postgresql",
-					"vpc_id":         "vpc-12345",
+					"database_name": tftest.UniqueID(),
+					"port":          "5432",
+					"engine":        "aurora-postgresql",
+					"vpc_id":        "vpc-12345",
 
 					"project":               tftest.UniqueID(),
 					"service":               tftest.UniqueID(),

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -112,13 +112,10 @@ variable "engine_version" {
   type = string
 }
 
-variable "params_engine_version" {
-  type = string
-}
-
 variable "iam_database_authentication_enabled" {
-  type    = string
-  default = true
+  type        = string
+  description = "Specifies whether or not mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled."
+  default     = true
 }
 
 variable "enabled_cloudwatch_logs_exports" {


### PR DESCRIPTION
`params_engine_version` was being calculated for naming purposes and wasn't being used as an actual input. Removing and reconfiguring the `aws-aurora` module.