### PR TITLE
feat: configure log retention in aws-lambda-edge-add-security-headers module

### DIFF
--- a/aws-cloudfront-domain-redirect/README.md
+++ b/aws-cloudfront-domain-redirect/README.md
@@ -62,6 +62,7 @@ module domain-redirect {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_lambda_cloudwatch_log_retention_in_days"></a> [lambda\_cloudwatch\_log\_retention\_in\_days](#input\_lambda\_cloudwatch\_log\_retention\_in\_days) | Retention policy (in days) for Lambda function's logs in Cloudwatch | `number` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-cloudfront-domain-redirect/main.tf
+++ b/aws-cloudfront-domain-redirect/main.tf
@@ -20,6 +20,8 @@ resource "aws_s3_bucket" "redirect_bucket" {
 module "security_headers_lambda" {
   source = "../aws-lambda-edge-add-security-headers"
 
+  lambda_cloudwatch_log_retention_in_days = var.lambda_cloudwatch_log_retention_in_days
+
   project = var.project
   owner   = var.owner
   env     = var.env

--- a/aws-cloudfront-domain-redirect/variables.tf
+++ b/aws-cloudfront-domain-redirect/variables.tf
@@ -32,3 +32,9 @@ variable "target_domain" {
   type        = string
   description = "The domain that will be redirected to."
 }
+
+variable "lambda_cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention policy (in days) for Lambda function's logs in Cloudwatch"
+  default     = null
+}

--- a/aws-lambda-edge-add-security-headers/README.md
+++ b/aws-lambda-edge-add-security-headers/README.md
@@ -63,6 +63,7 @@ resource aws_cloudfront_distribution cf {
 |------|-------------|------|---------|:--------:|
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name for the lambda function. | `string` | `null` | no |
+| <a name="input_lambda_cloudwatch_log_retention_in_days"></a> [lambda\_cloudwatch\_log\_retention\_in\_days](#input\_lambda\_cloudwatch\_log\_retention\_in\_days) | Retention policy (in days) for Lambda function's logs in Cloudwatch | `number` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |

--- a/aws-lambda-edge-add-security-headers/main.tf
+++ b/aws-lambda-edge-add-security-headers/main.tf
@@ -18,13 +18,14 @@ data "archive_file" "lambda" {
 module "lambda" {
   source = "../aws-lambda-function"
 
-  function_name    = var.function_name != null ? var.function_name : replace("${var.project}-${var.env}-${var.service}-security-headers", ".", "-")
-  filename         = data.archive_file.lambda.output_path
-  source_code_hash = data.archive_file.lambda.output_base64sha256
-  handler          = "index.handler"
-  runtime          = "nodejs14.x"
-  at_edge          = true
-  publish_lambda   = true
+  function_name         = var.function_name != null ? var.function_name : replace("${var.project}-${var.env}-${var.service}-security-headers", ".", "-")
+  filename              = data.archive_file.lambda.output_path
+  source_code_hash      = data.archive_file.lambda.output_base64sha256
+  handler               = "index.handler"
+  runtime               = "nodejs14.x"
+  at_edge               = true
+  publish_lambda        = true
+  log_retention_in_days = var.lambda_cloudwatch_log_retention_in_days
 
   env     = var.env
   owner   = var.owner

--- a/aws-lambda-edge-add-security-headers/variables.tf
+++ b/aws-lambda-edge-add-security-headers/variables.tf
@@ -23,3 +23,9 @@ variable "function_name" {
   description = "The name for the lambda function."
   default     = null
 }
+
+variable "lambda_cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention policy (in days) for Lambda function's logs in Cloudwatch"
+  default     = null
+}


### PR DESCRIPTION
### Summary
Make this parameter configurable for a consuming TF project. Otherwise it defaults to `null`, which is the equivalent of 0. A 0 day retention policy makes those logs essentially useless.

### Test Plan
I think somebody previously made a change in the UI to configure a 30 day retention policy on these logs. Hence, a plan (without this PR) was prompting TF to change the retention policy from 30 to 0 days. 

I tested this PR out by running `make plan` on the consuming TF project and noting that the 30 to 0 day change is no longer prompted.

### References
(Optional) Additional links to provide more context.
