### PR TITLE
feat: upgrade ESO version

### DIFF
--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -222,6 +222,7 @@ variable "addons" {
       use_name_prefix = false
     })
     external_secrets_config = optional(any, {
+      chart_version        = "0.16.2"
       service_account_name = "external-secrets-sa",
       namespace            = "external-secrets",
       wait                 = true


### PR DESCRIPTION
### Summary

Upgrades ESO version to 0.16.2. This is the latest version where `v1beta1` and `v1` api version are both available. This will allow us time to transition the `v1beta1` manifests to `v1` before upgrading further.

Ref:
- https://github.com/external-secrets/external-secrets/releases/tag/v0.16.2
- https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0 (breaking changes section notes that this version stops serving `v1beta1` apis)