### PR TITLE
fix: each cluster needs its own service linked role

### DIFF
--- a/aws-eks-cluster/karpenter.tf
+++ b/aws-eks-cluster/karpenter.tf
@@ -1,4 +1,5 @@
 resource "aws_iam_service_linked_role" "ec2_spot" {
+  custom_suffix    = "${var.cluster_name}-${var.tags.project}-${var.tags.env}-${var.tags.service}"
   aws_service_name = "spot.amazonaws.com"
 }
 


### PR DESCRIPTION
### Summary

Resolves:


```
* Failed to execute "terraform apply -no-color -auto-approve -input=false" in ./eks/.terragrunt-cache/ywtHD-rHoLuQMkKQxXN2Wygd2Ww/a43E4Oqk_mnXwUbWzwognPIO2Ko
  
  Error: creating IAM Service Linked Role (spot.amazonaws.com): operation error IAM: CreateServiceLinkedRole, https response error StatusCode: 400, RequestID: 4f934822-83e9-4838-9718-62bdd157f710, InvalidInput: Service role name AWSServiceRoleForEC2Spot has been taken in this account, please try a different suffix.
  
    with module.eks-cluster-v2.aws_iam_service_linked_role.ec2_spot,
    on .terraform/modules/eks-cluster-v2/aws-eks-cluster/karpenter.tf line 1, in resource "aws_iam_service_linked_role" "ec2_spot":
     1: resource "aws_iam_service_linked_role" "ec2_spot" {
  
  
  exit status 1
Error: Process completed with exit code 1.

```



### References

* https://github.com/chanzuckerberg/cztack/pull/832/changes
* https://github.com/chanzuckerberg/argus-infra-stacks/actions/runs/30039435740/job/89335015759
