### PR TITLE
Allow force_destroy option on s3 buckets

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -24,7 +24,8 @@ locals {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = var.bucket_name
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
   # `grant` and `acl` conflict with each other - https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#acl
 
   # Using canned ACL will conflict with using grant ACL

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -2,6 +2,12 @@ variable "bucket_name" {
   type = string
 }
 
+variable "force_destroy" {
+  type        = bool
+  description = "Allow objects to be deleted when the bucket is destroyed without errors."
+  default     = false
+}
+
 variable "bucket_policy" {
   type    = string
   default = ""

--- a/aws-s3-public-bucket/main.tf
+++ b/aws-s3-public-bucket/main.tf
@@ -15,9 +15,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = local.bucket_name
-
-  policy = data.aws_iam_policy_document.bucket_policy.json
+  bucket        = local.bucket_name
+  force_destroy = var.force_destroy
+  policy        = data.aws_iam_policy_document.bucket_policy.json
 
   versioning {
     enabled = var.enable_versioning

--- a/aws-s3-public-bucket/variables.tf
+++ b/aws-s3-public-bucket/variables.tf
@@ -23,6 +23,11 @@ variable "bucket_name" {
   description = "The name of the bucket. Note that `-public` will be appended to `bucket_name`s that don't contain a `public` substring. This module will output the computed `bucket_name`."
 }
 
+variable "force_destroy" {
+  type    = bool
+  default = false
+}
+
 variable "allow_public_list" {
   type        = bool
   description = "Allow public to list bucket contents."


### PR DESCRIPTION
### Summary
This option is helpful when we want to destroy a bucket and delete all objects within it: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#force_destroy
### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
