### PR TITLE
fix: CDI_2906 - Update custom job policy to work with jobs

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -444,13 +444,9 @@ module "single_node_cluster_policy" {
   databricks_workspace_id = var.databricks_workspace_id
   policy_name             = "${var.policy_name_prefix}Single Node Job Compute"
   policy_overrides = merge(local.logging_override, {
-    "autotermination_minutes" : {
-      "type" : "fixed",
-      "value" : 120
-    },
     "driver_node_type_id" : {
       "type" : "regex",
-      "pattern" : "([rcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
+      "pattern" : "([mrcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
       "hidden" : false
     },
     "aws_attributes.availability": {
@@ -485,7 +481,7 @@ module "single_node_cluster_policy" {
     },
     "driver_node_type_id" : {
       "type" : "regex",
-      "pattern" : "([rcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
+      "pattern" : "([mrcip]+[3-5]+[d]*\\.[0-1]{0,1}xlarge)",
       "hidden" : false
     },
     "enable_elastic_disk" : {


### PR DESCRIPTION
### Summary
Update small single node dbx cluster policy to work with jobs - does not support autotermination

### Test Plan
Test deploy on a cluster with these changes manually added

### References
(Optional) Additional links to provide more context.
