### PR TITLE
feat: Remove deprecated overwrite parameter

### DIFF
--- a/aws-params-writer/main.tf
+++ b/aws-params-writer/main.tf
@@ -14,7 +14,6 @@ resource "aws_ssm_parameter" "parameter" {
 
   type      = "SecureString"
   key_id    = data.aws_kms_key.key.id
-  overwrite = "true"
 
   tags = {
     managedBy = "terraform"


### PR DESCRIPTION
### Summary
Removing `overwrite` as it will be deprecated argument in `v6.0.0` of the provider.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
