### PR TITLE
fix: trigger release for S3 default KMS encryption fix

### DIFF
--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -73,6 +73,8 @@ No modules.
 | <a name="input_public_access_block"></a> [public\_access\_block](#input\_public\_access\_block) | n/a | `bool` | `true` | no |
 | <a name="input_service"></a> [service](#input\_service) | n/a | `string` | n/a | yes |
 | <a name="input_transfer_acceleration"></a> [transfer\_acceleration](#input\_transfer\_acceleration) | n/a | `bool` | `false` | no |
+| <a name="kms_encryption"></a> [kms\_encryption](#kms\_encryption) | Use KMS encryption instead of the default (SSE) | `bool` | `false` | no |
+| <a name="kms_key_type"></a> [kms\_encryption](#kms\_key\_type) | KMS encryption key type, if `kms_encryption`` is set to true| `string` | `SYMMETRIC_DEFAULT` | no |
 
 ## Outputs
 


### PR DESCRIPTION
### Summary
Prior [PR](https://github.com/chanzuckerberg/cztack/pull/516) did not trigger release-please

Also, update docs

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
