### PR TITLE
fix(aws-eks-cluster): make EC2 Spot service-linked role opt-out per cluster

### DIFF
--- a/aws-eks-cluster/karpenter.tf
+++ b/aws-eks-cluster/karpenter.tf
@@ -1,6 +1,16 @@
+# AWSServiceRoleForEC2Spot is account-global: only one may exist per account and it
+# does not accept a custom suffix. When several clusters share an account, exactly one
+# should own the role. Set create_ec2_spot_service_linked_role = false on the others.
 resource "aws_iam_service_linked_role" "ec2_spot" {
-  custom_suffix    = "${var.cluster_name}-${var.tags.project}-${var.tags.env}-${var.tags.service}"
+  count            = var.create_ec2_spot_service_linked_role ? 1 : 0
   aws_service_name = "spot.amazonaws.com"
+}
+
+# Existing clusters manage the role at the unindexed address. Adopt it into the
+# counted address so enabling the toggle does not destroy and recreate the role.
+moved {
+  from = aws_iam_service_linked_role.ec2_spot
+  to   = aws_iam_service_linked_role.ec2_spot[0]
 }
 
 locals {

--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -334,3 +334,9 @@ variable "aws_org_id" {
   description = "The org ID this cluster will be in. May be used in assume roles and pathfinding."
   default     = "o-56v5gp5fcu"
 }
+
+variable "create_ec2_spot_service_linked_role" {
+  type        = bool
+  description = "Whether to create the account-global AWSServiceRoleForEC2Spot service-linked role. Only one may exist per account, so set this to false on additional clusters that share an account with a cluster that already owns the role."
+  default     = true
+}


### PR DESCRIPTION
## Overview

`AWSServiceRoleForEC2Spot` is an account-global singleton. AWS permits exactly one per account, and it does not accept a custom suffix. The `aws-eks-cluster` module manages this role in per-cluster state, so any second cluster in an account collides with the first. Every prior attempt failed against this constraint:

- The unconditional resource (#832) fails on the second cluster with `AWSServiceRoleForEC2Spot has been taken in this account`.
- The custom-suffix approach (#897) fails outright with `Custom suffix is not allowed for spot.amazonaws.com`.
- The earlier data-source `count` (#826) flip-flopped between create and destroy on successive applies.

## Solution

Gate the role behind a new `create_ec2_spot_service_linked_role` variable, defaulting to `true`. One cluster per account owns the role and the rest opt out by setting it to `false`. The decision is a plan-time variable, so it never flip-flops. Existing single-cluster accounts are unaffected by the default. A `moved` block adopts the existing unindexed resource into the counted address so enabling the toggle does not destroy and recreate the live role.

## Impact

Accounts with multiple clusters can now apply. The owning cluster keeps the role. Secondary clusters set `create_ec2_spot_service_linked_role = false`.

## References

- Reverts the approach in #897
- Failing apply: https://github.com/chanzuckerberg/argus-infra-stacks/actions/runs/30047212399/job/89341154732