### PR TITLE
feat(aws-eks-cluster): pick up immutable GitHub OIDC subject claims

### DIFF
--- a/aws-eks-cluster/README.md
+++ b/aws-eks-cluster/README.md
@@ -1,3 +1,23 @@
+# AWS EKS Cluster
+
+## GitHub Actions role and OIDC subject claims
+
+When `authorized_github_repos` is set, this module creates a `gh_actions_*` role via
+[`aws-iam-role-github-action`](../aws-iam-role-github-action), granting the listed repos ECR push and
+`eks:DescribeCluster` access.
+
+That role's trust policy accepts both OIDC subject claim formats GitHub issues:
+
+| Format | Example |
+|------|---------|
+| Legacy (name only) | `repo:octo-org/octo-repo:ref:refs/heads/main` |
+| [Immutable](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims) (name plus IDs) | `repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main` |
+
+Repos created, renamed, or transferred after 2026-07-15 get the immutable format; everything else keeps
+the legacy one. The two are not interchangeable, so both are matched. Note that an org-wide entry such as
+`{ chanzuckerberg = ["*"] }` covers new repos in that org under either format, but only from
+`aws-eks-cluster` v8.20.3 onward — earlier versions match the legacy format alone.
+
 <!-- START -->
 ## Requirements
 

--- a/aws-eks-cluster/README.md
+++ b/aws-eks-cluster/README.md
@@ -1,23 +1,3 @@
-# AWS EKS Cluster
-
-## GitHub Actions role and OIDC subject claims
-
-When `authorized_github_repos` is set, this module creates a `gh_actions_*` role via
-[`aws-iam-role-github-action`](../aws-iam-role-github-action), granting the listed repos ECR push and
-`eks:DescribeCluster` access.
-
-That role's trust policy accepts both OIDC subject claim formats GitHub issues:
-
-| Format | Example |
-|------|---------|
-| Legacy (name only) | `repo:octo-org/octo-repo:ref:refs/heads/main` |
-| [Immutable](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims) (name plus IDs) | `repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main` |
-
-Repos created, renamed, or transferred after 2026-07-15 get the immutable format; everything else keeps
-the legacy one. The two are not interchangeable, so both are matched. Note that an org-wide entry such as
-`{ chanzuckerberg = ["*"] }` covers new repos in that org under either format, but only from
-`aws-eks-cluster` v8.20.3 onward — earlier versions match the legacy format alone.
-
 <!-- START -->
 ## Requirements
 

--- a/aws-eks-cluster/gh_action_role.tf
+++ b/aws-eks-cluster/gh_action_role.tf
@@ -3,6 +3,9 @@ locals {
   role_name = "gh_actions_${local.namespace}"
 }
 
+// This role's trust policy comes from the submodule below. release-please versions
+// each module directory independently and does not follow relative-path deps, so a
+// submodule fix only reaches aws-eks-cluster consumers once this module is released.
 module "gh_actions_role" {
   count  = length(var.authorized_github_repos) + length(var.authorized_aws_accounts) == 0 ? 0 : 1
   source = "../aws-iam-role-github-action"


### PR DESCRIPTION
## Summary

Cuts an `aws-eks-cluster` release so the sliding `aws-eks-cluster-v8` tag picks up the immutable OIDC subject claim fix from #902.

#902 fixed `aws-iam-role-github-action`, which `aws-eks-cluster` consumes through the relative path `../aws-iam-role-github-action`. release-please versions each module directory independently and does not follow relative-path dependencies, so it cut `aws-iam-role-github-action-v0.2.0` and root `v0.126.0` but left `aws-eks-cluster-v8` pointing at `a0541a7` — a build whose trust policy only matches the legacy name-only subject.

The practical effect, confirmed against a `prod-eks` apply after #902 merged: `module.eks-cluster.module.gh_actions_role[0].aws_iam_role.role` planned as **no-op**, and the live trust policy still reads `repo:chanzuckerberg/*:*`, `repo:czbiohub-sf/*:*`, `repo:czi-ai/*:*`. Since those are org-wide wildcards, any repo created in those orgs after 2026-07-15 currently cannot assume its `gh_actions_*` role for ECR pushes or `eks:DescribeCluster`.

## Why this is a comment and not an empty commit

The behavior fix rides along from the submodule, so there is no functional change to make here — the only job is getting the tag to move. That still requires touching a file under `aws-eks-cluster/`:

- release-please splits commits by path, so an empty commit is attributed to no package, and when it is the newest commit **nothing** is released ([release-please#1360](https://github.com/googleapis/release-please/issues/1360)).
- A `Release-As:` footer is worse: in manifest mode it forces that version onto every configured package ([release-please#2472](https://github.com/googleapis/release-please/issues/2472)), which across 94 modules would be a mess.

Touching a file in the component path is the maintainer-recommended workaround. The three-line comment records why this module gets released when the submodule changes, which is the non-obvious constraint that caused this bug.

## Review focus

- **Confirm the tag actually moves.** `aws-eks-cluster` is at 8.20.2 in the manifest, so a `fix:` should yield 8.20.3. That is the entire point of the PR; if release-please does not pick it up, this needs a different trigger.
- **Whether this gap deserves a systemic fix.** Every module consuming another via a relative path can silently ship stale dependency code; `aws-eks-cluster` is just the one that bit us. A dependency-aware release config or a lint check would prevent the next instance.

## Test plan

- `terraform fmt -check` passes on `aws-eks-cluster`.
- Net diff against `main` is three comment lines in `gh_action_role.tf` and nothing else.
- Verified `git diff v0.124.1..v0.126.0 -- aws-iam-role-github-action/main.tf` contains exactly the dual-format `concat`, and that no other module changed between those tags.
- After merge, confirm `git rev-list -n1 aws-eks-cluster-v8` contains `51a65f2`, then re-plan `prod-eks` and expect an in-place `assume_role_policy` update on `module.gh_actions_role[0].aws_iam_role.role` adding the `@*/` patterns.

## References

- #902 — the underlying fix
- [chanzuckerberg/core-platform-infra#536](https://github.com/chanzuckerberg/core-platform-infra/pull/536) — companion ref bump for the one direct consumer
- [Immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)
- CCIE-7088
