### PR TITLE
fix: Fix auto-typing of karpenter metrics annotations

### DIFF
--- a/aws-eks-cluster/blueprints.tf
+++ b/aws-eks-cluster/blueprints.tf
@@ -102,14 +102,17 @@ module "karpenter_controller" {
         {
           name  = "service.annotations.prometheus\\.io/scrape"
           value = "true"
+          type  = "string"
         },
         {
           name  = "service.annotations.prometheus\\.io/port"
           value = "8080"
+          type  = "string"
         },
         {
           name  = "service.annotations.prometheus\\.io/path"
           value = "/metrics"
+          type  = "string"
         },
       ],
       local.karpenter_odcr_enabled ? [


### PR DESCRIPTION
Addresses

```
  Error: unable to decode "": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.annotations of type string

    with module.eks-cluster-v2.module.karpenter_controller.module.karpenter.helm_release.this[0],
    on .terraform/modules/eks-cluster-v2.karpenter_controller.karpenter/main.tf line 9, in resource "helm_release" "this":
     9: resource "helm_release" "this" {
```

### Summary
A description of changes or issues addressed by this PR. Provide links to relevant PRs if any.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
