### PR TITLE
fix: concat two list of strings then turn it into set

### DIFF
--- a/aws-iam-role-s3-readonly/main.tf
+++ b/aws-iam-role-s3-readonly/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "s3-bucket-readonly" {
     actions = [
       "s3:ListAllMyBuckets"
     ]
-    resources = toset(formatlist("arn:aws:s3:::%s", var.s3_bucket_names), formatlist("arn:aws:s3:::%s/*", var.s3_bucket_names))
+    resources = toset(concat(formatlist("arn:aws:s3:::%s", var.s3_bucket_names), formatlist("arn:aws:s3:::%s/*", var.s3_bucket_names)))
   }
 }
 


### PR DESCRIPTION
### Summary
To fix this error
```
Error: Too many function arguments
│ 
│   on .terraform/modules/biohub-s3-readonly/aws-iam-role-s3-readonly/main.tf line 55, in data "aws_iam_policy_document" "s3-bucket-readonly":
│   55:     resources = toset(formatlist("arn:aws:s3:::%s", var.s3_bucket_names), formatlist("arn:aws:s3:::%s/*", var.s3_bucket_names))
│     ├────────────────
│     │ while calling toset(v)
│     │ var.s3_bucket_names is a set of string
│ 
│ Function "toset" expects only 1 argument(s).
```

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
