### PR TITLE
fix(aws-eks-cluster): grant external-dns RBAC to read ListenerSets

### DIFF
--- a/aws-eks-cluster/templates/external-dns/values.yaml
+++ b/aws-eks-cluster/templates/external-dns/values.yaml
@@ -21,6 +21,16 @@ extraArgs:
   - '--aws-zones-cache-duration=120s'
   - '--metrics-address=:7979'
   - '--gateway-listener-sets'
+rbac:
+  additionalPermissions:
+    - apiGroups:
+        - gateway.networking.k8s.io
+      resources:
+        - listenersets
+      verbs:
+        - get
+        - list
+        - watch
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: '7979'


### PR DESCRIPTION
## What

Grant the external-dns ClusterRole read access to `listenersets.gateway.networking.k8s.io` (get/list/watch) via `rbac.additionalPermissions`.

## Why

#887 set `--gateway-listener-sets` on external-dns by default, but the upstream chart only generates RBAC for the configured `sources` (gateways, httproutes) — it has no rule for `listenersets`, which that flag requires. So external-dns can't list ListenerSets, and DNS for ListenerSet-attached routes (the self-serve vanity-domain feature) is silently never published.

Found while testing #887 on dev-core-platform: external-dns v0.21.0 came up healthy and reconciling, but `kubectl auth can-i list listenersets.gateway.networking.k8s.io --as=system:serviceaccount:external-dns:external-dns-sa` returned `no`. The ClusterRole had `gateways` + `httproutes` but not `listenersets`.

## Change

Add to `templates/external-dns/values.yaml`:
```yaml
rbac:
  additionalPermissions:
    - apiGroups: [gateway.networking.k8s.io]
      resources: [listenersets]
      verbs: [get, list, watch]
```

## Validation

`helm template external-dns/external-dns --version 1.21.1 --set rbac.additionalPermissions...` confirms the rendered ClusterRole gains the `listenersets` rule. Pairs with #887; rolls out via the moving `aws-eks-cluster-v8` tag on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
