### PR TITLE
feat: output additional info from aws-aurora-postgres

### DIFF
--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -25,3 +25,7 @@ output "port" {
 output "cluster_resource_id" {
   value = module.aurora.cluster_resource_id
 }
+
+output "cluster_id" {
+  value = module.aurora.rds_cluster_id
+}

--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -21,3 +21,7 @@ output "reader_endpoint" {
 output "port" {
   value = module.aurora.port
 }
+
+output "cluster_resource_id" {
+  value = module.aurora.cluster_resource_id
+}

--- a/aws-aurora/outputs.tf
+++ b/aws-aurora/outputs.tf
@@ -29,3 +29,7 @@ output "rds_cluster_id" {
 output "db_parameter_group_name" {
   value = aws_db_parameter_group.db.name
 }
+
+output "cluster_resource_id" {
+  value = aws_rds_cluster.db.cluster_resource_id
+}


### PR DESCRIPTION
### Summary
Propagate additional outputs to aws-aurora-postgres module.

- cluster_resource_id is useful for if you want to enable iam authentication on the database. The IAM policy requires a reference to the resource id. https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
- the cluster_id is useful for providing unique names for other resources that are tied to the aurora instance

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
