### PR TITLE
fix: [ONCALL-693] Trigger release of databricks-default-cluster-policies

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -73,6 +73,10 @@ module "legacy_shared_compute_cluster_policy" {
   })
 }
 
+## Before addinging new policies, please create an account-level user group to use
+## for assigning permissions. This prevents users from being removed from policies
+## when the workspaces are updated by TFE.
+
 module "personal_compute_cluster_policy" {
   source = "../databricks-cluster-policy"
 


### PR DESCRIPTION
This PR adds a small comment to the default Databricks policies to remind developers to first create a user group in the account for permissions assignments.

It also serves to trigger deployment of this module to include changes made in #550.