### PR TITLE
fix: Do not set S3 kms encryption by default

### DIFF
--- a/aws-s3-private-bucket/variables.tf
+++ b/aws-s3-private-bucket/variables.tf
@@ -115,7 +115,7 @@ variable "object_ownership" {
 
 variable "kms_encryption" {
   type        = bool
-  default     = false
+  default     = null
   description = "Flag to indicate whether the bucket will be encrypted using a new customer-managed KMS key. Default behavior is no, and SSE-S3 is used instead. KMS is required for direct cross-account access (as opposed to via an assumed role in the target account)"
 }
 


### PR DESCRIPTION
### Summary
Previous change set s3 KMS encryption by default

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
