### PR TITLE
feat(aws-eks-cluster): enable external-dns gateway-listener-sets by default

### DIFF
--- a/aws-eks-cluster/blueprints.tf
+++ b/aws-eks-cluster/blueprints.tf
@@ -288,13 +288,12 @@ module "other_addons" {
     chart_version = var.addons.external_dns_config.chart_version
     create_role   = true
     values = [templatefile("${path.module}/templates/external-dns/values.yaml", {
-      txtOwnerId          = local.cluster_name
-      txtSuffix           = local.cluster_name
-      txtPrefix           = ""
-      imageTag            = var.addons.external_dns_config.image_tag
-      policy              = var.addons.external_dns_config.policy
-      sources             = var.addons.external_dns_config.sources
-      gatewayListenerSets = var.addons.external_dns_config.gateway_listener_sets
+      txtOwnerId = local.cluster_name
+      txtSuffix  = local.cluster_name
+      txtPrefix  = ""
+      imageTag   = var.addons.external_dns_config.image_tag
+      policy     = var.addons.external_dns_config.policy
+      sources    = var.addons.external_dns_config.sources
     })]
   }
   external_dns_route53_zone_arns = ["arn:aws:route53:::hostedzone/*"]

--- a/aws-eks-cluster/blueprints.tf
+++ b/aws-eks-cluster/blueprints.tf
@@ -288,12 +288,13 @@ module "other_addons" {
     chart_version = var.addons.external_dns_config.chart_version
     create_role   = true
     values = [templatefile("${path.module}/templates/external-dns/values.yaml", {
-      txtOwnerId = local.cluster_name
-      txtSuffix  = local.cluster_name
-      txtPrefix  = ""
-      imageTag   = var.addons.external_dns_config.image_tag
-      policy     = var.addons.external_dns_config.policy
-      sources    = var.addons.external_dns_config.sources
+      txtOwnerId          = local.cluster_name
+      txtSuffix           = local.cluster_name
+      txtPrefix           = ""
+      imageTag            = var.addons.external_dns_config.image_tag
+      policy              = var.addons.external_dns_config.policy
+      sources             = var.addons.external_dns_config.sources
+      gatewayListenerSets = var.addons.external_dns_config.gateway_listener_sets
     })]
   }
   external_dns_route53_zone_arns = ["arn:aws:route53:::hostedzone/*"]

--- a/aws-eks-cluster/templates/external-dns/values.yaml
+++ b/aws-eks-cluster/templates/external-dns/values.yaml
@@ -20,6 +20,9 @@ extraArgs:
   - '--aws-batch-change-size=1000'
   - '--aws-zones-cache-duration=120s'
   - '--metrics-address=:7979'
+  %{~ if gatewayListenerSets ~}
+  - '--gateway-listener-sets'
+  %{~ endif ~}
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: '7979'

--- a/aws-eks-cluster/templates/external-dns/values.yaml
+++ b/aws-eks-cluster/templates/external-dns/values.yaml
@@ -20,9 +20,7 @@ extraArgs:
   - '--aws-batch-change-size=1000'
   - '--aws-zones-cache-duration=120s'
   - '--metrics-address=:7979'
-  %{~ if gatewayListenerSets ~}
   - '--gateway-listener-sets'
-  %{~ endif ~}
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: '7979'

--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -251,6 +251,9 @@ variable "addons" {
       image_tag     = optional(string, "v0.19.0")
       policy        = optional(string, "upsert-only")
       sources       = optional(list(string), ["service", "ingress", "gateway-httproute"])
+      # Publish DNS for HTTPRoutes attached to a Gateway API ListenerSet (vanity
+      # domains). Requires external-dns image_tag >= v0.21.0; leave false on older tags.
+      gateway_listener_sets = optional(bool, false)
     }), {})
     cert_manager_route53_hosted_zone_arns = optional(list(string), ["arn:aws:route53:::hostedzone/*"])
     cert_manager_config = optional(any, {

--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -247,13 +247,10 @@ variable "addons" {
       selector_terms      = list(any)
     }), null)
     external_dns_config = optional(object({
-      chart_version = optional(string, "1.18.0")
-      image_tag     = optional(string, "v0.19.0")
+      chart_version = optional(string, "1.21.1")
+      image_tag     = optional(string, "v0.21.0")
       policy        = optional(string, "upsert-only")
       sources       = optional(list(string), ["service", "ingress", "gateway-httproute"])
-      # Publish DNS for HTTPRoutes attached to a Gateway API ListenerSet (vanity
-      # domains). Requires external-dns image_tag >= v0.21.0; leave false on older tags.
-      gateway_listener_sets = optional(bool, false)
     }), {})
     cert_manager_route53_hosted_zone_arns = optional(list(string), ["arn:aws:route53:::hostedzone/*"])
     cert_manager_config = optional(any, {


### PR DESCRIPTION
## What

- Always pass `--gateway-listener-sets` to external-dns (no opt-in flag).
- Bump external-dns defaults to the first release that supports it: `image_tag` `v0.19.0` → **`v0.21.0`**, `chart_version` `1.18.0` → **`1.21.1`**.

## Why

external-dns' `gateway-httproute` source only publishes DNS for HTTPRoutes attached **directly to a Gateway**. Vanity domains at CZI attach their HTTPRoute to a **ListenerSet** (so a tenant can add a listener + cert to the shared Gateway), and external-dns skips those — today the vanity CNAME has to be created by hand.

`--gateway-listener-sets` makes external-dns follow a route's ListenerSet parent to its Gateway and publish the record automatically. (cert-manager is already ListenerSet-aware via `enableGatewayAPIListenerSet`.)

The flag only exists in external-dns **≥ v0.21.0**, so the default image is moved up in the same change to keep the module self-consistent (an older image would crash on the unknown argument).

## Impact

Consumers pinned to the `aws-eks-cluster-v8` ref pick this up on their next apply: external-dns rolls to v0.21.0 and starts publishing ListenerSet/vanity hostnames automatically. No per-cluster config change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)