### PR TITLE
chore: add iam_role argument to aws-aurora, aws-aurora-postgres, aws-aurora-mysql

### DIFF
--- a/aws-aurora-mysql/main.tf
+++ b/aws-aurora-mysql/main.tf
@@ -16,6 +16,7 @@ module "aurora" {
   db_deletion_protection              = var.db_deletion_protection
   rds_cluster_parameters              = var.rds_cluster_parameters
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  iam_roles                           = var.iam_roles
   performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
   ca_cert_identifier                  = var.ca_cert_identifier

--- a/aws-aurora-mysql/variables.tf
+++ b/aws-aurora-mysql/variables.tf
@@ -164,6 +164,12 @@ variable "iam_database_authentication_enabled" {
   default = false
 }
 
+variable "iam_roles" {
+    type        = list(string)
+    description = "A list of IAM roles to associate with the RDS cluster."
+    default     = []
+}
+
 variable "db_deletion_protection" {
   type    = string
   default = false

--- a/aws-aurora-postgres/main.tf
+++ b/aws-aurora-postgres/main.tf
@@ -22,6 +22,7 @@ module "aurora" {
   db_parameters                       = var.db_parameters
   rds_cluster_parameters              = var.rds_cluster_parameters
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  iam_roles                           = var.iam_roles
   performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = ["postgresql"]
   ca_cert_identifier                  = var.ca_cert_identifier

--- a/aws-aurora-postgres/variables.tf
+++ b/aws-aurora-postgres/variables.tf
@@ -125,6 +125,12 @@ variable "iam_database_authentication_enabled" {
   default = false
 }
 
+variable "iam_roles" {
+    type        = list(string)
+    description = "A list of IAM roles to associate with the RDS cluster."
+    default     = []
+}
+
 variable "ca_cert_identifier" {
   type        = string
   description = "Identifier for the certificate authority."

--- a/aws-aurora/main.tf
+++ b/aws-aurora/main.tf
@@ -62,6 +62,7 @@ resource "aws_rds_cluster" "db" {
   db_subnet_group_name                = var.database_subnet_group
   storage_encrypted                   = true
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  iam_roles                           = var.iam_roles
   backup_retention_period             = 28
   snapshot_identifier                 = var.snapshot_identifier
   final_snapshot_identifier           = "${local.name}-snapshot"

--- a/aws-aurora/variables.tf
+++ b/aws-aurora/variables.tf
@@ -118,6 +118,12 @@ variable "iam_database_authentication_enabled" {
   default     = true
 }
 
+variable "iam_roles" {
+    type        = list(string)
+    description = "A list of IAM roles to associate with the RDS cluster."
+    default     = []
+}
+
 variable "enabled_cloudwatch_logs_exports" {
   type    = list(any)
   default = []


### PR DESCRIPTION
### Summary
Adds iam_role argument to the `aws-aurora` modules

### Test Plan
unittests

### References
The VC litqa agent embddings db requires the ability to add iam_roles to the db cluster
