### PR TITLE
feat: add module for ecr repository

### DIFF
--- a/aws-ecr-repo/.terraform.lock.hcl
+++ b/aws-ecr-repo/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.57.0"
+  constraints = ">= 4.22.0"
+  hashes = [
+    "h1:xMOeHMZM7RAO6HKP2C6XbbBjGdHogTJ3CwPRw6xFj30=",
+    "zh:07d89ad94267b7d6285fd65fbd67f8680e111abf9bbcbcac2e30154262fbbe46",
+    "zh:0eeee044e6fc285c20241d3de7f9b79450cab2df1452a9c18c0bed1090085a25",
+    "zh:306ba8ac99a0d9f9eba0386cb11459323696e69dcb28bc5e55b6fb2de28640cd",
+    "zh:40afc24b94e7cae387f22dd3045b09311a120e429aa4f06168d7498995a98f67",
+    "zh:5a2c846a2cc463841ca2353fb734ba6f9502e662196c85fd3332a4e18acec72e",
+    "zh:854fbf7d058e4e31ce4ed882e2085bd94c53be4b38b15f3b5d3d897a2c5102df",
+    "zh:89a7a5e7de6400662804d5dc43251172e3f0522853dcab304d637a7bbb266654",
+    "zh:89ef96a1b36396f555e80505f55fd29432be3dc518bd75b72a1aae29e8171b4a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b28516cc8e614fad40738ec73ce70528e2a817dae3118895333c1d63f1e22a89",
+    "zh:c3f1c6a7d56b0838da2f880a74e19df65ca9006cb3ebdc34403cb9d6e4ee046d",
+    "zh:d036a7355494792e2347b92d766431ba91cb399a4bd2bb719db3025542c0e674",
+    "zh:d3299b9507085238aaf24f38faffb5d6226a31f916e47320b31d728c7062be16",
+    "zh:d9f5c04f4648d593d91be2a66c6c61f6c52512c78ac6fb3077f0911a6b95fa2f",
+    "zh:f84143ee0cff2ad0af8ad40074fb5dcd83bfb8a514c7f43ca23c7422caa42330",
+  ]
+}

--- a/aws-ecr-repo/README.md
+++ b/aws-ecr-repo/README.md
@@ -1,16 +1,15 @@
-<!-- START -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 
@@ -24,7 +23,6 @@ No modules.
 | [aws_ecr_repository.repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [template_file.lifecycle](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -32,14 +30,12 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_lambda_pull"></a> [allow\_lambda\_pull](#input\_allow\_lambda\_pull) | Whether lambda can pull this ECR | `bool` | `false` | no |
 | <a name="input_ecr_resource_policy"></a> [ecr\_resource\_policy](#input\_ecr\_resource\_policy) | ECR resource-level policy, as JSON string | `string` | `null` | no |
-| <a name="input_env"></a> [env](#input\_env) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Allows this ECR repo to be automated deleted with terraform destroy. False by default | `bool` | `false` | no |
 | <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | ECR ifecycle policy, as JSON string. If provided, max\_images is ignored. | `string` | `""` | no |
-| <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | Maximum number of images to keep. ECR has a service limit of 1000 images. Ignored if lifecycle\_policy is provided. | `number` | `995` | no |
+| <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | Maximum number of images to keep. ECR has a service limit of 1000 images. Ignored if lifecycle\_policy is provided. | `number` | `100` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_owner"></a> [owner](#input\_owner) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
-| <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
 | <a name="input_read_arns"></a> [read\_arns](#input\_read\_arns) | ARNs of users/roles allowed to read images from the repository. | `list(string)` | `[]` | no |
-| <a name="input_service"></a> [service](#input\_service) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to ECR repo | <pre>object({<br>    project : string,<br>    env : string,<br>    service : string,<br>    owner : string,<br>    managedBy : string<br>  })</pre> | n/a | yes |
 | <a name="input_write_arns"></a> [write\_arns](#input\_write\_arns) | ARNs of users/roles allowed to write images to the repository. | `list(string)` | `[]` | no |
 
 ## Outputs
@@ -49,4 +45,3 @@ No modules.
 | <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | n/a |
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | n/a |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | n/a |
-<!-- END -->

--- a/aws-ecr-repo/README.md
+++ b/aws-ecr-repo/README.md
@@ -1,0 +1,52 @@
+<!-- START -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_lifecycle_policy.lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
+| [aws_ecr_repository.repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [template_file.lifecycle](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_lambda_pull"></a> [allow\_lambda\_pull](#input\_allow\_lambda\_pull) | Whether lambda can pull this ECR | `bool` | `false` | no |
+| <a name="input_ecr_resource_policy"></a> [ecr\_resource\_policy](#input\_ecr\_resource\_policy) | ECR resource-level policy, as JSON string | `string` | `null` | no |
+| <a name="input_env"></a> [env](#input\_env) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | ECR ifecycle policy, as JSON string. If provided, max\_images is ignored. | `string` | `""` | no |
+| <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | Maximum number of images to keep. ECR has a service limit of 1000 images. Ignored if lifecycle\_policy is provided. | `number` | `995` | no |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_owner"></a> [owner](#input\_owner) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_read_arns"></a> [read\_arns](#input\_read\_arns) | ARNs of users/roles allowed to read images from the repository. | `list(string)` | `[]` | no |
+| <a name="input_service"></a> [service](#input\_service) | Project for tagging and naming. See [doc](../README.md#consistent-tagging) | `string` | n/a | yes |
+| <a name="input_write_arns"></a> [write\_arns](#input\_write\_arns) | ARNs of users/roles allowed to write images to the repository. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | n/a |
+| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | n/a |
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | n/a |
+<!-- END -->

--- a/aws-ecr-repo/main.tf
+++ b/aws-ecr-repo/main.tf
@@ -1,0 +1,105 @@
+locals {
+  read_write_arns = concat(var.read_arns, var.write_arns)
+  lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep at most ${var.max_image_count} images",
+        selection = {
+          tagStatus   = "any",
+          countType   = "imageCountMoreThan",
+          countNumber = var.max_image_count
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository" "repo" {
+  name         = var.name
+  tags         = var.tags
+  force_delete = var.force_delete
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+
+resource "aws_ecr_repository_policy" "policy" {
+  # We need to make sure there are available ARNs for the policy to attach to.
+  # Create if there is at least read/write arn or have a non-empty JSON policy
+  count = (length(local.read_write_arns) > 0 || var.ecr_resource_policy != null) ? 1 : 0
+
+  repository = aws_ecr_repository.repo.name
+  policy     = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+
+  dynamic "statement" {
+    for_each = var.allow_lambda_pull ? { "principal" : "lambda.amazonaws.com" } : {}
+    content {
+      sid = "LambdaECRImageRetrievalPolicy"
+      actions = [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:SetRepositoryPolicy",
+        "ecr:DeleteRepositoryPolicy",
+        "ecr:GetRepositoryPolicy",
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["lambda.amazonaws.com"]
+      }
+    }
+  }
+  dynamic "statement" {
+    for_each = length(local.read_write_arns) > 0 ? [local.read_write_arns] : []
+    iterator = arns
+    content {
+      sid = "Read"
+
+      principals {
+        type        = "AWS"
+        identifiers = arns.value
+      }
+
+      actions = [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.write_arns
+    iterator = arn
+    content {
+      sid = "Write${arn.key}"
+
+      principals {
+        type        = "AWS"
+        identifiers = [arn.value]
+      }
+
+      actions = [
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+      ]
+    }
+  }
+
+  source_json = var.ecr_resource_policy
+}
+
+resource "aws_ecr_lifecycle_policy" "lifecycle" {
+  repository = aws_ecr_repository.repo.name
+  policy     = var.lifecycle_policy == "" ? local.lifecycle_policy : var.lifecycle_policy
+}

--- a/aws-ecr-repo/module_test.go
+++ b/aws-ecr-repo/module_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestAWSECRREpo(t *testing.T) {
+
+	// TODO needs variables set to pass
+	// test := tftest.Test{
+	// 	Options:  func(t *testing.T) *terraform.Options { return nil },
+	// 	Validate: func(t *testing.T, options *terraform.Options) {},
+	// }
+
+	// test.Run(t)
+}

--- a/aws-ecr-repo/outputs.tf
+++ b/aws-ecr-repo/outputs.tf
@@ -1,0 +1,11 @@
+output "repository_name" {
+  value = aws_ecr_repository.repo.name
+}
+
+output "repository_url" {
+  value = aws_ecr_repository.repo.repository_url
+}
+
+output "repository_arn" {
+  value = aws_ecr_repository.repo.arn
+}

--- a/aws-ecr-repo/variables.tf
+++ b/aws-ecr-repo/variables.tf
@@ -1,0 +1,56 @@
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type = object({
+    project : string,
+    env : string,
+    service : string,
+    owner : string,
+    managedBy : string
+  })
+  description = "Tags to apply to ECR repo"
+}
+
+variable "read_arns" {
+  description = "ARNs of users/roles allowed to read images from the repository."
+  type        = list(string)
+  default     = []
+}
+
+variable "write_arns" {
+  description = "ARNs of users/roles allowed to write images to the repository."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecr_resource_policy" {
+  description = "ECR resource-level policy, as JSON string"
+  type        = string
+  default     = null
+}
+
+variable "max_image_count" {
+  description = "Maximum number of images to keep. ECR has a service limit of 1000 images. Ignored if lifecycle_policy is provided."
+  type        = number
+  default     = 100
+}
+
+variable "lifecycle_policy" {
+  description = "ECR ifecycle policy, as JSON string. If provided, max_images is ignored."
+  type        = string
+  default     = ""
+}
+
+variable "allow_lambda_pull" {
+  type        = bool
+  description = "Whether lambda can pull this ECR"
+  default     = false
+}
+
+variable "force_delete" {
+  type        = bool
+  description = "Allows this ECR repo to be automated deleted with terraform destroy. False by default"
+  default     = false
+}

--- a/aws-ecr-repo/versions.tf
+++ b/aws-ecr-repo/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22.0"
+    }
+  }
+  required_version = ">= 1.0"
+}


### PR DESCRIPTION
### Summary
This PR adds a module for ECR repositories. The module creates an ECR repository with tags and configured name and optionally allows for a few configuration options such as force_delete (for terraform destroys), access policies, and lifecycle policies.

