### PR TITLE
fix: CDI-2906 Fix attributes for single node job compute

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -462,16 +462,15 @@ module "single_node_cluster_policy" {
       "defaultValue": "STANDARD",
       "hidden": false
     },
-    "autoscale.max_workers" : {
-      "type" : "fixed",
-      "value" : 0,
-      "hidden" : true
+    "spark_conf.spark.databricks.cluster.profile":{
+      "type":"fixed",
+      "value":"singleNode",
+      "hidden":true
     },
-    "autoscale.min_workers" : {
-      "type" : "fixed",
-      "value" : 0,
-      "hidden" : true
-    },
+    "num_workers":{
+      "type":"range",
+      "maxValue":0
+    }
     "data_security_mode" : {
       "type" : "whitelist",
       "values" : [


### PR DESCRIPTION
### Summary
Current setup doesn't create any workers but also doesn't specify that there shouldn't be any, causing the driver to fail to schedule jobs against non-existent workers

### Test Plan
Tested manually on ie-databricks

### References
(Optional) Additional links to provide more context.
