### PR TITLE
feat: limit the number of character to the maximum 32 chars

### DIFF
--- a/aws-ecs-service-fargate/main.tf
+++ b/aws-ecs-service-fargate/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name = "${var.project}-${var.env}-${var.service}"
+  name = format("%.32s", "${var.project}-${var.env}-${var.service}")
 
   default_tags = {
     managedBy = "terraform"


### PR DESCRIPTION
### Summary
Update to this module to disallow names longer than 32 characters. Here is an example:

~~~
> format("%.32s", "blahhhhhhh-blahhhhhh-blahhhhzzzzzzzzzzzzzzzzzzz")
"blahhhhhhh-blahhhhhh-blahhhhzzzz"
~~~

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
