### PR TITLE
feat: update go lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+        
       # - uses: hashicorp/setup-terraform@v1
       #   with:
       #     terraform_version: 0.14.5
@@ -33,7 +40,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60.3
-          github-token: ${{ secrets.GITHUB_TOKEN }}      
+          github-token: ${{ secrets.GITHUB_TOKEN }}  
 
   test:
     name: test ${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,6 @@ jobs:
           cache: true
           cache-dependency-path: |
             go.sum
-        
-      # - uses: hashicorp/setup-terraform@v1
-      #   with:
-      #     terraform_version: 0.14.5
-      #     terraform_wrapper: "false"
-      # - name: setup
-      #   run: make setup
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,30 @@ jobs:
         run: echo "::set-output name=matrix::$(ls -d */|sed -e 's/\///'|grep -v 'bless-ca\|scripts'|jq -cnR '[inputs | select(length>0)]')"
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: [ARM64, self-hosted, Linux]
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v1
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
         with:
-          terraform_version: 0.14.5
-          terraform_wrapper: "false"
-      - name: setup
-        run: make setup
-      - uses: golangci/golangci-lint-action@v3
+          app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
+          private_key: ${{ secrets.CZI_GITHUB_HELPER_PK }}
+      - uses: actions/checkout@v4
         with:
-          version: v1.56.2
-          args: --timeout=5m
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      # - uses: hashicorp/setup-terraform@v1
+      #   with:
+      #     terraform_version: 0.14.5
+      #     terraform_wrapper: "false"
+      # - name: setup
+      #   run: make setup
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60.3
+          github-token: ${{ secrets.GITHUB_TOKEN }}      
+
   test:
     name: test ${{ matrix.module }}
     needs: get-modules

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,4 +9,10 @@ linters:
     - gofmt
     - whitespace
     - unparam
-    - scopelint
+    - forbidigo
+    - gocritic
+
+output:
+  formats:
+    - format: tab
+  show-stats: true

--- a/aws-s3-public-bucket/module_test.go
+++ b/aws-s3-public-bucket/module_test.go
@@ -111,9 +111,10 @@ func TestPublicBucketDefaults(t *testing.T) {
 			}
 
 			for _, test := range sims {
-				resp := tftest.S3SimulateRequest(t, region, test.action, test.arn, bucketPolicy, test.secureTransport)
-				fmt.Println("Testing ", test.action, " with https enabled=", test.secureTransport)
-				r.Equal(test.result, *resp.EvalDecision)
+				t.Run(fmt.Sprintf("Testing %s with https enabled=%t", test.action, test.secureTransport), func(t *testing.T) {
+					resp := tftest.S3SimulateRequest(t, region, test.action, test.arn, bucketPolicy, test.secureTransport)
+					r.Equal(test.result, *resp.EvalDecision)
+				})
 			}
 		},
 	}

--- a/bless-ca/test/module_test.go
+++ b/bless-ca/test/module_test.go
@@ -26,7 +26,7 @@ func TestBlessCAInitAndApply(t *testing.T) {
 			return tftest.Options(
 				region,
 				map[string]interface{}{
-					//test only
+					// test only
 					"region":                     region,
 					"bless_provider_aws_profile": tftest.EnvVar(tftest.EnvAWSProfile),
 					"test_user_name":             fmt.Sprintf("bless-%s", tftest.UniqueID()),


### PR DESCRIPTION
### Summary
This change is for updating linter in this repo. James' [PR](https://github.com/chanzuckerberg/cztack/actions/runs/11490041738/job/32020193024) has been failing on this issue, so we're upgrading the go lint package to the latest and to used our self-hosted runner.

### Test Plan
As long as all check pass, it should be fine.

### References
[Argus Lint yaml](https://github.com/chanzuckerberg/argus/blob/12e26b94100f5ce86d3f92ee7d5a886abd1c97a5/.github/workflows/core-ci.yaml)