### PR TITLE
fix: relax databricks provider pin in databricks-catalog-external-loc…

### DIFF
--- a/databricks-catalog-external-location/versions.tf
+++ b/databricks-catalog-external-location/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     databricks = {
       source                = "databricks/databricks"
-      version               = "1.49.1"
+      version               = ">= 1.49.1"
       configuration_aliases = [databricks.mws, databricks.workspace]
     }
   }


### PR DESCRIPTION
…ation to >= 1.49.1

The module pinned databricks/databricks to exactly 1.49.1, which conflicts with databricks-s3-volume v0.3.0 (requires >= 1.82.0 for file events). A workspace that uses both modules cannot resolve a single provider version. The catalog module does not itself depend on 1.49.1, so relax to a permissive floor (>= 1.49.1) so it can coexist with newer provider versions while staying backward compatible.
