### PR TITLE
fix(aws-eks-cluster): bump aws-efs-csi-driver chart to 3.4.1 for startup-taint removal fix

### DIFF
--- a/aws-eks-cluster/blueprints.tf
+++ b/aws-eks-cluster/blueprints.tf
@@ -248,7 +248,7 @@ module "other_addons" {
   enable_kube_prometheus_stack          = var.addons.enable_kube_prometheus_stack // conflicts with rancher monitoring (prometheus-operator)
   enable_aws_efs_csi_driver             = var.addons.enable_aws_efs_csi_driver
   aws_efs_csi_driver = {
-    chart_version = "3.1.2"
+    chart_version = "3.4.1"
   }
 
   cert_manager_route53_hosted_zone_arns = var.addons.cert_manager_route53_hosted_zone_arns


### PR DESCRIPTION
Ticket: [CCIE-6972](https://czi.atlassian.net/browse/CCIE-6972)

## Problem

On staging-bhp, a Karpenter GPU NodeClaim (on-demand g5.4xlarge) sat in `Ready=Unknown` for 17 days. The node itself booted fine and its `efs-csi-node` pod ran 3/3 the entire time — but the `efs.csi.aws.com/agent-not-ready:NoSchedule` startup taint was never removed. That one leftover taint had two compounding effects:

- No workload could ever schedule on the node; it ran nothing but DaemonSets for its entire life.
- Karpenter never saw `Initialized=True`, so its disruption engine refused to touch the node — it could not be consolidated despite being empty, and its pending `AMIDrift` replacement was blocked (`DisruptionBlocked: Node isn't initialized`).

The net result was an idle on-demand GPU instance that no automation could reclaim, invisible to both the scheduler and Karpenter, until a human noticed.

## Why it happens

aws-efs-csi-driver v2.1.1 (chart 3.1.2, pinned here) has a known race: the driver's taint-removal patch can be silently lost when it races the node lifecycle controller during startup, and the driver trusts its own patch without checking the result (kubernetes-sigs/aws-efs-csi-driver#1320, aws/karpenter-provider-aws#7595, aws/containers-roadmap#2470). Driver v2.3.0 fixed this by verifying the taint is actually gone after the patch and retrying until it is (kubernetes-sigs/aws-efs-csi-driver#1774).

## Change

Bump the aws-efs-csi-driver helm chart from 3.1.2 (driver v2.1.1) to 3.4.1 (driver v2.3.1) — the newest chart on the v2.x driver line, containing the taint-removal verification fix. Deliberately not jumping to chart 4.x / driver v3.x: this takes the bug fix without a major-version driver upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CCIE-6972]: https://czi.atlassian.net/browse/CCIE-6972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ