### PR TITLE
fix: Use index as key instead of volume name for grants iterator for Databricks Volume creation

### DIFF
--- a/databricks-s3-volume-existing-catalog/grants.tf
+++ b/databricks-s3-volume-existing-catalog/grants.tf
@@ -19,9 +19,9 @@ locals {
 }
 
 resource "databricks_grants" "volume" {
-  for_each = var.volume_buckets
+  for_each = toset([bucket.volume_name for bucket in var.volume_buckets])
 
-  volume = each.value.volume_name
+  volume = each.value
 
   # Read-only access grants
   dynamic "grant" {

--- a/databricks-s3-volume-existing-catalog/grants.tf
+++ b/databricks-s3-volume-existing-catalog/grants.tf
@@ -18,24 +18,26 @@ locals {
   ])
 }
 
-# Read-only access grants
-resource "databricks_grant" "volume_r" {
-  for_each = { for grant in local.volume_r_grants : grant.volume_name => grant }
+resource "databricks_grants" "volume" {
+  for_each = var.volume_buckets
 
-  volume     = databricks_volume.volume[each.value.volume_name].id
-  principal  = each.value.principal
-  privileges = ["READ_VOLUME"]
+  volume = each.value.volume_name
 
-  depends_on = [databricks_volume.volume]
-}
+  # Read-only access grants
+  dynamic "grant" {
+    for_each = each.value.volume_r_grant_principals
+    content {
+      principal = grant.value
+      privileges = ["READ_VOLUME"]
+    }
+  }
 
-# Read/write access grants
-resource "databricks_grant" "volume_rw" {
-  for_each = { for grant in local.volume_rw_grants : grant.volume_name => grant }
-
-  volume     = databricks_volume.volume[each.value.volume_name].id
-  principal  = each.value.principal
-  privileges = ["READ_VOLUME", "WRITE_VOLUME"]
-
-  depends_on = [databricks_volume.volume]
+  # Read/write access grants
+  dynamic "grant" {
+    for_each = each.value.volume_rw_grant_principals
+    content {
+      principal = grant.value
+      privileges = ["READ_VOLUME", "WRITE_VOLUME"]
+    }
+  }
 }

--- a/databricks-s3-volume-existing-catalog/grants.tf
+++ b/databricks-s3-volume-existing-catalog/grants.tf
@@ -1,11 +1,11 @@
 resource "databricks_grants" "volume" {
-  for_each = toset([for bucket in var.volume_buckets : bucket.volume_name])
+  for_each = toset([for bucket in var.volume_buckets : bucket.volume_name => bucket])
 
   volume = each.value
 
   # Read-only access grants
   dynamic "grant" {
-    for_each = each.value.volume_r_grant_principals
+    for_each = toset(each.value.volume_r_grant_principals)
     content {
       principal = grant.value
       privileges = ["READ_VOLUME"]
@@ -14,7 +14,7 @@ resource "databricks_grants" "volume" {
 
   # Read/write access grants
   dynamic "grant" {
-    for_each = each.value.volume_rw_grant_principals
+    for_each = toset(each.value.volume_rw_grant_principals)
     content {
       principal = grant.value
       privileges = ["READ_VOLUME", "WRITE_VOLUME"]

--- a/databricks-s3-volume-existing-catalog/grants.tf
+++ b/databricks-s3-volume-existing-catalog/grants.tf
@@ -1,25 +1,5 @@
-locals {
-  volume_r_grants = flatten([
-    for volume in var.volume_buckets : [
-      for principal in volume.volume_r_grant_principals : {
-        volume_name = volume.volume_name
-        principal   = principal
-      }
-    ]
-  ])
-
-  volume_rw_grants = flatten([
-    for volume in var.volume_buckets : [
-      for principal in volume.volume_rw_grant_principals : {
-        volume_name = volume.volume_name
-        principal   = principal
-      }
-    ]
-  ])
-}
-
 resource "databricks_grants" "volume" {
-  for_each = toset([bucket.volume_name for bucket in var.volume_buckets])
+  for_each = toset([for bucket in var.volume_buckets : bucket.volume_name])
 
   volume = each.value
 


### PR DESCRIPTION
### Summary
Iterating over grants using the volume name was eliminating grant pairs with the same volume name. Using index to make entries unique.

### Test Plan
Tested in TFE workspace

### References
[CDI-3890]

[CDI-3890]: https://czi.atlassian.net/browse/CDI-3890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ