### PR TITLE
fix: Add depends_on to databricks_catalog

### DIFF
--- a/databricks-catalog-external-location/catalogs.tf
+++ b/databricks-catalog-external-location/catalogs.tf
@@ -5,6 +5,8 @@ resource "databricks_catalog" "catalog" {
   comment        = "this catalog is managed by terraform"
   isolation_mode = each.value.isolation_mode
   owner          = each.value.owner
+
+  depends_on = [databricks_external_location.external_locations]
 }
 
 resource "databricks_grants" "grants" {


### PR DESCRIPTION
### Summary
catalog is dependent on external location to be created

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
