### PR TITLE
feat: allow new Github OIDC subject format

### DIFF
--- a/aws-iam-role-github-action/README.md
+++ b/aws-iam-role-github-action/README.md
@@ -18,6 +18,19 @@ Where `role-to-assume` is the ARN of the role this module creates.
 
 NOTE: this module doesn't manage the role's permissions. Users of this module should handle these separately with an eye towards CI/CD least privilege.
 
+## OIDC subject claim formats
+
+GitHub issues the token's `sub` claim in one of two formats:
+
+| Format | Example |
+|------|---------|
+| Legacy (name only) | `repo:octo-org/octo-repo:ref:refs/heads/main` |
+| [Immutable](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims) (name plus IDs) | `repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main` |
+
+Repos created, renamed, or transferred after 2026-07-15 use the immutable format, as do repos that opt in through the org or repo OIDC settings. Everything else keeps the legacy format. The two are not interchangeable — the immutable format inserts `@OWNER-ID` ahead of the `/`, so a trust policy written for one format rejects the other.
+
+This module's trust policy accepts both, so a repo switching formats keeps its access without a Terraform change. You still authorize repos by name; the owner and repo IDs are wildcarded.
+
 
 <!-- START -->
 ## Requirements

--- a/aws-iam-role-github-action/main.tf
+++ b/aws-iam-role-github-action/main.tf
@@ -34,10 +34,30 @@ data "aws_iam_policy_document" "assume_role" {
       condition {
         test     = "StringLike"
         variable = "${local.idp}:sub"
-        values = formatlist(
-          "repo:%s/%s:*",
-          statement.key,
-          statement.value,
+
+        // GitHub mints subject claims in two shapes and they are not
+        // interchangeable: the immutable format inserts @OWNER-ID ahead of the "/",
+        // so a legacy pattern can never match an immutable subject. Match both, or a
+        // repo that switches formats loses access. Repos created, renamed, or
+        // transferred after 2026-07-15 use the immutable format; older repos keep
+        // the legacy one until they opt in.
+        // https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims
+        //
+        // The owner and repo IDs are wildcarded since callers authorize repos by
+        // name, which keeps this module's trust model unchanged across the switch.
+        // Neither pattern matches the other's format, so listing both grants no
+        // access beyond the named org and repos.
+        values = concat(
+          formatlist(
+            "repo:%s/%s:*",
+            statement.key,
+            statement.value,
+          ),
+          formatlist(
+            "repo:%s@*/%s@*:*",
+            statement.key,
+            statement.value,
+          ),
         )
       }
     }


### PR DESCRIPTION
## Summary

GitHub now mints OIDC subject claims in two incompatible shapes. The immutable format inserts `@OWNER-ID` ahead of the `/` (`repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main`), so the name-only pattern this module emitted can never match it. Any repo created, renamed, or transferred after 2026-07-15 — or opted in via org/repo OIDC settings — gets the immutable subject and fails `sts:AssumeRoleWithWebIdentity` with `AccessDenied` against every role this module builds.

The trust policy now lists both patterns in the same `StringLike` condition, so a repo keeps access regardless of which format GitHub hands it, with no Terraform change at the switchover.

- No new inputs and no change to how callers authorize repos: `authorized_github_repos` stays name-based, and the owner/repo IDs are wildcarded (`repo:ORG@*/REPO@*:*`).
- Deliberately not pinning IDs. Doing so would require every caller to look up numeric IDs, and this module has never offered anti-name-recycling protection, so this preserves the existing trust model rather than tightening it.
- Additive to existing roles — the legacy pattern is byte-for-byte unchanged, so no currently-working repo is affected.

## Review focus

- **The two patterns are disjoint, which is the security crux.** Listing both grants nothing beyond the named org and repos: the immutable pattern requires a literal `@` after the org name, which a legacy subject never contains, and GitHub org and repo names cannot contain `@`. Worth a second opinion.
- **The org-wildcard case.** `{ evolutionaryscale = ["*"] }` renders `repo:evolutionaryscale@*/*@*:*`. The trailing `@*` still forces a literal `@`, so this matches only immutable subjects within that org and does not widen the grant.
- **Whether wildcarded IDs are the right call** versus offering an opt-in to pin them, given the immutable format exists specifically to close the name-recycling hole.

## Test plan

- `terraform validate` and `terraform fmt -check` pass on the module.
- Rendered the `concat` + `formatlist` expression against both a named-repo map and an org wildcard, confirming the emitted values:
  - `repo:chanzuckerberg/cztack:*` and `repo:chanzuckerberg@*/cztack@*:*`
  - `repo:evolutionaryscale/*:*` and `repo:evolutionaryscale@*/*@*:*`
- Hand-traced IAM `StringLike` matching for a real immutable subject (`repo:evolutionaryscale@123456/new-repo@456789:ref:refs/heads/main`) and confirmed the legacy pattern rejects it while the new one matches.
- No `.tftest.hcl` added: this module has no test today, and assertions would need AWS credentials to resolve `aws_caller_identity`. Happy to add one if reviewers want it.

## References

- [Immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) (note the June 10 edit changing the delimiter from `-` to `@`)
- [GitHub OIDC reference: immutable subject claims](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims)
