### PR TITLE
feat(aws-iam-role-github-action): support granular OIDC claim conditions on trust policy

### DIFF
--- a/aws-iam-role-github-action/README.md
+++ b/aws-iam-role-github-action/README.md
@@ -31,20 +31,51 @@ Repos created, renamed, or transferred after 2026-07-15 use the immutable format
 
 This module's trust policy accepts both, so a repo switching formats keeps its access without a Terraform change. You still authorize repos by name; the owner and repo IDs are wildcarded.
 
+## Restricting to specific workflows
+
+By default an authorized repo can assume the role from any workflow, branch, or tag, because the trust policy only matches the `sub` claim as `repo:<org>/<repo>:*`. To scope the role to a specific workflow, use `authorized_github_repo_conditions` to add conditions on other GitHub OIDC claims. The most common is [`job_workflow_ref`](https://docs.github.com/en/actions/concepts/security/openid-connect#understanding-the-oidc-token), which identifies the top-level workflow file and ref that ran the job.
+
+```hcl
+module "role" {
+  source = "github.com/chanzuckerberg/cztack//aws-iam-role-github-action?ref=vX.Y.Z"
+
+  role = { name = "my-deploy-role" }
+  tags = var.tags
+
+  authorized_github_repos = {
+    chanzuckerberg = ["my-repo", "other-repo"]
+  }
+
+  authorized_github_repo_conditions = {
+    chanzuckerberg = {
+      my-repo = [{
+        test   = "StringLike"
+        claim  = "job_workflow_ref"
+        values = ["chanzuckerberg/my-repo/.github/workflows/deploy.yml@refs/heads/main"]
+      }]
+    }
+  }
+}
+```
+
+Here `other-repo` stays unrestricted, while `my-repo` may only assume the role from `deploy.yml` on `main`. Each condition is ANDed onto that repo's trust statement, and `claim` is a bare claim name that the module prefixes with the OIDC provider hostname. Every org and repo referenced in `authorized_github_repo_conditions` must also appear in `authorized_github_repos`.
+
+The reason conditions are keyed per repo is that IAM ANDs conditions within a single statement but ORs separate statements. This module emits one trust statement per authorized repo, so a condition only narrows the repo it is attached to. Adding a broadly scoped statement for the same repo elsewhere would OR back in the access you were trying to remove.
+
 
 <!-- START -->
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.45 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.58.0 |
 
 ## Modules
 
@@ -53,7 +84,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -62,16 +93,17 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_assume_role_policies_json"></a> [additional\_assume\_role\_policies\_json](#input\_additional\_assume\_role\_policies\_json) | The JSON string of any other additional assume role policies to add to the Github Actions role | `string` | `""` | no |
 | <a name="input_authorized_aws_accounts"></a> [authorized\_aws\_accounts](#input\_authorized\_aws\_accounts) | The map of authorized AWS accounts to assume the created role. | `map(string)` | `{}` | no |
-| <a name="input_authorized_github_repos"></a> [authorized\_github\_repos](#input\_authorized\_github\_repos) | A map that specifies the authorized repos to assume the created role.<br>  Keys specify the name of the GitHub org.<br>  Values specify the authorized repos within that org. | `map(list(string))` | n/a | yes |
-| <a name="input_role"></a> [role](#input\_role) | Configure the AWS IAM Role. | <pre>object({<br>    name : string,<br>  })</pre> | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Standard tagging. | <pre>object({<br>    env : string,<br>    owner : string,<br>    managedBy : string,<br>    project : string<br>    service : string<br>  })</pre> | n/a | yes |
+| <a name="input_authorized_github_repo_conditions"></a> [authorized\_github\_repo\_conditions](#input\_authorized\_github\_repo\_conditions) | Optional additional OIDC claim conditions applied per authorized repo.<br/>  The outer key is the GitHub org and the inner key is the repo; both must also<br/>  appear in authorized\_github\_repos. Each condition constrains a GitHub OIDC<br/>  token claim (for example job\_workflow\_ref) and is ANDed onto that repo's trust<br/>  statement, narrowing which workflows may assume the role. claim is a bare claim<br/>  name; the module prefixes it with the GitHub OIDC provider hostname. | <pre>map(map(list(object({<br/>    test   = string<br/>    claim  = string<br/>    values = list(string)<br/>  }))))</pre> | `{}` | no |
+| <a name="input_authorized_github_repos"></a> [authorized\_github\_repos](#input\_authorized\_github\_repos) | A map that specifies the authorized repos to assume the created role.<br/>  Keys specify the name of the GitHub org.<br/>  Values specify the authorized repos within that org. | `map(list(string))` | n/a | yes |
+| <a name="input_role"></a> [role](#input\_role) | Configure the AWS IAM Role. | <pre>object({<br/>    name : string,<br/>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Standard tagging. | <pre>object({<br/>    env : string,<br/>    owner : string,<br/>    managedBy : string,<br/>    project : string<br/>    service : string<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_role"></a> [role](#output\_role) | n/a |
 <!-- END -->

--- a/aws-iam-role-github-action/main.tf
+++ b/aws-iam-role-github-action/main.tf
@@ -3,6 +3,30 @@ data "aws_caller_identity" "current" {}
 locals {
   idp     = "token.actions.githubusercontent.com"
   idp_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.idp}"
+
+  authorized_repos = {
+    for pair in flatten([
+      for org, repos in var.authorized_github_repos : [
+        for repo in repos : { org = org, repo = repo }
+      ]
+    ]) : "${pair.org}/${pair.repo}" => pair
+  }
+
+  condition_repo_keys = flatten([
+    for org, repos in var.authorized_github_repo_conditions : [
+      for repo in keys(repos) : "${org}/${repo}"
+    ]
+  ])
+
+  unmatched_condition_keys = [
+    for key in local.condition_repo_keys : key
+    if !contains(keys(local.authorized_repos), key)
+  ]
+
+  statement_sids = [
+    for pair in values(local.authorized_repos) :
+    replace("Allow${pair.org}${pair.repo}ToAssumeRole", "/[^0-9A-Za-z]/", "")
+  ]
 }
 
 // https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-the-identity-provider-to-aws
@@ -21,10 +45,10 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
   dynamic "statement" {
-    for_each = var.authorized_github_repos
+    for_each = local.authorized_repos
 
     content {
-      sid = replace("Allow${statement.key}ToAssumeRole", "-", "")
+      sid = replace("Allow${statement.value.org}${statement.value.repo}ToAssumeRole", "/[^0-9A-Za-z]/", "")
       principals {
         type        = "Federated"
         identifiers = [local.idp_arn]
@@ -47,18 +71,20 @@ data "aws_iam_policy_document" "assume_role" {
         // name, which keeps this module's trust model unchanged across the switch.
         // Neither pattern matches the other's format, so listing both grants no
         // access beyond the named org and repos.
-        values = concat(
-          formatlist(
-            "repo:%s/%s:*",
-            statement.key,
-            statement.value,
-          ),
-          formatlist(
-            "repo:%s@*/%s@*:*",
-            statement.key,
-            statement.value,
-          ),
-        )
+        values = [
+          "repo:${statement.value.org}/${statement.value.repo}:*",
+          "repo:${statement.value.org}@*/${statement.value.repo}@*:*",
+        ]
+      }
+
+      dynamic "condition" {
+        for_each = try(var.authorized_github_repo_conditions[statement.value.org][statement.value.repo], [])
+
+        content {
+          test     = condition.value.test
+          variable = "${local.idp}:${condition.value.claim}"
+          values   = condition.value.values
+        }
       }
     }
   }
@@ -83,4 +109,16 @@ resource "aws_iam_role" "role" {
   # The other option would be to use name_prefix and create_before_destroy, but that
   # doesn't work if you want a role with a stable, memorable name.
   force_detach_policies = true
+
+  lifecycle {
+    precondition {
+      condition     = length(local.unmatched_condition_keys) == 0
+      error_message = "authorized_github_repo_conditions references org/repo pairs missing from authorized_github_repos: ${join(", ", local.unmatched_condition_keys)}"
+    }
+
+    precondition {
+      condition     = length(local.statement_sids) == length(distinct(local.statement_sids))
+      error_message = "authorized_github_repos produces colliding trust statement sids after stripping non-alphanumeric characters. Rename the offending repos or split them across roles."
+    }
+  }
 }

--- a/aws-iam-role-github-action/variables.tf
+++ b/aws-iam-role-github-action/variables.tf
@@ -37,3 +37,20 @@ variable "additional_assume_role_policies_json" {
   description = "The JSON string of any other additional assume role policies to add to the Github Actions role"
   default     = ""
 }
+
+variable "authorized_github_repo_conditions" {
+  type = map(map(list(object({
+    test   = string
+    claim  = string
+    values = list(string)
+  }))))
+  default     = {}
+  description = <<DESCRIPTION
+  Optional additional OIDC claim conditions applied per authorized repo.
+  The outer key is the GitHub org and the inner key is the repo; both must also
+  appear in authorized_github_repos. Each condition constrains a GitHub OIDC
+  token claim (for example job_workflow_ref) and is ANDed onto that repo's trust
+  statement, narrowing which workflows may assume the role. claim is a bare claim
+  name; the module prefixes it with the GitHub OIDC provider hostname.
+	DESCRIPTION
+}

--- a/aws-iam-role-github-action/versions.tf
+++ b/aws-iam-role-github-action/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 4.45"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
## Overview

An authorized repo can currently assume a GitHub Actions role from any workflow, branch, or tag, because the trust policy matches only the `sub` claim as `repo:<org>/<repo>:*`. There is no way to say that only one workflow file at one ref may assume the role. GitHub's OIDC token carries a `job_workflow_ref` claim that identifies the top-level workflow that ran the job, and constraining on it is the standard way to scope a CI role to a single deploy pipeline.

## Solution

Add an optional `authorized_github_repo_conditions` variable, keyed by org then repo, that appends arbitrary OIDC claim conditions to a repo's trust statement. It is generic over the claim, so `job_workflow_ref` is the common case but any claim works. The `claim` field is a bare name that the module prefixes with the OIDC provider hostname, so callers cannot typo it.

IAM ANDs conditions within a single statement but ORs separate statements, so a condition only narrows access if it sits in the same statement as the `sub` match for that repo. The federated trust statements are therefore split from one per org into one per repo, and each repo's conditions are ANDed onto its own statement. A repo with no conditions stays wide open exactly as before.

Two preconditions guard the footguns. One fails if a condition references an org or repo missing from `authorized_github_repos`, so a silently dropped restriction cannot masquerade as enforced. The other fails on colliding statement sids with a clear message instead of an opaque AWS `MalformedPolicyDocument`. Preconditions require Terraform 1.3, so `required_version` moves up from 1.0.

## Examples

### Restrict one repo, leave another open

Only `my-repo`'s `deploy.yml` on `main` is scoped down. `other-repo` keeps the default wide-open trust.

```hcl
authorized_github_repos = {
  chanzuckerberg = ["my-repo", "other-repo"]
}

authorized_github_repo_conditions = {
  chanzuckerberg = {
    my-repo = [{
      test   = "StringLike"
      claim  = "job_workflow_ref"
      values = ["chanzuckerberg/my-repo/.github/workflows/deploy.yml@refs/heads/main"]
    }]
  }
}
```

Produces two federated statements. The restricted one ANDs `job_workflow_ref` onto `sub`:

```json
{
  "Sid": "AllowchanzuckerbergmyrepoToAssumeRole",
  "Effect": "Allow",
  "Principal": { "Federated": "arn:aws:iam::<acct>:oidc-provider/token.actions.githubusercontent.com" },
  "Action": ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"],
  "Condition": {
    "StringLike": {
      "token.actions.githubusercontent.com:sub": [
        "repo:chanzuckerberg/my-repo:*",
        "repo:chanzuckerberg@*/my-repo@*:*"
      ],
      "token.actions.githubusercontent.com:job_workflow_ref": [
        "chanzuckerberg/my-repo/.github/workflows/deploy.yml@refs/heads/main"
      ]
    }
  }
}
```

```json
{
  "Sid": "AllowchanzuckerbergotherrepoToAssumeRole",
  "Effect": "Allow",
  "Principal": { "Federated": "arn:aws:iam::<acct>:oidc-provider/token.actions.githubusercontent.com" },
  "Action": ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"],
  "Condition": {
    "StringLike": {
      "token.actions.githubusercontent.com:sub": [
        "repo:chanzuckerberg/other-repo:*",
        "repo:chanzuckerberg@*/other-repo@*:*"
      ]
    }
  }
}
```

### Multiple conditions on one repo

Every condition on a repo is ANDed, so all must hold. This pins both the workflow and the branch ref.

```hcl
authorized_github_repo_conditions = {
  chanzuckerberg = {
    my-repo = [
      {
        test   = "StringLike"
        claim  = "job_workflow_ref"
        values = ["chanzuckerberg/my-repo/.github/workflows/deploy.yml@refs/heads/main"]
      },
      {
        test   = "StringEquals"
        claim  = "ref"
        values = ["refs/heads/main"]
      },
    ]
  }
}
```

```json
"Condition": {
  "StringLike": {
    "token.actions.githubusercontent.com:sub": [
      "repo:chanzuckerberg/my-repo:*",
      "repo:chanzuckerberg@*/my-repo@*:*"
    ],
    "token.actions.githubusercontent.com:job_workflow_ref": [
      "chanzuckerberg/my-repo/.github/workflows/deploy.yml@refs/heads/main"
    ]
  },
  "StringEquals": {
    "token.actions.githubusercontent.com:ref": ["refs/heads/main"]
  }
}
```

## Impact

Effective access is unchanged for existing callers. A single-repo org produces a byte-identical statement and sid. A multi-repo org splits into one statement per repo, which shows as an assume-role policy diff on the next plan. Callers pin the module by tag, so this only lands when they bump the ref.

## References

- [GitHub OIDC token claims](https://docs.github.com/en/actions/concepts/security/openid-connect#understanding-the-oidc-token)