### PR TITLE
chore: [ONCALL-693] Add account-level groups to default Databricks policies

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -135,6 +135,7 @@ module "large_personal_compute_cluster_policy" {
       "hidden" : false
     },
   })
+  grantees = ["CZI - Large Personal Compute"]
 }
 
 module "power_user_compute_cluster_policy" {
@@ -166,7 +167,7 @@ module "power_user_compute_cluster_policy" {
     },
   })
 
-  grantees = [local.power_user_group_name]
+  grantees = [local.power_user_group_name, "CZI - Power User Compute"]
 }
 module "job_compute_cluster_policy" {
   source = "../databricks-cluster-policy"
@@ -178,7 +179,7 @@ module "job_compute_cluster_policy" {
 
   policy_overrides = local.logging_override
 
-  grantees = [local.power_user_group_name]
+  grantees = [local.power_user_group_name, "CZI - Job Compute"]
 }
 
 module "small_job_compute_cluster_policy" {
@@ -197,7 +198,7 @@ module "small_job_compute_cluster_policy" {
     }
   })
 
-  grantees = [local.power_user_group_name]
+  grantees = [local.power_user_group_name, "CZI - Small Job Compute"]
 }
 
 ## Fully custom policies
@@ -246,6 +247,7 @@ module "large_gpu_large_clusters_cluster_policy" {
       "defaultValue" : "g4dn.xlarge"
     },
   })
+  grantees = ["CZI - Large GPU Large Clusters"]
 }
 
 module "large_gpu_personal_cluster_policy" {
@@ -281,6 +283,7 @@ module "large_gpu_personal_cluster_policy" {
       "defaultValue" : "g4dn.xlarge"
     },
   })
+  grantees = ["CZI - Large GPU Personal"]
 }
 
 module "large_gpu_small_clusters_cluster_policy" {
@@ -328,6 +331,7 @@ module "large_gpu_small_clusters_cluster_policy" {
       "defaultValue" : "g4dn.xlarge"
     },
   })
+  grantees = ["CZI - Large GPU Small Clusters"]
 }
 
 module "small_clusters" {
@@ -380,6 +384,7 @@ module "small_clusters" {
       "hidden" : false
     },
   })
+  grantees = ["CZI - Small Clusters"]
 }
 
 module "superset_compute_cluster_policy" {
@@ -415,4 +420,5 @@ module "superset_compute_cluster_policy" {
       "defaultValue" : "superset_pool"
     },
   })
+  grantees = ["CZI - Superset Compute"]
 }


### PR DESCRIPTION
### Summary
This PR gives account-level policy groups in Databricks permissions to use the associated workspaces where the policies are enacted.

### Test Plan
Will apply using ie databricks to make sure the permissions are properly loaded, then will upgrade all remaining databricks policy modules.
