### PR TITLE
feat!: Allow separate backing buckets for Databricks Catalog and Volume

### DIFF
--- a/aws-acm-certificate/README.md
+++ b/aws-acm-certificate/README.md
@@ -40,7 +40,7 @@ module "cert" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-aurora/README.md
+++ b/aws-aurora/README.md
@@ -13,7 +13,7 @@ This is a low-level module for creating AWS Aurora clusters. We strongly reccome
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.44.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-cloudfront-domain-redirect/README.md
+++ b/aws-cloudfront-domain-redirect/README.md
@@ -39,7 +39,7 @@ module domain-redirect {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-cloudfront-logs-bucket/README.md
+++ b/aws-cloudfront-logs-bucket/README.md
@@ -35,7 +35,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-cloudwatch-log-group/README.md
+++ b/aws-cloudwatch-log-group/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-default-vpc-security/README.md
+++ b/aws-default-vpc-security/README.md
@@ -44,7 +44,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-efs-volume/README.md
+++ b/aws-efs-volume/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-group-console-login/README.md
+++ b/aws-iam-group-console-login/README.md
@@ -26,7 +26,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-instance-profile/README.md
+++ b/aws-iam-instance-profile/README.md
@@ -37,7 +37,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-policy-cwlogs/README.md
+++ b/aws-iam-policy-cwlogs/README.md
@@ -26,7 +26,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-admin/README.md
+++ b/aws-iam-role-admin/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-bless/README.md
+++ b/aws-iam-role-bless/README.md
@@ -28,7 +28,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-cloudfront-poweruser/README.md
+++ b/aws-iam-role-cloudfront-poweruser/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-crossacct/README.md
+++ b/aws-iam-role-crossacct/README.md
@@ -27,7 +27,7 @@ module "group" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-ec2-poweruser/README.md
+++ b/aws-iam-role-ec2-poweruser/README.md
@@ -27,7 +27,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-ecs-poweruser/README.md
+++ b/aws-iam-role-ecs-poweruser/README.md
@@ -26,7 +26,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-infraci/README.md
+++ b/aws-iam-role-infraci/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-poweruser/README.md
+++ b/aws-iam-role-poweruser/README.md
@@ -25,7 +25,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-readonly/README.md
+++ b/aws-iam-role-readonly/README.md
@@ -29,7 +29,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-route53domains-poweruser/README.md
+++ b/aws-iam-role-route53domains-poweruser/README.md
@@ -26,7 +26,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role-security-audit/README.md
+++ b/aws-iam-role-security-audit/README.md
@@ -21,7 +21,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-iam-role/README.md
+++ b/aws-iam-role/README.md
@@ -34,7 +34,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-lambda-edge-add-security-headers/README.md
+++ b/aws-lambda-edge-add-security-headers/README.md
@@ -43,7 +43,7 @@ resource aws_cloudfront_distribution cf {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
 
 ## Modules
 

--- a/aws-params-reader-policy/README.md
+++ b/aws-params-reader-policy/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-params-secrets-setup/README.md
+++ b/aws-params-secrets-setup/README.md
@@ -14,7 +14,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-redis-node/README.md
+++ b/aws-redis-node/README.md
@@ -12,7 +12,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-redis-replication-group/README.md
+++ b/aws-redis-replication-group/README.md
@@ -15,7 +15,7 @@ a replication group with the given parameters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-s3-account-public-access-block/README.md
+++ b/aws-s3-account-public-access-block/README.md
@@ -17,7 +17,7 @@ Restrict:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | > 2.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-s3-private-bucket/README.md
+++ b/aws-s3-private-bucket/README.md
@@ -41,7 +41,7 @@ module "s3-bucket" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.76.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/aws-s3-public-bucket/README.md
+++ b/aws-s3-public-bucket/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.29.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 

--- a/databricks-s3-volume/README.md
+++ b/databricks-s3-volume/README.md
@@ -59,6 +59,7 @@
 | <a name="input_create_storage_credential"></a> [create\_storage\_credential](#input\_create\_storage\_credential) | (Optional) Flag to create a new Databricks storage credential or look for an existing one for the given bucket\_name | `bool` | `true` | no |
 | <a name="input_metastore_id"></a> [metastore\_id](#input\_metastore\_id) | ID of metastore to create catalog in | `string` | n/a | yes |
 | <a name="input_override_bucket_name"></a> [override\_bucket\_name](#input\_override\_bucket\_name) | (Optional) Name of the S3 bucket to create or use for Databricks volume, overriding the default | `string` | `null` | no |
+| <a name="input_override_catalog_storage_root"></a> [override\_catalog\_storage\_root](#input\_override\_catalog\_storage\_root) | (Optional) Override storage root of catalog instead of using bucket name | `string` | `null` | no |
 | <a name="input_override_policy_documents"></a> [override\_policy\_documents](#input\_override\_policy\_documents) | (Optional) Additional bucket policies to apply to the bucket. These should already be in JSON | `list(string)` | `[]` | no |
 | <a name="input_override_storage_location"></a> [override\_storage\_location](#input\_override\_storage\_location) | (Optional) Prefix to use for the storage location in case of an existing bucket (e.g. 's3://bucket' or 's3://bucket/prefix') | `string` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | User or group name of the owner - will be applied to the catalog, schema, and volume, if applicable | `string` | n/a | yes |

--- a/databricks-s3-volume/README.md
+++ b/databricks-s3-volume/README.md
@@ -54,26 +54,27 @@
 | <a name="input_catalog_name"></a> [catalog\_name](#input\_catalog\_name) | Name of the Databricks existing catalog to add the volume to | `string` | n/a | yes |
 | <a name="input_catalog_r_grant_principals"></a> [catalog\_r\_grant\_principals](#input\_catalog\_r\_grant\_principals) | (Optional) Databricks groups to grant read-only permissions to on the catalog | `list(string)` | `[]` | no |
 | <a name="input_catalog_rw_grant_principals"></a> [catalog\_rw\_grant\_principals](#input\_catalog\_rw\_grant\_principals) | (Optional) Databricks groups to grant read/write permissions to on the catalog | `list(string)` | `[]` | no |
+| <a name="input_catalog_storage_root_bucket_name"></a> [catalog\_storage\_root\_bucket\_name](#input\_catalog\_storage\_root\_bucket\_name) | (Optional) Override storage root of catalog instead of using bucket name | `string` | `null` | no |
 | <a name="input_create_catalog"></a> [create\_catalog](#input\_create\_catalog) | Flag to create a new catalog or look for an existing one with the given name | `bool` | n/a | yes |
+| <a name="input_create_catalog_bucket"></a> [create\_catalog\_bucket](#input\_create\_catalog\_bucket) | n/a | `bool` | `false` | no |
 | <a name="input_create_schema"></a> [create\_schema](#input\_create\_schema) | Flag to create a new catalog or look for an existing one with the given name | `bool` | n/a | yes |
 | <a name="input_create_storage_credential"></a> [create\_storage\_credential](#input\_create\_storage\_credential) | (Optional) Flag to create a new Databricks storage credential or look for an existing one for the given bucket\_name | `bool` | `true` | no |
+| <a name="input_create_volume_bucket"></a> [create\_volume\_bucket](#input\_create\_volume\_bucket) | n/a | `bool` | `false` | no |
 | <a name="input_metastore_id"></a> [metastore\_id](#input\_metastore\_id) | ID of metastore to create catalog in | `string` | n/a | yes |
-| <a name="input_override_bucket_name"></a> [override\_bucket\_name](#input\_override\_bucket\_name) | (Optional) Name of the S3 bucket to create or use for Databricks volume, overriding the default | `string` | `null` | no |
-| <a name="input_override_catalog_storage_root"></a> [override\_catalog\_storage\_root](#input\_override\_catalog\_storage\_root) | (Optional) Override storage root of catalog instead of using bucket name | `string` | `null` | no |
 | <a name="input_override_policy_documents"></a> [override\_policy\_documents](#input\_override\_policy\_documents) | (Optional) Additional bucket policies to apply to the bucket. These should already be in JSON | `list(string)` | `[]` | no |
-| <a name="input_override_storage_location"></a> [override\_storage\_location](#input\_override\_storage\_location) | (Optional) Prefix to use for the storage location in case of an existing bucket (e.g. 's3://bucket' or 's3://bucket/prefix') | `string` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | User or group name of the owner - will be applied to the catalog, schema, and volume, if applicable | `string` | n/a | yes |
 | <a name="input_read_only_volume"></a> [read\_only\_volume](#input\_read\_only\_volume) | (Optional) Flag to set volume as read-only | `bool` | `false` | no |
 | <a name="input_schema_name"></a> [schema\_name](#input\_schema\_name) | Name of the Databricks schema to add the volume to | `string` | n/a | yes |
 | <a name="input_schema_r_grant_principals"></a> [schema\_r\_grant\_principals](#input\_schema\_r\_grant\_principals) | (Optional) Databricks groups to grant read-only permissions to on the schema | `list(string)` | `[]` | no |
 | <a name="input_schema_rw_grant_principals"></a> [schema\_rw\_grant\_principals](#input\_schema\_rw\_grant\_principals) | (Optional) Databricks groups to grant read/write permissions to on the schema | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | REQUIRED: Tags to include for this environment. | <pre>object({<br>    project : string<br>    env : string<br>    service : string<br>    owner : string<br>    managedBy : string<br>  })</pre> | n/a | yes |
-| <a name="input_volume_bucket"></a> [volume\_bucket](#input\_volume\_bucket) | (Optional) Name of an existing S3 bucket to use for Databricks volume. NOTE: if provided, you will need to update the bucket policy whereever it is defined to allow Databricks access | `string` | `null` | no |
+| <a name="input_volume_bucket_name"></a> [volume\_bucket\_name](#input\_volume\_bucket\_name) | (Optional) Name of S3 bucket to use for Databricks volume. NOTE: if provided, you will need to update the bucket policy whereever it is defined to allow Databricks access | `string` | `null` | no |
 | <a name="input_volume_comment"></a> [volume\_comment](#input\_volume\_comment) | (Optional) Comment to add to the Databricks volume | `string` | `"Managed by Terraform - this is a default volume for the Databricks workspace"` | no |
 | <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | Name of the Databricks volume to create | `string` | n/a | yes |
 | <a name="input_volume_r_grant_principals"></a> [volume\_r\_grant\_principals](#input\_volume\_r\_grant\_principals) | (Optional) Databricks groups to grant read-only permissions to on the volume | `list(string)` | `[]` | no |
 | <a name="input_volume_rw_grant_principals"></a> [volume\_rw\_grant\_principals](#input\_volume\_rw\_grant\_principals) | (Optional) Databricks groups to grant read/write permissions to on the volume | `list(string)` | `[]` | no |
 | <a name="input_volume_schema_properties"></a> [volume\_schema\_properties](#input\_volume\_schema\_properties) | Properties of the Databricks schema to add the volume to | `map(string)` | `{}` | no |
+| <a name="input_volume_storage_location"></a> [volume\_storage\_location](#input\_volume\_storage\_location) | (Optional) Prefix to use for the storage location in case of an existing bucket (e.g. 's3://bucket' or 's3://bucket/prefix') | `string` | `null` | no |
 | <a name="input_workspace_name"></a> [workspace\_name](#input\_workspace\_name) | Name of the Databricks catalog to add the volume to | `string` | n/a | yes |
 
 ## Outputs

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_iam_policy_document" "databricks-s3" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.value.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.key.bucket_name] :
     []
   )
 
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "databricks-s3" {
 module "databricks_bucket" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.value.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.key.bucket_name] :
     []
   )
   depends_on = [

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_iam_policy_document" "databricks-s3" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element[bucket_name]] :
+    [for element in local.dbx_resource_storage_config : element.bucket_name] :
     []
   )
 
@@ -106,7 +106,11 @@ data "aws_iam_policy_document" "databricks-s3" {
 }
 
 module "databricks_bucket" {
-  for_each = local.new_buckets
+  for_each = (
+    var.create_volume_bucket ?
+    [for element in local.dbx_resource_storage_config : element.bucket_name] :
+    []
+  )
   depends_on = [
     aws_iam_role.dbx_unity_aws_role
   ]

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -6,12 +6,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "databricks-s3" {
-  for_each = (
-    var.create_volume_bucket ?
-    toset([for element in local.dbx_resource_storage_config : element["bucket_name"]]) :
-    toset([])
-  )
-
+  for_each                  = local.creating_s3_buckets
   override_policy_documents = var.override_policy_documents
 
   # standard UC access
@@ -106,11 +101,7 @@ data "aws_iam_policy_document" "databricks-s3" {
 }
 
 module "databricks_bucket" {
-  for_each = (
-    var.create_volume_bucket ?
-    toset([for element in local.dbx_resource_storage_config : element["bucket_name"]]) :
-    toset([])
-  )
+  for_each = local.creating_s3_buckets
   depends_on = [
     aws_iam_role.dbx_unity_aws_role
   ]

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_iam_policy_document" "databricks-s3" {
   for_each = length(
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.value["bucket_name"]] :
+    [for element in local.dbx_resource_storage_config : element["bucket_name"]] :
     []
   )
 
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "databricks-s3" {
 module "databricks_bucket" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.value["bucket_name"]] :
+    [for element in local.dbx_resource_storage_config : element["bucket_name"]] :
     []
   )
   depends_on = [

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -8,8 +8,8 @@ locals {
 data "aws_iam_policy_document" "databricks-s3" {
   for_each = length(
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element["bucket_name"]] :
-    []
+    toset([for element in local.dbx_resource_storage_config : element["bucket_name"]]) :
+    toset([])
   )
 
   override_policy_documents = var.override_policy_documents
@@ -108,8 +108,8 @@ data "aws_iam_policy_document" "databricks-s3" {
 module "databricks_bucket" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element["bucket_name"]] :
-    []
+    toset([for element in local.dbx_resource_storage_config : element["bucket_name"]]) :
+    toset([])
   )
   depends_on = [
     aws_iam_role.dbx_unity_aws_role

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_iam_policy_document" "databricks-s3" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.value.bucket_name] :
     []
   )
 
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "databricks-s3" {
 module "databricks_bucket" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.value.bucket_name] :
     []
   )
   depends_on = [

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "databricks-s3" {
-  for_each = length(
+  for_each = (
     var.create_volume_bucket ?
     toset([for element in local.dbx_resource_storage_config : element["bucket_name"]]) :
     toset([])

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -6,9 +6,9 @@ locals {
 }
 
 data "aws_iam_policy_document" "databricks-s3" {
-  for_each = (
+  for_each = length(
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.key.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.value["bucket_name"]] :
     []
   )
 
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "databricks-s3" {
 module "databricks_bucket" {
   for_each = (
     var.create_volume_bucket ?
-    [for element in local.dbx_resource_storage_config : element.key.bucket_name] :
+    [for element in local.dbx_resource_storage_config : element.value["bucket_name"]] :
     []
   )
   depends_on = [

--- a/databricks-s3-volume/bucket.tf
+++ b/databricks-s3-volume/bucket.tf
@@ -6,7 +6,11 @@ locals {
 }
 
 data "aws_iam_policy_document" "databricks-s3" {
-  for_each = local.new_buckets
+  for_each = (
+    var.create_volume_bucket ?
+    [for element in local.dbx_resource_storage_config : element[bucket_name]] :
+    []
+  )
 
   override_policy_documents = var.override_policy_documents
 

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -37,7 +37,11 @@ data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
 }
 
 resource "aws_iam_role" "dbx_unity_aws_role" {
-  count = local.create_storage_credentials ? 1 : 0
+  for_each = (
+    local.create_storage_credentials ?
+    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
+    toset([])
+  )
 
   name               = local.unity_aws_role_name
   path               = local.iam_role_path

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -90,9 +90,13 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
 }
 
 resource "aws_iam_policy" "dbx_unity_access_policy" {
-  count = local.create_storage_credentials ? 1 : 0
+  for_each = (
+    local.create_storage_credentials ?
+    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
+    toset([])
+  )
 
-  policy = data.aws_iam_policy_document.volume_bucket_dbx_unity_access[0].json
+  policy = data.aws_iam_policy_document.volume_bucket_dbx_unity_access[each.key].json
 }
 
 resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -37,11 +37,7 @@ data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
 }
 
 resource "aws_iam_role" "dbx_unity_aws_role" {
-  for_each = (
-    local.create_storage_credentials ?
-    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
-    toset([])
-  )
+  count = local.create_storage_credentials ? 1 : 0
 
   name               = local.unity_aws_role_name
   path               = local.iam_role_path
@@ -111,5 +107,5 @@ resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {
   )
 
   policy_arn = aws_iam_policy.dbx_unity_access_policy[each.key].arn
-  role       = aws_iam_role.dbx_unity_aws_role[each.key].name
+  role       = aws_iam_role.dbx_unity_aws_role.name
 }

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -100,8 +100,12 @@ resource "aws_iam_policy" "dbx_unity_access_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {
-  count = local.create_storage_credentials ? 1 : 0
+  for_each = (
+    local.create_storage_credentials ?
+    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
+    toset([])
+  )
 
-  policy_arn = aws_iam_policy.dbx_unity_access_policy[0].arn
-  role       = aws_iam_role.dbx_unity_aws_role[0].name
+  policy_arn = aws_iam_policy.dbx_unity_access_policy[each.key].arn
+  role       = aws_iam_role.dbx_unity_aws_role[each.key].name
 }

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
   for_each = (
     local.create_storage_credentials ?
-    [for resource in local.dbx_resource_storage_config : resource.key.bucket_name] :
+    [for resource in local.dbx_resource_storage_config : resource.value["bucket_name"]] :
     []
   )
 

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
     condition {
       test     = "ArnEquals"
       variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.unity_aws_role_name}"]
+      values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.iam_role_path}${local.unity_aws_role_name}"]
     }
   }
 }
@@ -40,7 +40,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
   count = local.create_storage_credential ? 1 : 0
 
   name               = local.unity_aws_role_name
-  path               = local.path
+  path               = local.iam_role_path
   assume_role_policy = data.aws_iam_policy_document.dbx_unity_aws_role_assume_role[0].json
 }
 
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
       "s3:PutLifecycleConfiguration"
     ]
     resources = [
-      "arn:aws:s3:::${local.bucket_name}",
+      "arn:aws:s3:::${local.volume_bucket_name}",
     ]
   }
   statement {
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
       "s3:DeleteObject",
     ]
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/*",
+      "arn:aws:s3:::${local.volume_bucket_name}/*",
     ]
   }
   statement {
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
       "sts:AssumeRole"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.unity_aws_role_name}"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.iam_role_path}${local.unity_aws_role_name}"
     ]
   }
 }

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
   for_each = (
     local.create_storage_credentials ?
-    [for resource in local.dbx_resource_storage_config : resource.value["bucket_name"]] :
+    [for resource in local.dbx_resource_storage_config : resource["bucket_name"]] :
     []
   )
 

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -90,21 +90,13 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
 }
 
 resource "aws_iam_policy" "dbx_unity_access_policy" {
-  for_each = (
-    local.create_storage_credentials ?
-    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
-    toset([])
-  )
+  for_each = local.creating_storage_credentials
 
   policy = data.aws_iam_policy_document.volume_bucket_dbx_unity_access[each.key].json
 }
 
 resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {
-  for_each = (
-    local.create_storage_credentials ?
-    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
-    toset([])
-  )
+  for_each = local.creating_storage_credentials
 
   policy_arn = aws_iam_policy.dbx_unity_access_policy[each.key].arn
   role       = aws_iam_role.dbx_unity_aws_role[0].name

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
   for_each = (
     local.create_storage_credentials ?
-    [for resource in local.dbx_resource_storage_config : resource.value.bucket_name] :
+    [for resource in local.dbx_resource_storage_config : resource.key.bucket_name] :
     []
   )
 

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -48,8 +48,8 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
   for_each = (
     local.create_storage_credentials ?
-    [for resource in local.dbx_resource_storage_config : resource["bucket_name"]] :
-    []
+    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
+    toset([])
   )
 
   statement {

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
   for_each = (
     local.create_storage_credentials ?
-    [for resource in local.dbx_resource_storage_config : resource.bucket_name] :
+    [for resource in local.dbx_resource_storage_config : resource.value.bucket_name] :
     []
   )
 

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -107,5 +107,5 @@ resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {
   )
 
   policy_arn = aws_iam_policy.dbx_unity_access_policy[each.key].arn
-  role       = aws_iam_role.dbx_unity_aws_role.name
+  role       = aws_iam_role.dbx_unity_aws_role[0].name
 }

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -21,7 +21,7 @@ locals {
 
   create_storage_credential = var.create_catalog || var.create_storage_credential
   volume_storage_location = coalesce(
-    "s3://${var.volume_storage_location},
+    "s3://${var.volume_storage_location}",
     "s3://${local.volume_bucket_name}/${local.schema_name}/${local.volume_name}"
   )
   storage_credential_name = "${local.catalog_name}-${local.schema_name}-${local.volume_name}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -43,7 +43,7 @@ locals {
   }
 
   creating_storage_credentials = (
-    create_storage_credentials == true ? {
+    var.create_storage_credentials == true ? {
       for k, v in local.dbx_resource_storage_config :
       v["bucket_name"] => v["storage_credential_name"]
       if v["create_bucket"] == true

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -96,7 +96,7 @@ resource "databricks_catalog" "volume" {
     var.create_catalog ?
     [
       for element in local.dbx_resource_storage_config :
-      element if element.resource_name == local.catalog_name
+      element if element.value.resource_name == local.catalog_name
     ] :
     []
   )

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -108,7 +108,7 @@ resource "databricks_volume" "volume" {
   catalog_name     = local.catalog_name
   schema_name      = local.schema_name
   volume_type      = "EXTERNAL"
-  storage_location = local.storage_location
+  storage_location = local.volume_storage_location
   owner            = var.owner
   comment          = "This volume is managed by Terraform - ${var.volume_comment}"
 }

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -48,8 +48,8 @@ locals {
 resource "databricks_storage_credential" "this" {
   for_each = (
     local.create_storage_credentials == true ?
-    local.dbx_resource_storage_config :
-    []
+    toset([for element in local.dbx_resource_storage_config : element.storage_credential_name]) :
+    toset([])
   )
 
   depends_on = [

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -20,6 +20,7 @@ locals {
   # Allow overriding the storage location in case of an existing bucket
   storage_location = var.override_storage_location != null ? var.override_storage_location : "s3://${local.bucket_name}/${local.schema_name}/${local.volume_name}"
 
+  catalog_storage_root = coalesce(var.override_catalog_storage_root, local.bucket_name)
 }
 
 ### Databricks storage credential - allows workspace to access an external location.

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -100,9 +100,10 @@ resource "databricks_external_location" "this" {
 resource "databricks_catalog" "volume" {
   for_each = (
     var.create_catalog ?
+    # get the catalog-related entry (not the volume one)
     {
       for element in local.dbx_resource_storage_config :
-      element["resource_name"] => element["catalog_bucket_name"]
+      element["resource_name"] => element["bucket_name"]
       if element["resource_name"] == local.catalog_name
     } :
     {}

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -35,7 +35,7 @@ locals {
     {
       bucket_name = local.catalog_bucket_name,
       resource_name = local.catalog_name,
-      storage_location = local.catalog_bucket_name,
+      storage_location = "s3://${local.catalog_bucket_name}",
       storage_credential_name = "${local.catalog_name}-catalog",
     }
   ])
@@ -89,7 +89,7 @@ resource "databricks_external_location" "this" {
   ]
 
   name            = databricks_storage_credential.this[each.key].name
-  url             = "s3://${each.value}"
+  url             = each.value
   credential_name = databricks_storage_credential.this[each.key].name
   comment         = "Managed by Terraform - access for ${each.key}"
   read_only       = var.read_only_volume

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -39,19 +39,6 @@ locals {
       storage_credential_name = "${local.catalog_name}-catalog",
     }
   ]
-
-  volume_storage_credential_name = "${local.catalog_name}-${local.schema_name}-${local.volume_name}"
-
-  new_storage_locations = (
-    create_storage_locations != true ? [] : (
-      toset([
-        local.catalog_bucket_name,
-        local.volume_bucket_name == local.catalog_bucket_name ?
-          local.catalog_bucket_name :
-          local.volume_storage_location
-      ])
-    )
-  )
 }
 
 ### Databricks storage credential - allows workspace to access an external location.

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -125,7 +125,7 @@ resource "databricks_schema" "volume" {
 }
 
 resource "databricks_volume" "volume" {
-  depends_on       = [databricks_external_location.volume, databricks_schema.volume]
+  depends_on       = [databricks_external_location.this, databricks_schema.volume]
   name             = local.volume_name
   catalog_name     = local.catalog_name
   schema_name      = local.schema_name

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -82,7 +82,7 @@ resource "databricks_catalog" "volume" {
   name         = local.catalog_name
   metastore_id = var.metastore_id
   owner        = var.owner
-  storage_root = "s3://${local.catalog_storage_root}"
+  storage_root = "s3://${local.catalog_storage_root_bucket_name}"
   comment      = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"
   properties = {
     purpose = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -64,7 +64,7 @@ resource "databricks_storage_credential" "this" {
   name = each.value
 
   aws_iam_role {
-    role_arn = aws_iam_role.dbx_unity_aws_role[each.key].arn
+    role_arn = aws_iam_role.dbx_unity_aws_role[0].arn
   }
 
   comment   = "Managed by Terraform - access for ${each.key}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -58,13 +58,13 @@ resource "databricks_storage_credential" "this" {
     module.databricks_bucket
   ]
 
-  name = each.storage_credential_name
+  name = each.value.storage_credential_name
 
   aws_iam_role {
-    role_arn = aws_iam_role.dbx_unity_aws_role[each.bucket_name].arn
+    role_arn = aws_iam_role.dbx_unity_aws_role[each.value.bucket_name].arn
   }
 
-  comment   = "Managed by Terraform - access for ${each.bucket_name}"
+  comment   = "Managed by Terraform - access for ${each.value.bucket_name}"
   read_only = var.read_only_volume
 }
 
@@ -82,10 +82,10 @@ resource "databricks_external_location" "this" {
     databricks_storage_credential.this,
   ]
 
-  name            = databricks_storage_credential.this[each.bucket_name].name
-  url             = "s3://${each.store_location}"
-  credential_name = databricks_storage_credential.this[each.bucket_name].name
-  comment         = "Managed by Terraform - access for ${each.bucket_name}"
+  name            = databricks_storage_credential.this[each.value.bucket_name].name
+  url             = "s3://${each.value.store_location}"
+  credential_name = databricks_storage_credential.this[each.value.bucket_name].name
+  comment         = "Managed by Terraform - access for ${each.value.bucket_name}"
   read_only       = var.read_only_volume
 }
 
@@ -102,10 +102,10 @@ resource "databricks_catalog" "volume" {
   )
   depends_on   = [databricks_external_location.this]
 
-  name         = each.resource_name
+  name         = each.value.resource_name
   metastore_id = var.metastore_id
   owner        = var.owner
-  storage_root = "s3://${each.catalog_bucket_name}"
+  storage_root = "s3://${each.value.catalog_bucket_name}"
   comment      = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"
   properties = {
     purpose = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -83,7 +83,7 @@ resource "databricks_catalog" "volume" {
   name         = local.catalog_name
   metastore_id = var.metastore_id
   owner        = var.owner
-  storage_root = "s3://${local.catalog_storage_root}"
+  storage_root = "s3://${local.catalog_storage_root_bucket_name}"
   comment      = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"
   properties = {
     purpose = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -66,7 +66,7 @@ resource "databricks_storage_credential" "this" {
   )
 
   depends_on = [
-    resource.aws_iam_role.dbx_unity_aws_role[each.bucket_name],
+    resource.aws_iam_role.dbx_unity_aws_role,
     resource.aws_iam_role_policy_attachment.dbx_unity_aws_access,
     module.databricks_bucket
   ]

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -25,7 +25,7 @@ locals {
     "s3://${local.volume_bucket_name}/${local.schema_name}/${local.volume_name}"
   )
 
-  dbx_resource_storage_config = [
+  dbx_resource_storage_config = toset([
     {
       bucket_name = local.volume_bucket_name,
       resource_name = local.volume_name,
@@ -38,7 +38,7 @@ locals {
       storage_location = local.catalog_bucket_name,
       storage_credential_name = "${local.catalog_name}-catalog",
     }
-  ]
+  ])
 }
 
 ### Databricks storage credential - allows workspace to access an external location.

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -85,6 +85,7 @@ resource "databricks_external_location" "this" {
   }
   depends_on = [
     time_sleep.wait_30_seconds,
+    resource.aws_iam_role.dbx_unity_aws_role,
     databricks_storage_credential.this,
   ]
 

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -55,7 +55,7 @@ locals {
 
   creating_databricks_catalogs = (
     var.create_catalog == true ? {
-      local.dbx_resource_storage_config["CATALOG"]["resource_name"] = local.dbx_resource_storage_config["CATALOG"]["bucket_name"]
+      (local.dbx_resource_storage_config["CATALOG"]["resource_name"]) = local.dbx_resource_storage_config["CATALOG"]["bucket_name"]
     } : {}
   )
 

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -97,7 +97,7 @@ resource "databricks_external_location" "this" {
 
   name            = databricks_storage_credential.this[each.bucket_name].name
   url             = "s3://${each.store_location}"
-  credential_name = databricks_storage_credential.this[each.bucket_name]].name
+  credential_name = databricks_storage_credential.this[each.bucket_name].name
   comment         = "Managed by Terraform - access for ${each.bucket_name}"
   read_only       = var.read_only_volume
 }

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -71,7 +71,7 @@ resource "databricks_catalog" "volume" {
   name         = local.catalog_name
   metastore_id = var.metastore_id
   owner        = var.owner
-  storage_root = "s3://${local.bucket_name}"
+  storage_root = "s3://${local.catalog_storage_root}"
   comment      = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"
   properties = {
     purpose = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -79,16 +79,19 @@ resource "time_sleep" "wait_30_seconds" {
 }
 
 resource "databricks_external_location" "this" {
-  for_each = local.dbx_resource_storage_config
+  for_each = {
+    for e in local.dbx_resource_storage_config :
+    e["bucket_name"] => e["storage_location"]
+  }
   depends_on = [
     time_sleep.wait_30_seconds,
     databricks_storage_credential.this,
   ]
 
-  name            = databricks_storage_credential.this[each.value.bucket_name].name
-  url             = "s3://${each.value.store_location}"
-  credential_name = databricks_storage_credential.this[each.value.bucket_name].name
-  comment         = "Managed by Terraform - access for ${each.value.bucket_name}"
+  name            = databricks_storage_credential.this[each.key].name
+  url             = "s3://${each.value}"
+  credential_name = databricks_storage_credential.this[each.key].name
+  comment         = "Managed by Terraform - access for ${each.key}"
   read_only       = var.read_only_volume
 }
 

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -94,18 +94,19 @@ resource "databricks_external_location" "this" {
 resource "databricks_catalog" "volume" {
   for_each = (
     var.create_catalog ?
-    [
+    {
       for element in local.dbx_resource_storage_config :
-      element if element.value.resource_name == local.catalog_name
-    ] :
-    []
+      element["resource_name"] => element["catalog_bucket_name"]
+      if element["resource_name"] == local.catalog_name
+    } :
+    {}
   )
   depends_on   = [databricks_external_location.this]
 
-  name         = each.value.resource_name
+  name         = each.key
   metastore_id = var.metastore_id
   owner        = var.owner
-  storage_root = "s3://${each.value.catalog_bucket_name}"
+  storage_root = "s3://${each.value}"
   comment      = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"
   properties = {
     purpose = "this catalog is managed by terraform - default volume catalog for Databricks workspace ${var.workspace_name}"

--- a/databricks-s3-volume/outputs.tf
+++ b/databricks-s3-volume/outputs.tf
@@ -3,7 +3,7 @@ output "dbx_unity_aws_role_arn" {
 }
 
 output "volume_bucket_name" {
-  value = local.bucket_name
+  value = local.volume_bucket_name
 }
 
 output "volume_path" {

--- a/databricks-s3-volume/outputs.tf
+++ b/databricks-s3-volume/outputs.tf
@@ -1,5 +1,5 @@
 output "dbx_unity_aws_role_arn" {
-  value = length(aws_iam_role.dbx_unity_aws_role) > 0 ? aws_iam_role.dbx_unity_aws_role[0].arn : null
+  value = aws_iam_role.dbx_unity_aws_role[*].arn
 }
 
 output "volume_bucket_name" {

--- a/databricks-s3-volume/outputs.tf
+++ b/databricks-s3-volume/outputs.tf
@@ -1,5 +1,5 @@
 output "dbx_unity_aws_role_arns" {
-  value = values(aws_iam_role.dbx_unity_aws_role)[*].arn
+  value = aws_iam_role.dbx_unity_aws_role[0].arn
 }
 
 output "volume_bucket_name" {

--- a/databricks-s3-volume/outputs.tf
+++ b/databricks-s3-volume/outputs.tf
@@ -1,5 +1,5 @@
-output "dbx_unity_aws_role_arn" {
-  value = aws_iam_role.dbx_unity_aws_role[*].arn
+output "dbx_unity_aws_role_arns" {
+  value = values(aws_iam_role.dbx_unity_aws_role)[*].arn)
 }
 
 output "volume_bucket_name" {

--- a/databricks-s3-volume/outputs.tf
+++ b/databricks-s3-volume/outputs.tf
@@ -1,5 +1,5 @@
 output "dbx_unity_aws_role_arns" {
-  value = values(aws_iam_role.dbx_unity_aws_role)[*].arn)
+  value = values(aws_iam_role.dbx_unity_aws_role)[*].arn
 }
 
 output "volume_bucket_name" {

--- a/databricks-s3-volume/variables.tf
+++ b/databricks-s3-volume/variables.tf
@@ -4,19 +4,39 @@ variable "workspace_name" {
   type        = string
 }
 
+variable "create_catalog" {
+  description = "Flag to create a new catalog or look for an existing one with the given name"
+  type        = bool
+}
+
 variable "catalog_name" {
   description = "Name of the Databricks existing catalog to add the volume to"
   type        = string
 }
 
+variable "create_volume_bucket" {
+  type    = bool
+  default = false
+}
+
+variable "volume_bucket_name" {
+  type = string
+}
+
+variable "create_catalog_bucket" {
+  type    = bool
+  default = false
+}
+
+variable "catalog_storage_root_bucket_name" {
+  description = "(Optional) Override storage root of catalog instead of using bucket name"
+  type        = string
+  default     = null
+}
+
 variable "owner" {
   description = "User or group name of the owner - will be applied to the catalog, schema, and volume, if applicable"
   type        = string
-}
-
-variable "create_catalog" {
-  description = "Flag to create a new catalog or look for an existing one with the given name"
-  type        = bool
 }
 
 variable "metastore_id" {
@@ -39,8 +59,8 @@ variable "volume_name" {
   type        = string
 }
 
-variable "volume_bucket" {
-  description = "(Optional) Name of an existing S3 bucket to use for Databricks volume. NOTE: if provided, you will need to update the bucket policy whereever it is defined to allow Databricks access"
+variable "volume_bucket_name" {
+  description = "(Optional) Name of S3 bucket to use for Databricks volume. NOTE: if provided, you will need to update the bucket policy whereever it is defined to allow Databricks access"
   type        = string
   default     = null
 }
@@ -130,20 +150,8 @@ variable "create_storage_credential" {
   default     = true
 }
 
-variable "override_bucket_name" {
-  description = "(Optional) Name of the S3 bucket to create or use for Databricks volume, overriding the default"
-  type        = string
-  default     = null
-}
-
-variable "override_storage_location" {
+variable "volume_storage_location" {
   description = "(Optional) Prefix to use for the storage location in case of an existing bucket (e.g. 's3://bucket' or 's3://bucket/prefix')"
-  type        = string
-  default     = null
-}
-
-variable "override_catalog_storage_root" {
-  description = "(Optional) Override storage root of catalog instead of using bucket name"
   type        = string
   default     = null
 }

--- a/databricks-s3-volume/variables.tf
+++ b/databricks-s3-volume/variables.tf
@@ -142,6 +142,12 @@ variable "override_storage_location" {
   default     = null
 }
 
+variable "override_catalog_storage_root" {
+  description = "(Optional) Override storage root of catalog instead of using bucket name"
+  type        = string
+  default     = null
+}
+
 variable "read_only_volume" {
   description = "(Optional) Flag to set volume as read-only"
   type        = bool

--- a/databricks-s3-volume/variables.tf
+++ b/databricks-s3-volume/variables.tf
@@ -19,12 +19,16 @@ variable "create_volume_bucket" {
   default = false
 }
 
+variable "volume_bucket_name" {
+  type = string
+}
+
 variable "create_catalog_bucket" {
   type    = bool
   default = false
 }
 
-variable "catalog_storage_root_bucket_name" {
+variable "catalog_bucket_name" {
   description = "(Optional) Override storage root of catalog instead of using bucket name"
   type        = string
   default     = null
@@ -140,7 +144,7 @@ variable "override_policy_documents" {
   default     = []
 }
 
-variable "create_storage_credential" {
+variable "create_storage_credentials" {
   description = "(Optional) Flag to create a new Databricks storage credential or look for an existing one for the given bucket_name"
   type        = bool
   default     = true

--- a/databricks-s3-volume/variables.tf
+++ b/databricks-s3-volume/variables.tf
@@ -19,10 +19,6 @@ variable "create_volume_bucket" {
   default = false
 }
 
-variable "volume_bucket_name" {
-  type = string
-}
-
 variable "create_catalog_bucket" {
   type    = bool
   default = false

--- a/snowflake-account-grant-all/README.md
+++ b/snowflake-account-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-database-grant-all/README.md
+++ b/snowflake-database-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-integration-grant-all/README.md
+++ b/snowflake-integration-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-resource-monitor-grant-all/README.md
+++ b/snowflake-resource-monitor-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-schema-grant-all/README.md
+++ b/snowflake-schema-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-stage-grant-all/README.md
+++ b/snowflake-stage-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-table-grant-all/README.md
+++ b/snowflake-table-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-view-grant-all/README.md
+++ b/snowflake-view-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 

--- a/snowflake-warehouse-grant-all/README.md
+++ b/snowflake-warehouse-grant-all/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.20.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.34.0 |
 
 ## Modules
 


### PR DESCRIPTION
### Summary
databricks-s3-volume:
- Add the ability to configure the backing buckets each for the Databricks Catalog and Databricks Volume
- Changes input variables for consistency

databricks-s3-volume will no longer be backwards-compatible.

Changes in other modules were just from updating Terraform formatting and/or docs.

### Test Plan
Tested in a TF workspace

### References
