### PR TITLE
fix: Add depends_on for data source for service principal

### DIFF
--- a/databricks-workspace-e2/main.tf
+++ b/databricks-workspace-e2/main.tf
@@ -49,6 +49,10 @@ resource "databricks_mws_workspaces" "databricks" {
 
 data "databricks_service_principal" "tfe_service_principal" {
   application_id = var.tfe_service_principal_id
+
+  depends_on = [
+    databricks_mws_workspaces.databricks
+  ]
 }
 
 resource "databricks_mws_permission_assignment" "tfe_service_principal_admin" {


### PR DESCRIPTION
### Summary
When trying to import resources locally, I'm getting the error described here: https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/troubleshooting#data-resources-and-authentication-is-not-configured-errors. For this specific resource, it needs the depends_on in order to lazy auth.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
