### PR TITLE
fix: add an optional redirect bucket variable for the redirect module

### DIFF
--- a/aws-cloudfront-domain-redirect/main.tf
+++ b/aws-cloudfront-domain-redirect/main.tf
@@ -9,7 +9,8 @@ locals {
 }
 
 resource "aws_s3_bucket" "redirect_bucket" {
-  bucket = "redirect-${var.source_domain}-to-${var.target_domain}"
+  bucket = (var.redirect_bucket_name == null) : "redirect-${var.source_domain}-to-${var.target_domain}" ? var.redirect_bucket_name
+  
   website {
     redirect_all_requests_to = "https://${var.target_domain}"
   }

--- a/aws-cloudfront-domain-redirect/variables.tf
+++ b/aws-cloudfront-domain-redirect/variables.tf
@@ -38,3 +38,9 @@ variable "lambda_cloudwatch_log_retention_in_days" {
   description = "Retention policy (in days) for Lambda function's logs in Cloudwatch"
   default     = null
 }
+
+variable "redirect_bucket_name" {
+  type        = string
+  description = "Unique name for the redirect bucket (provide if possible)."
+  default     = null
+}


### PR DESCRIPTION
sometimes the default variable is too long, so this will provide an optional name if that's the case.