### PR TITLE
fix: databricks-catalog-external-location - Make role self-assuming

### DIFF
--- a/databricks-catalog-external-location/main.tf
+++ b/databricks-catalog-external-location/main.tf
@@ -60,7 +60,10 @@ data "aws_iam_policy_document" "databricks_external_location_assume_role" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"]
+      identifiers = [
+        "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.iam_role_name}"
+      ]
     }
 
     actions = ["sts:AssumeRole"]


### PR DESCRIPTION
### Summary
Fix the role managing access to a Databricks external location to be self-assuming.

### Test Plan
- TFE checks
- ran in a development environment

### References
https://docs.databricks.com/en/connect/unity-catalog/storage-credentials.html#step-3-update-the-iam-role-trust-relationship-policy
