### PR TITLE
feat: Catalog prefix option

### DIFF
--- a/databricks-catalog-external-location/catalogs.tf
+++ b/databricks-catalog-external-location/catalogs.tf
@@ -1,7 +1,7 @@
 resource "databricks_catalog" "catalog" {
   for_each       = { for idx, catalog in var.catalogs : catalog.name => catalog }
   name           = each.value.name
-  storage_root   = "s3://${module.catalog_bucket.name}/${each.value.name}"
+  storage_root   = "s3://${module.catalog_bucket.name}/${each.value.catalog_prefix != "" ? each.value.catalog_prefix : each.value.name}"
   comment        = "this catalog is managed by terraform"
   isolation_mode = each.value.isolation_mode
   owner          = each.value.owner

--- a/databricks-catalog-external-location/variables.tf
+++ b/databricks-catalog-external-location/variables.tf
@@ -28,5 +28,6 @@ variable "catalogs" {
       all_privileges_groups   = list(string)
       read_privileges_groups  = optional(list(string), [])
       write_privileges_groups = optional(list(string), [])
+      catalog_prefix          = optional(string, "")
   }))
 }


### PR DESCRIPTION
### Summary
I want to be able to give a hardcoded prefix name in case we wanted to not have to recreate a storage bucket for a catalog when renaming the catalog.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
