### PR TITLE
feat: CDI-1607 Add KMS encryption key var to s3 bucket

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -192,7 +192,12 @@ resource "aws_kms_key" "bucket_kms_key" {
   description              = "This key is used to encrypt bucket objects for bucket ${var.bucket_name}"
   customer_master_key_spec = var.kms_key_type
   tags                     = {
-    
+    project   = var.project
+    env       = var.env
+    service   = var.service
+    owner     = var.owner
+    bucket    = var.bucket_name
+    managedBy = "terraform"
   }
 }
 

--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -185,3 +185,26 @@ resource "aws_s3_bucket_ownership_controls" "bucket" {
     object_ownership = var.object_ownership
   }
 }
+
+resource "aws_kms_key" "bucket_kms_key" {
+  count = var.kms_encryption != null ? 1 : 0
+
+  description              = "This key is used to encrypt bucket objects for bucket ${var.bucket_name}"
+  customer_master_key_spec = var.kms_key_type
+  tags                     = {
+    
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_kms_encryption" {
+  count = var.kms_encryption != null ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.bucket_kms_key[0].arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}

--- a/aws-s3-private-bucket/outputs.tf
+++ b/aws-s3-private-bucket/outputs.tf
@@ -14,3 +14,7 @@ output "arn" {
 output "id" {
   value = aws_s3_bucket.bucket.id
 }
+
+output "bucket_kms_encryption_key_arn" {
+  value = one(aws_kms_key.bucket_kms_key[*].arn)
+}

--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -112,3 +112,20 @@ variable "object_ownership" {
 
   }
 }
+
+variable "kms_encryption" {
+  type        = bool
+  default     = false
+  description = "Flag to indicate whether the bucket will be encrypted using a new customer-managed KMS key. Default behavior is no, and SSE-S3 is used instead. KMS is required for direct cross-account access (as opposed to via an assumed role in the target account)"
+}
+
+variable "kms_key_type" {
+  type        = string
+  default     = "SYMMETRIC_DEFAULT"
+  description = "KMS key type with which to encrypt bucket"
+  validation {
+    condition     = var.kms_key_type == null ? true : contains(["SYMMETRIC_DEFAULT", "RSA_2048", "RSA_3072", "RSA_4096", "HMAC_256", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521", "ECC_SECG_P256K1"], var.kms_key_type)
+    error_message = "Valid values for var.kms_key_type are ('SYMMETRIC_DEFAULT', 'RSA_2048', 'RSA_3072', 'RSA_4096', 'HMAC_256', 'ECC_NIST_P256', 'ECC_NIST_P384', 'ECC_NIST_P521', 'ECC_SECG_P256K1')."
+
+  }
+}

--- a/aws-s3-private-bucket/versions.tf
+++ b/aws-s3-private-bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69.0"
+      version = ">= 3.76.1"
     }
   }
 }


### PR DESCRIPTION
### Summary
Add functionality to set private s3 bucket encryption to use a specified (new) KMS key instead of the default SSE-S3 keys,  allowing cross-account access to the bucket without needing to assume a role in the target AWS account

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
