### PR TITLE
fix: Use id and not resource itself as value

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -180,7 +180,7 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
 resource "aws_s3_bucket_ownership_controls" "bucket" {
   count = var.object_ownership != null ? 1 : 0
 
-  bucket = aws_s3_bucket.bucket
+  bucket = aws_s3_bucket.bucket.id
   rule {
     object_ownership = var.object_ownership
   }


### PR DESCRIPTION
### Summary
Supply the `id` of the bucket and not the `aws_s3_bucket` resource itself to the `aws_s3_bucket_ownership_controls` resource.