### PR TITLE
fix: Replace a deprecated source_json attribute

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -142,7 +142,7 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 
 data "aws_iam_policy_document" "bucket_policy" {
   # Deny access to bucket if it's not accessed through HTTPS
-  source_json = var.bucket_policy
+  source_policy_documents = [var.bucket_policy]
 
   statement {
     sid     = "EnforceTLS"


### PR DESCRIPTION
AWS provider 5.x removed the deprecated attribute source_json.