### PR TITLE
chore: remove deprecated attribute

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -119,14 +119,17 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+  tags = local.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "enc" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "AES256"
     }
   }
-  tags = local.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {


### PR DESCRIPTION
### Summary
This PR removes a deprecated attribute on s3 buckets and moves out into the resource aws_s3_bucket_server_side_encryption_configuration

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
