### PR TITLE
feat: make github CI role opensource

### DIFF
--- a/aws-iam-role-github-action/README.md
+++ b/aws-iam-role-github-action/README.md
@@ -1,0 +1,60 @@
+# AWS IAM Role GitHub Action
+This module creates a role that is assumable from a github action via OIDC federation. We therefore do not need to add static AWS credentials to the GitHub action.
+
+You must specify which of our repos are authorized to assume this role. As always, be mindful of least privilege and such.
+
+AWS provides an [official GitHub action](https://github.com/aws-actions/configure-aws-credentials) that facilitates working with this paradigm.
+
+You can use it in your GitHub actions as follows:
+```
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+        aws-region: us-west-2
+```
+
+Where `role-to-assume` is the ARN of the role this module creates.
+
+NOTE: this module doesn't manage the role's permissions. Users of this module should handle these separately with an eye towards CI/CD least privilege.
+
+
+<!-- START -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_assert"></a> [assert](#provider\_assert) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [assert_test.authorized_github_org](https://registry.terraform.io/providers/bwoznicki/assert/latest/docs/data-sources/test) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_authorized_github_repos"></a> [authorized\_github\_repos](#input\_authorized\_github\_repos) | A map that specifies the authorized repos to assume the created role.<br>  Keys specify the name of the GitHub org.<br>  Values specify the authorized repos within that org.<br><br>  NOTE: "chanzuckerberg" is, currently, the only authorized GitHub org. | `map(list(string))` | n/a | yes |
+| <a name="input_role"></a> [role](#input\_role) | Configure the AWS IAM Role. | <pre>object({<br>    name : string,<br>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Standard tagging. | <pre>object({<br>    env : string,<br>    owner : string,<br>    managedBy : string,<br>    project : string<br>    service : string<br>  })</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role"></a> [role](#output\_role) | n/a |
+<!-- END -->

--- a/aws-iam-role-github-action/main.tf
+++ b/aws-iam-role-github-action/main.tf
@@ -1,0 +1,45 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  idp     = "token.actions.githubusercontent.com"
+  idp_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.idp}"
+}
+
+// https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-the-identity-provider-to-aws
+data "aws_iam_policy_document" "assume_role" {
+  dynamic "statement" {
+    for_each = var.authorized_github_repos
+
+    content {
+      principals {
+        type        = "Federated"
+        identifiers = [local.idp_arn]
+      }
+
+      actions = ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"]
+      condition {
+        test     = "StringLike"
+        variable = "${local.idp}:sub"
+        values = formatlist(
+          "repo:%s/%s:*",
+          statement.key,
+          statement.value,
+        )
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name = var.role.name
+
+  tags = var.tags
+
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  max_session_duration = 60 * 60 // 1 hour, not sure what max github action exec time is
+
+  # We have to force detach policies in order to recreate roles.
+  # The other option would be to use name_prefix and create_before_destroy, but that
+  # doesn't work if you want a role with a stable, memorable name.
+  force_detach_policies = true
+}

--- a/aws-iam-role-github-action/outputs.tf
+++ b/aws-iam-role-github-action/outputs.tf
@@ -1,0 +1,6 @@
+output "role" {
+  value = {
+    name = aws_iam_role.role.name
+    arn  = aws_iam_role.role.arn
+  }
+}

--- a/aws-iam-role-github-action/variables.tf
+++ b/aws-iam-role-github-action/variables.tf
@@ -1,0 +1,27 @@
+variable "authorized_github_repos" {
+  type        = map(list(string))
+  description = <<DESCRIPTION
+  A map that specifies the authorized repos to assume the created role.
+  Keys specify the name of the GitHub org.
+  Values specify the authorized repos within that org.
+	DESCRIPTION
+}
+
+variable "role" {
+  type = object({
+    name : string,
+  })
+  description = "Configure the AWS IAM Role."
+}
+
+variable "tags" {
+  type = object({
+    env : string,
+    owner : string,
+    managedBy : string,
+    project : string
+    service : string
+  })
+
+  description = "Standard tagging."
+}

--- a/aws-iam-role-github-action/versions.tf
+++ b/aws-iam-role-github-action/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0.0"
+}

--- a/aws-iam-role-github-action/versions.tf
+++ b/aws-iam-role-github-action/versions.tf
@@ -1,3 +1,9 @@
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.45"
+    }
+  }
   required_version = ">= 1.0.0"
 }

--- a/scripts/snowflake_generate_grant_all/ensure_ci.go
+++ b/scripts/snowflake_generate_grant_all/ensure_ci.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -19,7 +18,7 @@ func ensureCI(names []string) error {
 	}
 
 	ciPath := path.Join(cwd, "..", "..", ".github", "workflows", "ci.yml")
-	ciFile, err := ioutil.ReadFile(ciPath)
+	ciFile, err := os.ReadFile(ciPath)
 	if err != nil {
 		return err
 	}
@@ -57,5 +56,5 @@ func ensureCI(names []string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(ciPath, out, 0644)
+	return os.WriteFile(ciPath, out, 0644)
 }

--- a/scripts/snowflake_generate_grant_all/main.go
+++ b/scripts/snowflake_generate_grant_all/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -99,13 +98,13 @@ func writeModule(name string, tf []byte, testCode []byte) error {
 	}
 
 	// write the file terraform file
-	err = ioutil.WriteFile(path.Join(moduleDir, "main.tf.json"), tf, 0644)
+	err = os.WriteFile(path.Join(moduleDir, "main.tf.json"), tf, 0644)
 	if err != nil {
 		return err
 	}
 
 	// write the file terraform file
-	return ioutil.WriteFile(path.Join(moduleDir, "module_test.go"), testCode, 0644)
+	return os.WriteFile(path.Join(moduleDir, "module_test.go"), testCode, 0644)
 }
 
 func generateModule(name string, grant *resources.TerraformGrantResource) ([]byte, error) {


### PR DESCRIPTION
### Summary
A role that can be used by Github Actions to assume into based on what repo is trusted.