### PR TITLE
fix: Move out power user group

### DIFF
--- a/databricks-default-cluster-policies/main.tf
+++ b/databricks-default-cluster-policies/main.tf
@@ -2,7 +2,7 @@ data "aws_caller_identity" "current" {
   provider = aws
 }
 locals {
-  power_user_group_name = "Power Users"
+  power_user_group_name = var.power_user_group_name
   all_users_group_name  = "users"
 
   default_policy_family_ids = {
@@ -48,12 +48,6 @@ locals {
       "values" : var.personal_compute_pool_ids
     }
   } : {}
-}
-
-resource "databricks_group" "power_user_group" {
-  display_name               = local.power_user_group_name
-  allow_cluster_create       = true
-  allow_instance_pool_create = false
 }
 
 ## Modified Databricks defaults

--- a/databricks-default-cluster-policies/variables.tf
+++ b/databricks-default-cluster-policies/variables.tf
@@ -38,4 +38,5 @@ variable "policy_map" {
 variable "power_user_group_name" {
   description = "Name of the power user group"
   type = string
+  default = "Power Users"
 }

--- a/databricks-default-cluster-policies/variables.tf
+++ b/databricks-default-cluster-policies/variables.tf
@@ -34,3 +34,8 @@ variable "policy_map" {
   description = "Map of policy names to groups"
   type = list(map(list(string)))
 }
+
+variable "power_user_group_name" {
+  description = "Name of the power user group"
+  type = string
+}


### PR DESCRIPTION
This group was causing issues if you wanted to create multiple versions of this module in one env.