### PR TITLE
feat(aws-eks-cluster): opt-in cilium startup taint on the default NodePool

### DIFF
--- a/aws-eks-cluster/karpenter.tf
+++ b/aws-eks-cluster/karpenter.tf
@@ -124,6 +124,22 @@ locals {
 
   custom_nodepool_spec    = try(var.addons.karpenter_nodepool_spec, null)
   effective_nodepool_spec = local.custom_nodepool_spec != null ? local.custom_nodepool_spec : local.default_nodepool_spec
+
+  cilium_startup_taints = [
+    {
+      "key"    = "node.cilium.io/agent-not-ready"
+      "effect" = "NoSchedule"
+    }
+  ]
+  final_nodepool_spec = merge(local.effective_nodepool_spec, {
+    "template" = merge(local.effective_nodepool_spec.template, {
+      "spec" = merge(
+        local.effective_nodepool_spec.template.spec,
+        { for k, v in { "startupTaints" = local.cilium_startup_taints } : k => v
+        if try(var.addons.karpenter_declare_cilium_startup_taint, false) }
+      )
+    })
+  })
 }
 
 resource "random_id" "node_pool_name" {
@@ -131,7 +147,7 @@ resource "random_id" "node_pool_name" {
   prefix      = "nodepool-"
   keepers = {
     # Regenerate nodepool definition every time spec changes
-    version = yamlencode(local.effective_nodepool_spec)
+    version = yamlencode(local.final_nodepool_spec)
   }
   lifecycle {
     create_before_destroy = true
@@ -148,7 +164,7 @@ resource "kubectl_manifest" "karpenter_nodepool" {
     "metadata" = {
       "name" = random_id.node_pool_name.hex
     }
-    "spec" = local.effective_nodepool_spec
+    "spec" = local.final_nodepool_spec
   })
   force_new = true
   depends_on = [

--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -196,7 +196,7 @@ variable "placement_group_strategy" {
 }
 
 variable "addons" {
-  description = "Map of addon definitions to create"
+  description = "Map of addon definitions to create. karpenter_declare_cilium_startup_taint adds node.cilium.io/agent-not-ready (NoSchedule) to the NodePool startupTaints so Karpenter's scheduling simulation waits for the cilium agent instead of double-provisioning; it merges into the effective spec, so it also applies on top of a karpenter_nodepool_spec override (overwriting any startupTaints the override defines). Enabling it changes the NodePool spec hash and therefore replaces the NodePool: every node on the pool drains in parallel (PDBs honored only until terminationGracePeriod). Opt in per cluster as a planned change."
   type = object({
     enable_guardduty                    = optional(bool, false)
     enable_aws_load_balancer_controller = optional(bool, true)
@@ -239,9 +239,10 @@ variable "addons" {
     karpenter_config = optional(any, {
       chart_version = "1.6.1"
     })
-    karpenter_nodepool_spec               = optional(any, null)
-    karpenter_ami_selector_terms          = optional(list(any), [{ alias = "al2023@latest" }])
-    enable_karpenter_capacity_reservation = optional(bool, false)
+    karpenter_nodepool_spec                = optional(any, null)
+    karpenter_declare_cilium_startup_taint = optional(bool, false)
+    karpenter_ami_selector_terms           = optional(list(any), [{ alias = "al2023@latest" }])
+    enable_karpenter_capacity_reservation  = optional(bool, false)
     karpenter_capacity_reservation = optional(object({
       ec2_node_class_name = optional(string, "odcr")
       selector_terms      = list(any)


### PR DESCRIPTION
## Summary

cilium-operator taints every joining node `node.cilium.io/agent-not-ready` while the agent boots, but the default NodePool never declares it in `startupTaints` — Karpenter's simulation assumes new nodes are immediately schedulable, the triggering pods can't bind when the taint appears, and the provisioner launches duplicates ~20–30s apart. Measured: 72% redundant nodeclaim creations on dev-bhp (karpenter-lens), ~68% on dev-sc (41 launches / 13 bursts / zero singletons in 7d of events). Declaring the taint makes the simulation wait for the agent.

- `addons.karpenter_declare_cilium_startup_taint` (default **false**) — a bool, not a taint list: the tuple lives in one place, matching exactly what cilium-operator applies (NoSchedule, no value; operator removes by key — verified against deployed v1.18.3 source).
- Merges on `effective_nodepool_spec`, so full `karpenter_nodepool_spec` override clusters opt in with the same line — required, since the override ternary needs same-shaped objects and cannot add the key itself.
- The false branch renders byte-identical YAML, so the `random_id` pool-name keeper does not move: unopted clusters see zero diff under the moving v8 tag.
- Opting in replaces the NodePool → all its nodes drain in parallel (PDBs honored only until terminationGracePeriod). Per-cluster planned change; semantics documented in the variable description.

## Test plan

Real plans against a live consumer (dev-cilium-test, TF 1.9.8, module source pointed at this branch): bool unset → zero karpenter diff (drift list identical to the unmodified module, `random_id` refreshes unchanged); bool true → exactly `random_id.node_pool_name` + `kubectl_manifest.karpenter_nodepool` replaced, rendered manifest carries the taint. A matching all-nodes stuck-taint alert ships in core-platform-infra #530 before the first measured pilot.
