### PR TITLE
fix: variable name

### DIFF
--- a/databricks-s3-volume-existing-catalog/grants.tf
+++ b/databricks-s3-volume-existing-catalog/grants.tf
@@ -11,7 +11,7 @@ locals {
   volume_rw_grants = flatten([
     for volume in var.volume_buckets : [
       for principal in volume.volume_rw_grant_principals : {
-        bucket_name = volume.volume_name
+        volume_name = volume.volume_name
         principal   = principal
       }
     ]

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -24,7 +24,7 @@ locals {
 
 ### Databricks storage credential - allows workspace to access an external location.
 ### NOTE: names need to be unique across an account, not just a workspace
-### NOTE: 
+### NOTE:
 
 resource "databricks_storage_credential" "volume" {
   count = var.create_storage_credential ? 1 : 0


### PR DESCRIPTION
Fixing attribute name for read-write principals to match that of read principals, also making consistent with usage below of the `volume_name` attribute.