### PR TITLE
fix: Assign all listed Databricks usergroups to associated Databricks cluster policy groups

### DIFF
--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -5,9 +5,11 @@ locals {
 
   policy_group_membership_list = toset([
     for prefix in local.ws_policy_name_prefixes
-    : for policy_suffix, groups_names in var.policy_map
-      : for group_name in groups_names
+    : [ for policy_suffix, groups_names in var.policy_map
+      : [ for group_name in groups_names
         : "${prefix}${policy_suffix}" => "${group_name}"
+      ]
+    ]
   ])
 }
 

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -25,8 +25,8 @@ locals {
     ]
   ])
 
-  ws_cluster_policy_names = flatten([for pair in local.policy_group_memberships : pair.policy])
-  usergroups_names        = flatten([for pair in local.policy_group_memberships : pair.group])
+  ws_cluster_policy_names = toset(flatten([for pair in local.policy_group_memberships : pair.policy]))
+  usergroups_names        = toset(flatten([for pair in local.policy_group_memberships : pair.group]))
 }
 
 # Create Databricks groups for each policy name

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 # Create Databricks groups for each policy name
-resource "databricks_group" "ws_policy_groups" {
+resource "databricks_group" "ws_cluster_policy_groups" {
   for_each = local.ws_cluster_policy_names
 
   display_name     = each.key
@@ -35,6 +35,6 @@ data "databricks_group" "usergroups" {
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = local.policy_group_membership_list
 
-  group_id = data.databricks_group.ws_policy_groups[each.key]
-  member_id = data.databricks_group.groups[each.value].id
+  group_id = databricks_group.ws_cluster_policy_groups[each.key]
+  member_id = data.databricks_group.usergroups[each.value].id
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -41,6 +41,6 @@ resource "databricks_group_member" "ws_policy_group_members" {
     }
   }
 
-  group_id = databricks_group.ws_cluster_policy_groups[each.value.policy]
+  group_id = databricks_group.ws_cluster_policy_groups[each.value.policy].id
   member_id = data.databricks_group.usergroups[each.value.group].id
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -3,17 +3,6 @@ locals {
     var.policy_name_prefix,
   ])
 
-  #policy_group_membership_list = toset(flatten([
-  #  for prefix in local.ws_policy_name_prefixes
-  #  : [ for policy_suffix, groups_names in merge(var.policy_map...)
-  #    : [ for group_name in groups_names
-  #      : "${prefix} - ${policy_suffix} - ${group_name}" = {
-  #          policy : "${prefix}${policy_suffix}",
-  #          group : group_name
-  #      }
-  #    ]
-  #  ]
-  #]))
   policy_group_memberships = flatten([
     for prefix in local.ws_policy_name_prefixes : [
       for policy_suffix, groups_names in merge(var.policy_map...) : [

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -11,11 +11,14 @@ locals {
       ]
     ]
   ])
+
+  ws_cluster_policy_names = toset(flatten([for pair in local.policy_group_membership_list : keys(pair)]))
+  usergroups_names = toset(flatten([for pair in local.policy_group_membership_list : flatten(values(pair))]))
 }
 
 # Create Databricks groups for each policy name
 resource "databricks_group" "ws_policy_groups" {
-  for_each = toset(keys(local.policy_group_membership_list))
+  for_each = local.ws_cluster_policy_names
 
   display_name     = each.key
   workspace_access = true
@@ -23,7 +26,7 @@ resource "databricks_group" "ws_policy_groups" {
 
 # Retrieve the existing Databricks usergroups that need to be assigned
 data "databricks_group" "usergroups" {
-  for_each = toset(values(local.policy_group_membership_list))
+  for_each = local.usergroups_names
 
   display_name = each.value
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -5,7 +5,7 @@ locals {
 
   policy_group_membership_list = toset([
     for prefix in local.ws_policy_name_prefixes
-    : [ for policy_suffix, groups_names in var.policy_map
+    : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
         : "${prefix}${policy_suffix}" => "${group_name}"
       ]

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -34,10 +34,13 @@ data "databricks_group" "usergroups" {
 # Assign user groups to policy groups per policy-usergroup pair
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = {
-    for i, e in local.policy_group_membership_list
-    : i => e
+    for i, e in tolist(local.policy_group_membership_list)
+    : i => {
+      policy: keys(e)[0],
+      group: values(e)[0],
+    }
   }
 
-  group_id = databricks_group.ws_cluster_policy_groups[each.value.key]
-  member_id = data.databricks_group.usergroups[each.value.value].id
+  group_id = databricks_group.ws_cluster_policy_groups[each.value.policy]
+  member_id = data.databricks_group.usergroups[each.value.group].id
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -7,7 +7,7 @@ locals {
     for prefix in local.ws_policy_name_prefixes
     : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
-        : "${prefix} - ${policy_suffix}" => {
+        : "${prefix} - ${policy_suffix} - ${group_name}" = {
             policy : "${prefix}${policy_suffix}",
             group : group_name
         }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -19,7 +19,7 @@ resource "databricks_group" "ws_policy_groups" {
   workspace_access = true
 }
 
-# Retrieve the existing Databricks groups that need to be assigned
+# Retrieve the existing Databricks usergroups that need to be assigned
 data "databricks_group" "usergroups" {
   for_each = toset(values(local.policy_group_membership_list))
 

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -48,7 +48,7 @@ data "databricks_group" "usergroups" {
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = {
     for pair in local.policy_group_memberships :
-    "${pair.policy}+${group}" => {
+    "${pair.policy}+${pair.roup}" => {
       policy : pair.policy,
       group : pair.group,
     }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -33,8 +33,10 @@ data "databricks_group" "usergroups" {
 
 # Assign user groups to policy groups per policy-usergroup pair
 resource "databricks_group_member" "ws_policy_group_members" {
-  for_each = local.policy_group_membership_list
+  for_each = {
+    for i, definition in local.policy_group_membership_list
+  }
 
-  group_id = databricks_group.ws_cluster_policy_groups[each.key]
-  member_id = data.databricks_group.usergroups[each.value].id
+  group_id = databricks_group.ws_cluster_policy_groups[each.value.key]
+  member_id = data.databricks_group.usergroups[each.value.value].id
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -3,44 +3,33 @@ locals {
     var.policy_name_prefix,
   ])
 
-  # Define the policies with existing groups mapped to each policy
-  policies = var.policy_map
-
-  # Generate full workspace policy names by prefixing policy names
-  all_ws_policy_names = flatten([
-    for prefix in local.ws_policy_name_prefixes : [
-      for policy_map in local.policies :
-      "${prefix}${keys(policy_map)[0]}"
-    ]
+  policy_group_membership_list = toset([
+    for prefix in local.ws_policy_name_prefixes
+    : for policy_suffix, groups_names in var.policy_map
+      : for group_name in groups_names
+        : "${prefix}${policy_suffix}" => "${group_name}"
   ])
-
-  # Create a flat map of policy names to associated groups
-  policy_group_map = merge([for policy_map in local.policies : policy_map]...)
 }
 
 # Create Databricks groups for each policy name
 resource "databricks_group" "ws_policy_groups" {
-  for_each = toset(local.all_ws_policy_names)
+  for_each = toset(keys(local.policy_group_membership_list))
 
   display_name     = each.key
   workspace_access = true
 }
 
 # Retrieve the existing Databricks groups that need to be assigned
-data "databricks_group" "groups" {
-  for_each = toset(flatten([
-    for group in local.policy_group_map : group
-  ]))
+data "databricks_group" "usergroups" {
+  for_each = toset(values(local.policy_group_membership_list))
 
   display_name = each.value
 }
 
-# Assign the existing groups to the newly created policy groups
+# Assign user groups to policy groups per policy-usergroup pair
 resource "databricks_group_member" "ws_policy_group_members" {
-  for_each = databricks_group.ws_policy_groups
+  for_each = local.policy_group_membership_list
 
-  group_id = each.value.id
-
-  # Assign all existing groups that correspond to this policy group
-  member_id = data.databricks_group.groups[local.policy_group_map[replace(each.key, var.policy_name_prefix, "")][0]].id
+  group_id = data.databricks_group.ws_policy_groups[each.key]
+  member_id = data.databricks_group.groups[each.value].id
 }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -7,7 +7,7 @@ locals {
     for prefix in local.ws_policy_name_prefixes
     : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
-        : {"${prefix}${policy_suffix}" => "${group_name}"}
+        : {"${prefix}${policy_suffix}" = "${group_name}"}
       ]
     ]
   ])

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -48,7 +48,7 @@ data "databricks_group" "usergroups" {
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = {
     for pair in local.policy_group_memberships :
-    "${pair.policy}+${pair.roup}" => {
+    "${pair.policy}+${pair.group}" => {
       policy : pair.policy,
       group : pair.group,
     }

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -34,7 +34,8 @@ data "databricks_group" "usergroups" {
 # Assign user groups to policy groups per policy-usergroup pair
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = {
-    for i, definition in local.policy_group_membership_list
+    for i, e in local.policy_group_membership_list
+    : i => e
   }
 
   group_id = databricks_group.ws_cluster_policy_groups[each.value.key]

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -7,7 +7,7 @@ locals {
     for prefix in local.ws_policy_name_prefixes
     : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
-        : "${prefix}${policy_suffix}" => "${group_name}"
+        : {"${prefix}${policy_suffix}" => "${group_name}"}
       ]
     ]
   ])

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -3,14 +3,14 @@ locals {
     var.policy_name_prefix,
   ])
 
-  policy_group_membership_list = toset([
+  policy_group_membership_list = toset(flatten([
     for prefix in local.ws_policy_name_prefixes
     : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
         : {"${prefix}${policy_suffix}" = "${group_name}"}
       ]
     ]
-  ])
+  ]))
 
   ws_cluster_policy_names = toset(flatten([for pair in local.policy_group_membership_list : keys(pair)]))
   usergroups_names = toset(flatten([for pair in local.policy_group_membership_list : flatten(values(pair))]))

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -8,7 +8,7 @@ locals {
     : [ for policy_suffix, groups_names in merge(var.policy_map...)
       : [ for group_name in groups_names
         : "${prefix} - ${policy_suffix}" => {
-            policy : "${prefix}${policy_suffix}" = "${group_name}",
+            policy : "${prefix}${policy_suffix}",
             group : group_name
         }
       ]

--- a/databricks-default-cluster-policies/groups.tf
+++ b/databricks-default-cluster-policies/groups.tf
@@ -3,20 +3,30 @@ locals {
     var.policy_name_prefix,
   ])
 
-  policy_group_membership_list = toset(flatten([
-    for prefix in local.ws_policy_name_prefixes
-    : [ for policy_suffix, groups_names in merge(var.policy_map...)
-      : [ for group_name in groups_names
-        : "${prefix} - ${policy_suffix} - ${group_name}" = {
-            policy : "${prefix}${policy_suffix}",
-            group : group_name
+  #policy_group_membership_list = toset(flatten([
+  #  for prefix in local.ws_policy_name_prefixes
+  #  : [ for policy_suffix, groups_names in merge(var.policy_map...)
+  #    : [ for group_name in groups_names
+  #      : "${prefix} - ${policy_suffix} - ${group_name}" = {
+  #          policy : "${prefix}${policy_suffix}",
+  #          group : group_name
+  #      }
+  #    ]
+  #  ]
+  #]))
+  policy_group_memberships = flatten([
+    for prefix in local.ws_policy_name_prefixes : [
+      for policy_suffix, groups_names in merge(var.policy_map...) : [
+        for group_name in groups_names : {
+          policy = "${prefix}${policy_suffix}",
+          group  = group_name
         }
       ]
     ]
-  ]))
+  ])
 
-  ws_cluster_policy_names = toset(flatten([for _, pair in local.policy_group_membership_list : pair.policy]))
-  usergroups_names = toset(flatten([for _, pair in local.policy_group_membership_list : pair.group]))
+  ws_cluster_policy_names = flatten([for pair in local.policy_group_memberships : pair.policy])
+  usergroups_names        = flatten([for pair in local.policy_group_memberships : pair.group])
 }
 
 # Create Databricks groups for each policy name
@@ -37,13 +47,13 @@ data "databricks_group" "usergroups" {
 # Assign user groups to policy groups per policy-usergroup pair
 resource "databricks_group_member" "ws_policy_group_members" {
   for_each = {
-    for _, pair in local.policy_group_membership_list
-    : _ => {
-      policy: pair.policy,
-      group: pair.group,
+    for pair in local.policy_group_memberships :
+    "${pair.policy}+${group}" => {
+      policy : pair.policy,
+      group : pair.group,
     }
   }
 
-  group_id = databricks_group.ws_cluster_policy_groups[each.value.policy].id
+  group_id  = databricks_group.ws_cluster_policy_groups[each.value.policy].id
   member_id = data.databricks_group.usergroups[each.value.group].id
 }

--- a/databricks-default-cluster-policies/outputs.tf
+++ b/databricks-default-cluster-policies/outputs.tf
@@ -1,0 +1,3 @@
+output policy_group_membership_list {
+  value = local.policy_group_membership_list
+}

--- a/databricks-default-cluster-policies/outputs.tf
+++ b/databricks-default-cluster-policies/outputs.tf
@@ -1,3 +1,3 @@
-output policy_group_membership_list {
+output "policy_group_membership_map" {
   value = local.policy_group_membership_list
 }

--- a/databricks-default-cluster-policies/outputs.tf
+++ b/databricks-default-cluster-policies/outputs.tf
@@ -1,3 +1,3 @@
-output "policy_group_membership_map" {
-  value = local.policy_group_membership_list
+output "policy_group_memberships" {
+  value = local.policy_group_memberships
 }


### PR DESCRIPTION
### Summary
Previously, as a list of usergroups was associated per cluster policy, only the first usergroup in the usergroup list was being added to the cluster policy's group membership.

Instead, "flattening" out to a list of policy-to-group mappings, and creating `databricks_group_member`ship for each explicitly. Each `databricks_group_member` resource is now named after the pairing instead of just the policy name.

### Test Plan
Tested in local TF workspace.
