### PR TITLE
feat: Attach ssm permissions to ecs fargate job module

### DIFF
--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -72,11 +72,11 @@ No modules.
 | <a name="input_registry_secretsmanager_arn"></a> [registry\_secretsmanager\_arn](#input\_registry\_secretsmanager\_arn) | ARN for AWS Secrets Manager secret for credentials to private registry | `string` | `null` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group to use for the Fargate task. | `list(string)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
-| <a name="input_ssm_arn"></a> [ssm\_arn](#input\_ssm\_arn) | Parameter Store ARN | `string` | `null` | no |
 | <a name="input_tag_service"></a> [tag\_service](#input\_tag\_service) | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | `bool` | `true` | no |
 | <a name="input_task_definition"></a> [task\_definition](#input\_task\_definition) | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | `string` | `null` | no |
 | <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | n/a | `string` | n/a | yes |
 | <a name="input_task_subnets"></a> [task\_subnets](#input\_task\_subnets) | Subnets to launch Fargate task in. | `list(string)` | `[]` | no |
+| <a name="input_var.ssm_parameter_store_arns"></a> [var.ssm\_parameter\_store\_arns](#input\_var.ssm\_parameter\_store\_arns) | List of SSM Parameter Store ARNs. If present, allows ECS task to make ssm:GetParameters call. | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/aws-ecs-job-fargate/README.md
+++ b/aws-ecs-job-fargate/README.md
@@ -44,11 +44,14 @@ No modules.
 | [aws_ecs_service.job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.unmanaged-job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.task_execution_role_ssm_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.task_execution_role_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.task_execution_role_ssm_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.registry_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ssm_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -69,6 +72,7 @@ No modules.
 | <a name="input_registry_secretsmanager_arn"></a> [registry\_secretsmanager\_arn](#input\_registry\_secretsmanager\_arn) | ARN for AWS Secrets Manager secret for credentials to private registry | `string` | `null` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group to use for the Fargate task. | `list(string)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging). | `string` | n/a | yes |
+| <a name="input_ssm_arn"></a> [ssm\_arn](#input\_ssm\_arn) | Parameter Store ARN | `string` | `null` | no |
 | <a name="input_tag_service"></a> [tag\_service](#input\_tag\_service) | Apply cost tags to the ECS service. Only specify false for backwards compatibility with old ECS services. | `bool` | `true` | no |
 | <a name="input_task_definition"></a> [task\_definition](#input\_task\_definition) | JSON to describe task. If omitted, defaults to a stub task that is expected to be managed outside of Terraform. | `string` | `null` | no |
 | <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | n/a | `string` | n/a | yes |

--- a/aws-ecs-job-fargate/iam.tf
+++ b/aws-ecs-job-fargate/iam.tf
@@ -43,24 +43,24 @@ resource "aws_iam_role_policy" "task_execution_role_secretsmanager" {
 }
 
 data "aws_iam_policy_document" "ssm_permission" {
-  count = var.ssm_arn != null ? 1 : 0
+  count = var.ssm_parameter_store_arns != null ? 1 : 0
 
   statement {
     actions = [
       "ssm:GetParameters",
     ]
 
-    resources = [var.ssm_arn]
+    resources = var.ssm_parameter_store_arns
   }
 }
 
 resource "aws_iam_policy" "task_execution_role_ssm_permission" {
-  count  = var.ssm_arn != null ? 1 : 0
+  count  = var.ssm_parameter_store_arns != null ? 1 : 0
   policy = data.aws_iam_policy_document.ssm_permission[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "task_execution_role_ssm_attachment" {
-  count      = var.ssm_arn != null ? 1 : 0
+  count      = var.ssm_parameter_store_arns != null ? 1 : 0
   role       = aws_iam_role.task_execution_role.name
   policy_arn = aws_iam_policy.task_execution_role_ssm_permission[0].arn
 }

--- a/aws-ecs-job-fargate/iam.tf
+++ b/aws-ecs-job-fargate/iam.tf
@@ -41,3 +41,26 @@ resource "aws_iam_role_policy" "task_execution_role_secretsmanager" {
   role   = aws_iam_role.task_execution_role.name
   policy = data.aws_iam_policy_document.registry_secretsmanager[0].json
 }
+
+data "aws_iam_policy_document" "ssm_permission" {
+  count = var.ssm_arn != null ? 1 : 0
+
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+
+    resources = [var.ssm_arn]
+  }
+}
+
+resource "aws_iam_policy" "task_execution_role_ssm_permission" {
+  count  = var.ssm_arn != null ? 1 : 0
+  policy = data.aws_iam_policy_document.ssm_permission[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_role_ssm_attachment" {
+  count      = var.ssm_arn != null ? 1 : 0
+  role       = aws_iam_role.task_execution_role.name
+  policy_arn = aws_iam_policy.task_execution_role_ssm_permission[0].arn
+}

--- a/aws-ecs-job-fargate/variables.tf
+++ b/aws-ecs-job-fargate/variables.tf
@@ -101,3 +101,9 @@ variable "ordered_placement_strategy" {
   default     = []
   description = "Placement strategy for the task instances."
 }
+
+variable "ssm_arn" {
+  type        = string
+  default     = null
+  description = "Parameter Store ARN"
+}

--- a/aws-ecs-job-fargate/variables.tf
+++ b/aws-ecs-job-fargate/variables.tf
@@ -102,8 +102,8 @@ variable "ordered_placement_strategy" {
   description = "Placement strategy for the task instances."
 }
 
-variable "ssm_arn" {
-  type        = string
+variable "ssm_parameter_store_arns" {
+  type        = list(string)
   default     = null
-  description = "Parameter Store ARN"
+  description = "List of SSM Parameter Store ARNs. If present, allows ECS task to make ssm:GetParameters call."
 }


### PR DESCRIPTION
Adding an option to attach ssm permission to ecs fargate job module. This option can be used when the task running in ECS Fargate needs to use parameter store to retrieve secret credentials.

Background on why we needed this: We plan to deploy a docker image on ECS Fargate which needs to set some authentication credentials as its environment variables. Since these are confidential credentials, we have stored them in parameter store and hence ECS task needs access to that store to retrieve them. 