### PR TITLE
fix(aws-vpc-env): filter VPC endpoint subnets by supported AZ IDs

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@conventional-commits-v1

--- a/aws-vpc-env/variables.tf
+++ b/aws-vpc-env/variables.tf
@@ -60,11 +60,12 @@ variable "skip_az_checks" {
 }
 
 variable "vpc_endpoints" {
-  description = "List of VPC endpoints to create"
+  description = "List of VPC endpoints to create. Set supported_az_ids to restrict which AZs the endpoint is placed in (required for cross-region endpoints that don't support all local AZs)."
   type = list(object({
-    enabled = bool
-    service = string
-    region  = optional(string)
+    enabled          = bool
+    service          = string
+    region           = optional(string)
+    supported_az_ids = optional(list(string), [])
   }))
   default = []
 }

--- a/aws-vpc-env/vpc_endpoints.tf
+++ b/aws-vpc-env/vpc_endpoints.tf
@@ -2,6 +2,10 @@
 # is described in this document - https://docs.aws.amazon.com/prescriptive-guidance/latest/integrate-third-party-services/architecture-1.html.
 # Only https traffic is allowed to the VPC endpoints.
 
+data "aws_subnet" "private" {
+  for_each = toset(module.vpc.private_subnets)
+  id       = each.value
+}
 
 locals {
   enabled_vpc_endpoints = {
@@ -9,6 +13,11 @@ locals {
       region = try(endpoint.region, "us-west-2")
     })
     if endpoint.enabled
+  }
+
+  # Map from subnet ID to its AZ ID (e.g. "use1-az1")
+  private_subnet_az_ids = {
+    for subnet_id, subnet in data.aws_subnet.private : subnet_id => subnet.availability_zone_id
   }
 }
 
@@ -38,11 +47,14 @@ resource "aws_security_group" "vpc_endpoint" {
 }
 
 resource "aws_vpc_endpoint" "vpc_endpoints" {
-  for_each           = local.enabled_vpc_endpoints
-  vpc_id             = module.vpc.vpc_id
-  service_name       = each.value.service
-  vpc_endpoint_type  = "Interface"
-  subnet_ids         = module.vpc.private_subnets
+  for_each          = local.enabled_vpc_endpoints
+  vpc_id            = module.vpc.vpc_id
+  service_name      = each.value.service
+  vpc_endpoint_type = "Interface"
+  subnet_ids = length(each.value.supported_az_ids) > 0 ? [
+    for subnet_id in module.vpc.private_subnets :
+    subnet_id if contains(each.value.supported_az_ids, local.private_subnet_az_ids[subnet_id])
+  ] : module.vpc.private_subnets
   security_group_ids = [aws_security_group.vpc_endpoint[each.key].id]
   service_region     = each.value.region
 

--- a/aws-vpc-env/vpc_endpoints.tf
+++ b/aws-vpc-env/vpc_endpoints.tf
@@ -2,9 +2,9 @@
 # is described in this document - https://docs.aws.amazon.com/prescriptive-guidance/latest/integrate-third-party-services/architecture-1.html.
 # Only https traffic is allowed to the VPC endpoints.
 
-data "aws_subnet" "private" {
-  for_each = toset(module.vpc.private_subnets)
-  id       = each.value
+data "aws_availability_zone" "vpc_azs" {
+  for_each = toset(var.azs)
+  name     = each.value
 }
 
 locals {
@@ -15,9 +15,19 @@ locals {
     if endpoint.enabled
   }
 
-  # Map from subnet ID to its AZ ID (e.g. "use1-az1")
-  private_subnet_az_ids = {
-    for subnet_id, subnet in data.aws_subnet.private : subnet_id => subnet.availability_zone_id
+  # Build a map from AZ name to AZ ID using static var.azs (known at plan time)
+  az_name_to_id = {
+    for az_name, az in data.aws_availability_zone.vpc_azs : az_name => az.zone_id
+  }
+
+  # Indices of private subnets whose AZ is in the supported list.
+  # var.azs[i] corresponds to module.vpc.private_subnets[i].
+  vpc_endpoint_subnet_indices = {
+    for service, endpoint in local.enabled_vpc_endpoints : service => (
+      length(endpoint.supported_az_ids) > 0
+      ? [for i, az in var.azs : i if contains(endpoint.supported_az_ids, local.az_name_to_id[az])]
+      : range(length(var.azs))
+    )
   }
 }
 
@@ -51,10 +61,9 @@ resource "aws_vpc_endpoint" "vpc_endpoints" {
   vpc_id            = module.vpc.vpc_id
   service_name      = each.value.service
   vpc_endpoint_type = "Interface"
-  subnet_ids = length(each.value.supported_az_ids) > 0 ? [
-    for subnet_id in module.vpc.private_subnets :
-    subnet_id if contains(each.value.supported_az_ids, local.private_subnet_az_ids[subnet_id])
-  ] : module.vpc.private_subnets
+  subnet_ids = [
+    for i in local.vpc_endpoint_subnet_indices[each.key] : module.vpc.private_subnets[i]
+  ]
   security_group_ids = [aws_security_group.vpc_endpoint[each.key].id]
   service_region     = each.value.region
 


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-6548

## Summary

- Adds optional `supported_az_ids` field to `vpc_endpoints` variable so callers can restrict which availability zones a VPC endpoint is placed in
- Uses `data "aws_subnet"` to map private subnet IDs to their AZ IDs, then filters accordingly
- When `supported_az_ids` is empty (default), all private subnets are used — fully backwards compatible

## Context

Cross-region VPC endpoint services (e.g. Loki/Mimir via PrivateLink from us-west-2 to us-east-1) may not support all local AZs. The `aws_vpc_endpoint_service` data source [does not return `availability_zones` for cross-region services](https://github.com/hashicorp/terraform-provider-aws/issues/44186), so automatic discovery isn't possible. Instead, callers specify the supported AZ IDs explicitly.

**Error this fixes:**
```
Error: creating EC2 VPC Endpoint: api error InvalidParameter:
  Only the following availability zones are supported for remote access:
  use1-az1, use1-az2, use1-az6, use1-az4, use1-az5
```

## Usage

```hcl
vpc_endpoints = [
  {
    enabled          = true
    region           = "us-west-2"
    service          = "com.amazonaws.vpce.us-west-2.vpce-svc-0c1025c8ebbe3b22e"
    supported_az_ids = ["use1-az1", "use1-az2", "use1-az4", "use1-az5", "use1-az6"]
  }
]
```

Same-region endpoints that support all AZs can omit `supported_az_ids` entirely (no change needed).

## Test plan

- [x] Verify `terraform validate` passes
- [x] Verify backwards compatibility: existing callers without `supported_az_ids` produce no plan diff
- [x] Test with cross-region endpoint that previously failed on a 6-AZ VPC

Made with [Cursor](https://cursor.com)