### PR TITLE
fix: ADI-236 - bucket acc status param changed

### DIFF
--- a/aws-s3-private-bucket/main.tf
+++ b/aws-s3-private-bucket/main.tf
@@ -58,8 +58,6 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
-  acceleration_status = var.transfer_acceleration ? "Enabled" : "Suspended"
-
   # dynamic block used instead of simply assigning a variable b/c lifecycle_rule is configuration block
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules
@@ -120,6 +118,13 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   tags = local.tags
+}
+
+resource "aws_s3_bucket_accelerate_configuration" "bucket" {
+  count = var.transfer_acceleration ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket.id
+  status = "Enabled"
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {


### PR DESCRIPTION
### Summary
Have a bucket that we are trying to disable this for, as its a feature thats not supported in every region. However, this parma has changed since the module was last authored

## Changes Made
1. Removed deprecated parameter ([line 61](vscode-webview://13uv54p19dqbfud53o49eit3dmnnhgijeoes3860mka5p2tvqe7s/aws-s3-private-bucket/main.tf#L61)): Removed acceleration_status = var.transfer_acceleration ? "Enabled" : "Suspended" from the aws_s3_bucket resource
2. Added separate configuration resource ([lines 123-128](vscode-webview://13uv54p19dqbfud53o49eit3dmnnhgijeoes3860mka5p2tvqe7s/aws-s3-private-bucket/main.tf#L123-L128)): Created a new aws_s3_bucket_accelerate_configuration resource that:
- Only creates when var.transfer_acceleration = true (using count)
- Sets status = "Enabled" when created
- Crucially: Does NOT create any resource when transfer_acceleration = false, avoiding the 405 MethodNotAllowed error in regions like eu-south-2 that don't support transfer acceleration

## Why This Fixes the Issue
The old implementation tried to set acceleration_status = "Suspended" even when transfer_acceleration = false. This caused errors in regions that don't support transfer acceleration at all (like eu-south-2), because AWS would reject the request with a 405 error. The new implementation only touches acceleration configuration when explicitly enabled, avoiding conflicts with regions that don't support this feature.
Sources:
- [aws_s3_bucket_accelerate_configuration | Terraform Registry](https://registry.terraform.io/providers/-/aws/6.9.0/docs/resources/s3_bucket_accelerate_configuration)
- [aws_s3_bucket_accelerate_configuration Issue #44012](https://github.com/hashicorp/terraform-provider-aws/issues/44012)
