### PR TITLE
fix: personal instance pools var for databricks compute policies

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -36,6 +36,13 @@ locals {
       "defaultValue" : local.default_cluster_instance_profile_arn
     }
   }
+  personal_instance_pools = var.personal_compute_pool_ids != [] ? {
+    "instance_pool_id" : {
+      "type" : "allowlist",
+      "isOptional": true,
+      "values" : var.personal_compute_pool_ids
+    }
+  } : {}
 }
 
 resource "databricks_group" "power_user_group" {
@@ -82,12 +89,8 @@ module "personal_compute_cluster_policy" {
       "type" : "regex",
       "pattern" : "([rcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
       "hidden" : false
-    },
-    "instance_pool_id" : {
-      type: "allowlist",
-      values: ["i3-xlarge-pool"]
     }
-  })
+  }, local.personal_instance_pools)
   grantees = [local.all_users_group_name]
 }
 

--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -41,6 +41,11 @@ locals {
       "type" : "allowlist",
       "isOptional": true,
       "values" : var.personal_compute_pool_ids
+    },
+    "driver_node_type_id": {
+      "type" : "allowlist",
+      "isOptional": true,
+      "values" : var.personal_compute_pool_ids
     }
   } : {}
 }
@@ -75,7 +80,7 @@ module "personal_compute_cluster_policy" {
   databricks_workspace_id = var.databricks_workspace_id
   policy_name             = "${var.policy_name_prefix}Personal Compute"
   policy_family_id        = local.default_policy_family_ids["personal_compute"]
-  policy_overrides = merge(local.logging_override, {
+  policy_overrides = merge(local.logging_override, local.personal_instance_pools, {
     "autotermination_minutes" : {
       "type" : "fixed",
       "value" : 120
@@ -89,8 +94,21 @@ module "personal_compute_cluster_policy" {
       "type" : "regex",
       "pattern" : "([rcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
       "hidden" : false
-    }
-  }, local.personal_instance_pools)
+    },
+    "aws_attributes.availability": {
+      "type": "allowlist",
+      "values": [
+        "ON_DEMAND",
+        "SPOT_WITH_FALLBACK"
+      ],
+      "hidden": false
+    },
+    "runtime_engine": {
+      "type": "unlimited",
+      "defaultValue": "STANDARD",
+      "hidden": false
+    },
+  })
   grantees = [local.all_users_group_name]
 }
 

--- a/databricks-default-cluster-policies/variables.tf
+++ b/databricks-default-cluster-policies/variables.tf
@@ -24,3 +24,9 @@ variable "policy_name_prefix" {
   type = string
   default = ""
 }
+
+variable "personal_compute_pool_ids" {
+  description = "List of personal compute pool ids allowed"
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
Rather than hard-coding, this requires a by-workspace variable as the pool ID is workspace dependent.