### PR TITLE
feat: AWS provider version bump to support BucketOwnerEnforced object…

### DIFF
--- a/aws-s3-private-bucket/versions.tf
+++ b/aws-s3-private-bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.29.0"
+      version = ">= 3.69.0"
     }
   }
 }


### PR DESCRIPTION
… ownership value

### Summary
Bump AWS version to support the `BucketOwnerEnforced` value for `aws_s3_bucket_ownership_controls`.
