### PR TITLE
feat: Add BROWSE to catalog perms

### DIFF
--- a/databricks-catalog-external-location/catalogs.tf
+++ b/databricks-catalog-external-location/catalogs.tf
@@ -33,6 +33,7 @@ resource "databricks_grants" "grants" {
         "USE_CATALOG",
         "USE_SCHEMA",
         "SELECT",
+        "BROWSE",
       ]
     }
   }
@@ -48,6 +49,7 @@ resource "databricks_grants" "grants" {
         "CREATE_TABLE",
         "CREATE_SCHEMA",
         "MODIFY",
+        "BROWSE",
       ]
     }
   }

--- a/databricks-s3-volume/grants.tf
+++ b/databricks-s3-volume/grants.tf
@@ -13,7 +13,7 @@ resource "databricks_grant" "catalog_r" {
 
   catalog    = local.catalog_name
   principal  = each.value
-  privileges = ["USE_CATALOG", "USE_SCHEMA", "SELECT"]
+  privileges = ["USE_CATALOG", "USE_SCHEMA", "SELECT", "BROWSE"]
 }
 
 resource "databricks_grant" "catalog_rw" {
@@ -36,6 +36,7 @@ resource "databricks_grant" "catalog_rw" {
     "READ_VOLUME",
     "WRITE_VOLUME",
     "USE_SCHEMA",
+    "BROWSE",
   ]
 }
 


### PR DESCRIPTION
### Summary
`BROWSE` is needed for all users to be able to see the catalogs in the Catalog Explorer. 

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/privileges.html#browse
