### PR TITLE
feat: add pool use to personal compute Databricks policy

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -83,6 +83,10 @@ module "personal_compute_cluster_policy" {
       "pattern" : "([rcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
       "hidden" : false
     },
+    "instance_pool_id" : {
+      type: "allowlist",
+      values: ["i3-xlarge-pool"]
+    }
   })
   grantees = [local.all_users_group_name]
 }


### PR DESCRIPTION
Adds `i3-xlarge-pool` pool usage permissions to Personal Compute cluster policies
