### PR TITLE
fix: CDI-3446 - Remove read_file permissions from dbx volume

### DIFF
--- a/databricks-s3-volume/grants.tf
+++ b/databricks-s3-volume/grants.tf
@@ -70,8 +70,6 @@ resource "databricks_grant" "volume_rw" {
   principal  = each.value
   privileges = [
     "READ_VOLUME",
-    "READ_FILES",
     "WRITE_VOLUME",
-    "WRITE_FILES",
   ]
 }


### PR DESCRIPTION
### Summary
Despite documentation on Databricks site, `READ_FILES` and `WRITE_FILES` don't seem to be supported permissions for volumes. Removing them here

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
