### PR TITLE
feat: retrigger release-please after GitHub outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ A few notes on writing test for this repo. Note that this is new ground for us, 
 ## Code of Conduct
 
 This project adheres to the Contributor Covenant [code of conduct](https://github.com/chanzuckerberg/.github/blob/master/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. 
+By participating, you are expected to uphold this code.
 Please report unacceptable behavior to [opensource@chanzuckerberg.com](mailto:opensource@chanzuckerberg.com).


### PR DESCRIPTION
## Overview

release-please has not run on `main` since August 3. Yesterday's GitHub outage dropped the push events for the last two commits, so no run was ever created for them and the open release PR is stale.

Two older release-please runs are also still sitting in `queued` from the outage and will never be picked up.

## Solution

Land a no-op `feat:` commit on `main` to generate a fresh push event. Strips a trailing space from the README so the diff is effectively blank. The conventional commit type is what makes release-please pick it up and refresh the release PR.

## Impact

release-please runs again and the open release PR reflects everything currently on `main`. No module behavior changes.

## References

- [Open release PR #907](https://github.com/chanzuckerberg/cztack/pull/907)
- [release-please workflow runs](https://github.com/chanzuckerberg/cztack/actions/workflows/release-please.yml)