### PR TITLE
fix: CDI-3949 fix dbx volume storage credentials

### DIFF
--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {
 }
 
 data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
-  count = len(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
+  count = length(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
 
   statement {
     principals {
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
 }
 
 resource "aws_iam_role" "dbx_unity_aws_role" {
-  count = len(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
+  count = length(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
 
   name               = local.unity_aws_role_name
   path               = local.iam_role_path

--- a/databricks-s3-volume/iam.tf
+++ b/databricks-s3-volume/iam.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {
 }
 
 data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
-  count = local.create_storage_credentials ? 1 : 0
+  count = len(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
 
   statement {
     principals {
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "dbx_unity_aws_role_assume_role" {
 }
 
 resource "aws_iam_role" "dbx_unity_aws_role" {
-  count = local.create_storage_credentials ? 1 : 0
+  count = len(keys(local.storage_credentials_to_create)) > 0 ? 1 : 0
 
   name               = local.unity_aws_role_name
   path               = local.iam_role_path
@@ -46,11 +46,7 @@ resource "aws_iam_role" "dbx_unity_aws_role" {
 
 ### Policy document to access default volume bucket and assume role
 data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
-  for_each = (
-    local.create_storage_credentials ?
-    toset([for resource in local.dbx_resource_storage_config : resource["bucket_name"]]) :
-    toset([])
-  )
+  for_each = local.storage_credentials_to_create
 
   statement {
     sid    = "dbxSCBucketAccess"
@@ -90,13 +86,13 @@ data "aws_iam_policy_document" "volume_bucket_dbx_unity_access" {
 }
 
 resource "aws_iam_policy" "dbx_unity_access_policy" {
-  for_each = local.creating_storage_credentials
+  for_each = local.storage_credentials_to_create
 
   policy = data.aws_iam_policy_document.volume_bucket_dbx_unity_access[each.key].json
 }
 
 resource "aws_iam_role_policy_attachment" "dbx_unity_aws_access" {
-  for_each = local.creating_storage_credentials
+  for_each = local.storage_credentials_to_create
 
   policy_arn = aws_iam_policy.dbx_unity_access_policy[each.key].arn
   role       = aws_iam_role.dbx_unity_aws_role[0].name

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -45,12 +45,12 @@ locals {
 
   catalog_storage_credentials = (
     local.create_catalog_storage_credentials == true ? {
-      (local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"]) = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
+      (local.dbx_resource_storage_config["CATALOG"]["bucket_name"]) = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
   storage_credentials_to_create = merge(local.catalog_storage_credentials, (
     var.create_volume_storage_credentials == true ? {
-      (local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"]) = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
+      (local.dbx_resource_storage_config["VOLUME"]["bucket_name"]) = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
     } : {}
   ))
 

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -43,12 +43,12 @@ locals {
     }
   }
 
-  creating_storage_credentials = (
+  catalog_storage_credentials = (
     local.create_catalog_storage_credentials == true ? {
       local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"] = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
-  creating_storage_credentials = merge(creating_storage_credentials, (
+  creating_storage_credentials = merge(catalog_storage_credentials, (
     var.create_volume_storage_credentials == true ? {
       local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"] = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
     } : {}

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -48,7 +48,7 @@ locals {
       local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"] = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
-  creating_storage_credentials = merge(catalog_storage_credentials, (
+  creating_storage_credentials = merge(local.catalog_storage_credentials, (
     var.create_volume_storage_credentials == true ? {
       local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"] = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
     } : {}

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -46,7 +46,6 @@ locals {
     var.create_storage_credentials == true ? {
       for k, v in local.dbx_resource_storage_config :
       v["bucket_name"] => v["storage_credential_name"]
-      if v["create_bucket"] == true
     } : {}
   )
   creating_external_locations = {

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -48,7 +48,7 @@ locals {
       local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"] = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
-  creating_storage_credentials = merge(local.catalog_storage_credentials, (
+  storage_credentials_to_create = merge(local.catalog_storage_credentials, (
     var.create_volume_storage_credentials == true ? {
       local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"] = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
     } : {}
@@ -75,7 +75,7 @@ locals {
 ### NOTE:
 
 resource "databricks_storage_credential" "this" {
-  for_each = local.creating_storage_credentials
+  for_each = local.storage_credentials_to_create
 
   depends_on = [
     resource.aws_iam_role.dbx_unity_aws_role,

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -12,7 +12,7 @@ locals {
   schema_name  = var.create_schema ? replace(var.schema_name, "-", "_") : var.schema_name
   volume_name  = replace(var.volume_name, "-", "_")
 
-  unity_aws_role_name    = "${local.catalog_name}-${local.schema_name}-${local.volume_name}-unity"
+  unity_aws_role_name    = replace("${local.catalog_name}-${local.schema_name}-${local.volume_name}-dbx", "_", "")
 
   volume_bucket_name = var.create_volume_bucket ? replace(var.volume_bucket_name, "_", "-") : var.volume_bucket_name
   catalog_bucket_name = coalesce(

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -2,7 +2,6 @@
 
 // https://docs.databricks.com/administration-guide/multiworkspace/iam-role.html#language-Your%C2%A0VPC,%C2%A0custom
 locals {
-  unity_aws_role_name    = "${var.catalog_name}-unity"
   iam_role_path          = "/databricks/"
   databricks_aws_account = "414351767826" # Databricks' own AWS account, not CZI's. See https://docs.databricks.com/en/administration-guide/account-settings-e2/credentials.html#step-1-create-a-cross-account-iam-role
 
@@ -12,6 +11,8 @@ locals {
   catalog_name = var.create_catalog ? replace(var.catalog_name, "-", "_") : var.catalog_name
   schema_name  = var.create_schema ? replace(var.schema_name, "-", "_") : var.schema_name
   volume_name  = replace(var.volume_name, "-", "_")
+
+  unity_aws_role_name    = "${local.catalog_name}-${local.schema_name}-${local.volume_name}-unity"
 
   volume_bucket_name = var.create_volume_bucket ? replace(var.volume_bucket_name, "_", "-") : var.volume_bucket_name
   catalog_bucket_name = coalesce(

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -45,12 +45,12 @@ locals {
 
   catalog_storage_credentials = (
     local.create_catalog_storage_credentials == true ? {
-      local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"] = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
+      (local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"]) = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
   storage_credentials_to_create = merge(local.catalog_storage_credentials, (
     var.create_volume_storage_credentials == true ? {
-      local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"] = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
+      (local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"]) = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
     } : {}
   ))
 

--- a/databricks-s3-volume/main.tf
+++ b/databricks-s3-volume/main.tf
@@ -20,7 +20,7 @@ locals {
     local.catalog_name
   )
 
-  create_storage_credentials = var.create_catalog || var.create_storage_credentials
+  create_catalog_storage_credentials = var.create_catalog || var.create_catalog_storage_credentials
   volume_storage_location = coalesce(
     var.volume_storage_location,
     "s3://${local.volume_bucket_name}/${local.schema_name}/${local.volume_name}"
@@ -44,11 +44,16 @@ locals {
   }
 
   creating_storage_credentials = (
-    var.create_storage_credentials == true ? {
-      for k, v in local.dbx_resource_storage_config :
-      v["bucket_name"] => v["storage_credential_name"]
+    local.create_catalog_storage_credentials == true ? {
+      local.dbx_resource_storage_config["CATALOG"]["catalog_bucket_name"] = local.dbx_resource_storage_config["CATALOG"]["storage_credential_name"]
     } : {}
   )
+  creating_storage_credentials = merge(creating_storage_credentials, (
+    var.create_volume_storage_credentials == true ? {
+      local.dbx_resource_storage_config["VOLUME"]["catalog_bucket_name"] = local.dbx_resource_storage_config["VOLUME"]["storage_credential_name"]
+    } : {}
+  ))
+
   creating_external_locations = {
     for k, v in local.dbx_resource_storage_config : v["bucket_name"] => v["storage_location"]
   }

--- a/databricks-s3-volume/variables.tf
+++ b/databricks-s3-volume/variables.tf
@@ -140,8 +140,14 @@ variable "override_policy_documents" {
   default     = []
 }
 
-variable "create_storage_credentials" {
-  description = "(Optional) Flag to create a new Databricks storage credential or look for an existing one for the given bucket_name"
+variable "create_volume_storage_credentials" {
+  description = "(Optional) Flag to create a new Databricks storage credential for the volume or look for an existing one for the given bucket_name"
+  type        = bool
+  default     = true
+}
+
+variable "create_catalog_storage_credentials" {
+  description = "(Optional) Flag to create a new Databricks storage credential for the catalog or look for an existing one for the given bucket_name"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
### Summary
Breaks out storage credential creation between catalogs and volumes, allowing situations where we want to create a multiple volumes on an existing catalog

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
