### PR TITLE
fix: CDI-2604 Databricks cluster policy permission grants not being applied correctly

### DIFF
--- a/databricks-cluster-policy/main.tf
+++ b/databricks-cluster-policy/main.tf
@@ -35,12 +35,14 @@ resource "databricks_cluster_policy" "inherited_cluster_policy" {
 }
 
 resource "databricks_permissions" "can_use_inherited_cluster_policy" {
-  for_each = local.inherited_cluster_policy_grantees
-
   cluster_policy_id = databricks_cluster_policy.inherited_cluster_policy[0].id
-  access_control {
-    group_name       = each.value
-    permission_level = "CAN_USE"
+  
+  dynamic "access_control" {
+    for_each = local.inherited_cluster_policy_grantees
+    content {
+      group_name       = access_control.value
+      permission_level = "CAN_USE"
+    }
   }
 }
 
@@ -53,11 +55,13 @@ resource "databricks_cluster_policy" "custom_cluster_policy" {
 }
 
 resource "databricks_permissions" "can_use_custom_cluster_policy" {
-  for_each = local.custom_cluster_policy_grantees
-
   cluster_policy_id = databricks_cluster_policy.custom_cluster_policy[0].id
-  access_control {
-    group_name       = each.value
-    permission_level = "CAN_USE"
+
+  dynamic "access_control" {
+    for_each = local.custom_cluster_policy_grantees
+    content {
+      group_name       = access_control.value
+      permission_level = "CAN_USE"
+    }
   }
 }

--- a/databricks-cluster-policy/main.tf
+++ b/databricks-cluster-policy/main.tf
@@ -36,7 +36,8 @@ resource "databricks_cluster_policy" "inherited_cluster_policy" {
 
 resource "databricks_permissions" "can_use_inherited_cluster_policy" {
   cluster_policy_id = databricks_cluster_policy.inherited_cluster_policy[0].id
-  
+
+  # TF provider requires a dynamic block rather than a for_each - for_each will override permissions
   dynamic "access_control" {
     for_each = local.inherited_cluster_policy_grantees
     content {
@@ -57,6 +58,7 @@ resource "databricks_cluster_policy" "custom_cluster_policy" {
 resource "databricks_permissions" "can_use_custom_cluster_policy" {
   cluster_policy_id = databricks_cluster_policy.custom_cluster_policy[0].id
 
+  # TF provider requires a dynamic block rather than a for_each - for_each will override permissions
   dynamic "access_control" {
     for_each = local.custom_cluster_policy_grantees
     content {


### PR DESCRIPTION
### Summary
TF provider requires all grants on the same resource to be in the same resource block, requiring use of a dynamic block instead of a standard for_each

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
