### PR TITLE
feat: aws-s3-private-bucket Allow specifying bucket object blanket ow…

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -176,3 +176,12 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
   // https://github.com/terraform-providers/terraform-provider-aws/issues/7628
   depends_on = [aws_s3_bucket_public_access_block.bucket]
 }
+
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  count = var.object_ownership != null ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket
+  rule {
+    object_ownership = var.object_ownership
+  }
+}

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -99,3 +99,15 @@ variable "acl" {
   default     = "private"
   description = "Canned ACL to use if grants object is not given. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl"
 }
+
+variable "object_ownership" {
+  type        = string
+  default     = null
+  description = "Set default owner of all objects within bucket (e.g., bucket vs. object owner)"
+
+  validation {
+    condition     = contains(["BucketOwnerEnforced", "BucketOwnerPreferred", "ObjectWriter"], var.object_ownership)
+    error_message = "Valid values for var.object_ownership are ('BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter')."
+
+  }
+}


### PR DESCRIPTION
### Summary
Allow setting `object_ownership` as default ownership for all bucket's objects.