### PR TITLE
fix: CDI-2179 Remove unused databricks-workspace-e2 variable

### DIFF
--- a/databricks-workspace-e2/variables.tf
+++ b/databricks-workspace-e2/variables.tf
@@ -51,11 +51,6 @@ variable "object_ownership" {
   }
 }
 
-variable "audit_log_bucket_name" {
-  type        = string
-  description = "Name of bucket to write cluster logs to - also where the audit logs go, too"
-}
-
 variable "workspace_name_override" {
   type        = string
   default     = null


### PR DESCRIPTION
### Summary
Variable was copied over from shared-infra, but isn't actually used (though there was a default value) - dropping

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
