### PR TITLE
feat: all more options when creating the trust relationship

### DIFF
--- a/aws-iam-role-github-action/main.tf
+++ b/aws-iam-role-github-action/main.tf
@@ -8,9 +8,23 @@ locals {
 // https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-the-identity-provider-to-aws
 data "aws_iam_policy_document" "assume_role" {
   dynamic "statement" {
+    for_each = var.authorized_aws_accounts
+
+    content {
+      sid = "AllowAssumeRoleFrom${statement.key}"
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+      effect  = "Allow"
+    }
+  }
+  dynamic "statement" {
     for_each = var.authorized_github_repos
 
     content {
+      sid = "AllowGithubActionsToAssumeRole"
       principals {
         type        = "Federated"
         identifiers = [local.idp_arn]

--- a/aws-iam-role-github-action/main.tf
+++ b/aws-iam-role-github-action/main.tf
@@ -44,12 +44,19 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
+data "aws_iam_policy_document" "this" {
+  source_policy_documents = compact([
+    data.aws_iam_policy_document.assume_role.json,
+    var.additional_assume_role_policies_json,
+  ])
+}
+
 resource "aws_iam_role" "role" {
   name = var.role.name
 
   tags = var.tags
 
-  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  assume_role_policy   = data.aws_iam_policy_document.this.json
   max_session_duration = 60 * 60 // 1 hour, not sure what max github action exec time is
 
   # We have to force detach policies in order to recreate roles.

--- a/aws-iam-role-github-action/variables.tf
+++ b/aws-iam-role-github-action/variables.tf
@@ -25,3 +25,9 @@ variable "tags" {
 
   description = "Standard tagging."
 }
+
+variable "authorized_aws_accounts" {
+  type        = map(string)
+  description = "The map of authorized AWS accounts to assume the created role."
+  default     = {}
+}

--- a/aws-iam-role-github-action/variables.tf
+++ b/aws-iam-role-github-action/variables.tf
@@ -31,3 +31,9 @@ variable "authorized_aws_accounts" {
   description = "The map of authorized AWS accounts to assume the created role."
   default     = {}
 }
+
+variable "additional_assume_role_policies_json" {
+  type        = string
+  description = "The JSON string of any other additional assume role policies to add to the Github Actions role"
+  default     = ""
+}


### PR DESCRIPTION
### Summary

This PR allows the Github Role to have more than just IdP references. We can easily make the role trusted by another AWS account or through a generic trust relation JSON policy.