### PR TITLE
feat: add option for predictive optimization to catalog config

### DIFF
--- a/databricks-catalog-external-location/catalogs.tf
+++ b/databricks-catalog-external-location/catalogs.tf
@@ -1,10 +1,11 @@
 resource "databricks_catalog" "catalog" {
-  for_each       = { for idx, catalog in var.catalogs : catalog.name => catalog }
-  name           = each.value.name
-  storage_root   = "s3://${module.catalog_bucket.name}/${each.value.catalog_prefix != "" ? each.value.catalog_prefix : each.value.name}"
-  comment        = "this catalog is managed by terraform"
-  isolation_mode = each.value.isolation_mode
-  owner          = each.value.owner
+  for_each                       = { for idx, catalog in var.catalogs : catalog.name => catalog }
+  name                           = each.value.name
+  storage_root                   = "s3://${module.catalog_bucket.name}/${each.value.catalog_prefix != "" ? each.value.catalog_prefix : each.value.name}"
+  comment                        = "this catalog is managed by terraform"
+  isolation_mode                 = each.value.isolation_mode
+  enable_predictive_optimization = each.value.enable_predictive_optimization
+  owner                          = each.value.owner
 
   depends_on = [databricks_external_location.external_locations]
 }

--- a/databricks-catalog-external-location/variables.tf
+++ b/databricks-catalog-external-location/variables.tf
@@ -40,12 +40,13 @@ variable "catalogs" {
   description = "List of catalogs to create with their cooresponding attributes"
   type = list(
     object({
-      name                    = string
-      isolation_mode          = optional(string, "ISOLATED")
-      owner                   = string
-      all_privileges_groups   = list(string)
-      read_privileges_groups  = optional(list(string), [])
-      write_privileges_groups = optional(list(string), [])
-      catalog_prefix          = optional(string, "")
+      name                           = string
+      isolation_mode                 = optional(string, "ISOLATED")
+      enable_predictive_optimization = optional(string, "INHERIT")
+      owner                          = string
+      all_privileges_groups          = list(string)
+      read_privileges_groups         = optional(list(string), [])
+      write_privileges_groups        = optional(list(string), [])
+      catalog_prefix                 = optional(string, "")
   }))
 }


### PR DESCRIPTION
### Summary
This change updates the databricks-catalog-external-location module to include a property which can control enablement of predictive optimization at the catalog level.

### Test Plan
Have tested leaving the new property blank as well as setting possible values "INHERIT", "ENABLE", "DISABLE".

