### PR TITLE
feat: add source role arns

### DIFF
--- a/aws-assume-role-policy/main.tf
+++ b/aws-assume-role-policy/main.tf
@@ -11,6 +11,17 @@ data "aws_iam_policy_document" "assume-role" {
   }
 
   dynamic "statement" {
+    for_each = var.source_role_arns
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+    }
+  }
+
+  dynamic "statement" {
     for_each = var.saml_idp_arns
 
     content {

--- a/aws-assume-role-policy/module_test.go
+++ b/aws-assume-role-policy/module_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/chanzuckerberg/go-misc/tftest"
@@ -24,6 +25,7 @@ func TestAWSAssumeRolePolicy(t *testing.T) {
 				tftest.IAMRegion,
 				map[string]interface{}{
 					"source_account_ids": []string{curAcct},
+					"source_role_arns":   []string{fmt.Sprintf("arn:aws:iam::%s:role/okta-czi-admin", curAcct)},
 					"saml_idp_arns":      []string{"samlARN1", "samlARN2"},
 					"oidc":               oidcCfg,
 				},

--- a/aws-assume-role-policy/variables.tf
+++ b/aws-assume-role-policy/variables.tf
@@ -23,6 +23,11 @@ variable "source_account_ids" {
   description = "The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided."
 }
 
+variable "source_role_arns" {
+  type        = list(string)
+  description = "The source AWS roles to establish a trust relationship. Ignored if empty or not provided."
+}
+
 variable "saml_idp_arns" {
   type        = set(string)
   default     = []

--- a/aws-iam-role-crossacct/main.tf
+++ b/aws-iam-role-crossacct/main.tf
@@ -11,6 +11,7 @@ module "assume_role_policy" {
   source             = "../aws-assume-role-policy"
   source_account_ids = var.source_account_ids
   saml_idp_arns      = var.saml_idp_arns
+  source_role_arns   = var.source_role_arns
   oidc               = var.oidc
   env                = var.env
   owner              = var.owner

--- a/aws-iam-role-crossacct/module_test.go
+++ b/aws-iam-role-crossacct/module_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/chanzuckerberg/go-misc/tftest"
@@ -20,6 +21,7 @@ func TestAWSIAMRoleCrossAcct(t *testing.T) {
 				map[string]interface{}{
 					"role_name":          random.UniqueId(),
 					"source_account_ids": []string{curAcct},
+					"source_role_arns":   []string{fmt.Sprintf("arn:aws:iam::%s:role/okta-czi-admin", curAcct)},
 				},
 			)
 		},

--- a/aws-iam-role-crossacct/variables.tf
+++ b/aws-iam-role-crossacct/variables.tf
@@ -20,6 +20,12 @@ variable "saml_idp_arns" {
   description = "The AWS SAML IDP arns to establish a trust relationship. Ignored if empty or not provided."
 }
 
+variable "source_role_arns" {
+  type        = list(string)
+  description = "The source AWS roles to establish a trust relationship. Ignored if empty or not provided."
+  default = []
+}
+
 variable "oidc" {
   type = list(object(
     {


### PR DESCRIPTION
### Summary
Allows for cross account roles to add a role arn to the trust policy and not just a root account.

### Test Plan
Testing through usage in shared_infra for adding a role arn to the trust policy

### References
https://czi-tech.atlassian.net/browse/CCIE-679
