### PR TITLE
fix: mark outputs with sensitive attribute

### DIFF
--- a/aws-aurora-postgres/outputs.tf
+++ b/aws-aurora-postgres/outputs.tf
@@ -1,31 +1,39 @@
 output "database_name" {
   value = module.aurora.database_name
+  sensitive = false
 }
 
 output "master_username" {
   value = module.aurora.database_username
+  sensitive = false
 }
 
 output "master_password" {
   value = module.aurora.database_password
+  sensitive = true
 }
 
 output "endpoint" {
   value = module.aurora.endpoint
+  sensitive = false
 }
 
 output "reader_endpoint" {
   value = module.aurora.reader_endpoint
+  sensitive = false
 }
 
 output "port" {
   value = module.aurora.port
+  sensitive = false
 }
 
 output "cluster_resource_id" {
   value = module.aurora.cluster_resource_id
+  sensitive = false
 }
 
 output "cluster_id" {
   value = module.aurora.rds_cluster_id
+  sensitive = false
 }


### PR DESCRIPTION
### Summary
This PR adds the sensitive attribute to the outputs of this module which are required by newer versions of terraform. Specifically, master_password is a sensitive attribute and needs to marked as such otherwise terraform will throw:

~~~
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 24:
│   24: output "master_password" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true
╵
~~~

