### PR TITLE
fix: Ternary operator for variable validation check against null

### DIFF
--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -100,13 +100,14 @@ variable "acl" {
   description = "Canned ACL to use if grants object is not given. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl"
 }
 
+# check if argument is null or is in list (2nd parameter of contains() cannot be null)
 variable "object_ownership" {
   type        = string
   default     = null
   description = "Set default owner of all objects within bucket (e.g., bucket vs. object owner)"
 
   validation {
-    condition     = contains(["BucketOwnerEnforced", "BucketOwnerPreferred", "ObjectWriter"], var.object_ownership) || var.object_ownership == null
+    condition     = var.object_ownership == null ? true : contains(["BucketOwnerEnforced", "BucketOwnerPreferred", "ObjectWriter"], var.object_ownership)
     error_message = "Valid values for var.object_ownership are ('BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter')."
 
   }


### PR DESCRIPTION
### Summary
`null` cannot be the second argument of `contains()`. Use the ternary operator to check for null first, and then if not, check using `contains()` (with the 2nd argument guaranteed to be non-null).

### Test Plan
```
> null == null ? true : contains(["a", "b", "c"], null)
true
```
