### PR TITLE
fix: update docs and add ALB ARNs to ECS services

### DIFF
--- a/aws-aurora-postgres/README.md
+++ b/aws-aurora-postgres/README.md
@@ -87,6 +87,8 @@ No resources.
 |------|-------------|
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | n/a |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | n/a |
+| <a name="output_master_password"></a> [master\_password](#output\_master\_password) | n/a |
+| <a name="output_master_username"></a> [master\_username](#output\_master\_username) | n/a |
 | <a name="output_port"></a> [port](#output\_port) | n/a |
 | <a name="output_reader_endpoint"></a> [reader\_endpoint](#output\_reader\_endpoint) | n/a |
 <!-- END -->

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -69,6 +69,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | n/a |
+| <a name="output_database_password"></a> [database\_password](#output\_database\_password) | n/a |
+| <a name="output_database_username"></a> [database\_username](#output\_database\_username) | n/a |
 | <a name="output_db_parameter_group_name"></a> [db\_parameter\_group\_name](#output\_db\_parameter\_group\_name) | n/a |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | n/a |
 | <a name="output_port"></a> [port](#output\_port) | n/a |

--- a/aws-ecs-service-fargate/README.md
+++ b/aws-ecs-service-fargate/README.md
@@ -240,6 +240,7 @@ No requirements.
 | <a name="output_alb_https_listener_arn"></a> [alb\_https\_listener\_arn](#output\_alb\_https\_listener\_arn) | ALB HTTPS listener ARN |
 | <a name="output_alb_route53_zone_id"></a> [alb\_route53\_zone\_id](#output\_alb\_route53\_zone\_id) | n/a |
 | <a name="output_container_security_group_id"></a> [container\_security\_group\_id](#output\_container\_security\_group\_id) | Security group id for the container. |
+| <a name="output_ecs_albs"></a> [ecs\_albs](#output\_ecs\_albs) | Application Load Balancer (ALB) ARNs for the ECS Deployment |
 | <a name="output_ecs_service_arn"></a> [ecs\_service\_arn](#output\_ecs\_service\_arn) | The ARN of the ECS unmanaged service that is created |
 | <a name="output_ecs_task_definition_family"></a> [ecs\_task\_definition\_family](#output\_ecs\_task\_definition\_family) | The family of the task definition defined for the given/generated container definition. |
 | <a name="output_private_service_discovery_domain"></a> [private\_service\_discovery\_domain](#output\_private\_service\_discovery\_domain) | Domain name for service discovery, if with\_service\_discovery=true. Only resolvable within the VPC. |

--- a/aws-ecs-service-fargate/outputs.tf
+++ b/aws-ecs-service-fargate/outputs.tf
@@ -6,6 +6,11 @@ output "alb_route53_zone_id" {
   value = aws_lb.service.zone_id
 }
 
+output "ecs_albs" {
+  value       = [aws_lb.service.arn]
+  description = "Application Load Balancer (ALB) ARNs for the ECS Deployment"
+}
+
 output "ecs_task_definition_family" {
   description = "The family of the task definition defined for the given/generated container definition."
   value       = aws_ecs_task_definition.job.family

--- a/aws-ecs-service/README.md
+++ b/aws-ecs-service/README.md
@@ -231,6 +231,7 @@ No requirements.
 | <a name="output_alb_https_listener_arn"></a> [alb\_https\_listener\_arn](#output\_alb\_https\_listener\_arn) | ALB HTTPS listener ARN |
 | <a name="output_alb_route53_zone_id"></a> [alb\_route53\_zone\_id](#output\_alb\_route53\_zone\_id) | n/a |
 | <a name="output_container_security_group_id"></a> [container\_security\_group\_id](#output\_container\_security\_group\_id) | Security group id for the container. |
+| <a name="output_ecs_albs"></a> [ecs\_albs](#output\_ecs\_albs) | Application Load Balancer (ALB) ARNs for the ECS Deployment |
 | <a name="output_ecs_task_definition_family"></a> [ecs\_task\_definition\_family](#output\_ecs\_task\_definition\_family) | The family of the task definition defined for the given/generated container definition. |
 | <a name="output_private_service_discovery_domain"></a> [private\_service\_discovery\_domain](#output\_private\_service\_discovery\_domain) | Domain name for service discovery, if with\_service\_discovery=true. Only resolvable within the VPC. |
 <!-- END -->

--- a/aws-ecs-service/outputs.tf
+++ b/aws-ecs-service/outputs.tf
@@ -6,6 +6,11 @@ output "alb_route53_zone_id" {
   value = aws_lb.service.zone_id
 }
 
+output "ecs_albs" {
+  value       = [aws_lb.service.arn]
+  description = "Application Load Balancer (ALB) ARNs for the ECS Deployment"
+}
+
 output "ecs_task_definition_family" {
   description = "The family of the task definition defined for the given/generated container definition."
   value       = aws_ecs_task_definition.job.family

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -50,6 +50,7 @@ No modules.
 | [aws_iam_instance_profile.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch-agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm-agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -53,6 +53,7 @@ No requirements.
 | <a name="input_saml_idp_arns"></a> [saml\_idp\_arns](#input\_saml\_idp\_arns) | The AWS SAML IDP arns to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_source_account_ids"></a> [source\_account\_ids](#input\_source\_account\_ids) | The source AWS account IDs to establish a trust relationship. Ignored if empty or not provided. | `set(string)` | `[]` | no |
+| <a name="input_source_role_arns"></a> [source\_role\_arns](#input\_source\_role\_arns) | The source AWS roles to establish a trust relationship. Ignored if empty or not provided. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/aws-s3-public-bucket/README.md
+++ b/aws-s3-public-bucket/README.md
@@ -30,6 +30,7 @@ No modules.
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | A policy to attach to this bucket. | `string` | `""` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Keep old versions of objects in this bucket. | `bool` | `true` | no |
 | <a name="input_env"></a> [env](#input\_env) | Env for tagging and naming. | `string` | n/a | yes |
+| <a name="input_logging_bucket"></a> [logging\_bucket](#input\_logging\_bucket) | Log bucket name and prefix to enable logs for this bucket | `object({ name = string, prefix = string })` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Owner for tagging and naming. | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. | `string` | n/a | yes |
 | <a name="input_public_read_justification"></a> [public\_read\_justification](#input\_public\_read\_justification) | Describe why this bucket must be public and what it is being used for. | `string` | n/a | yes |


### PR DESCRIPTION
### Summary
Ran `make docs` and returned the ALB ARNs for ECS Services. The added output will help users configure ALB-compatible features like Web ACLs.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
