### PR TITLE
feat(aws-eks-cluster): cluster_tags passthrough for per-cluster tags

### DIFF
--- a/aws-eks-cluster/main.tf
+++ b/aws-eks-cluster/main.tf
@@ -154,6 +154,8 @@ module "cluster" {
 
   tags = merge(var.tags, local.karpenter_discovery, local.karpenter_discovery_per_cluster)
 
+  cluster_tags = var.cluster_tags
+
   cluster_name              = local.cluster_name
   cluster_version           = local.cluster_version
   vpc_id                    = var.vpc_id

--- a/aws-eks-cluster/variables.tf
+++ b/aws-eks-cluster/variables.tf
@@ -87,6 +87,12 @@ variable "tags" {
   description = "Typically fogg's var.tags"
 }
 
+variable "cluster_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags applied only to the EKS cluster itself, e.g. GuardDutyManaged=false to opt the cluster out of GuardDuty agent auto-management"
+}
+
 // https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html
 // https://github.com/awslabs/amazon-eks-ami/releases
 variable "ami_release_version" {


### PR DESCRIPTION
## Summary

Exposes the upstream `terraform-aws-modules/eks` module's `cluster_tags` input (map, default `{}` — additive tags on the EKS cluster resource only). Motivation (CCIE-7191): GuardDuty's org-level EKS addon management force-installs the runtime agent into clusters whose VPCs lack a `guardduty-data` endpoint, leaving 48-pod DaemonSets in permanent NXDOMAIN crashloop (~13k restarts/day on prod-central alone). The documented opt-out is a `GuardDutyManaged=false` tag on the cluster — which must live in Terraform or the next apply strips it. A follow-up in argus-infra-stacks sets the tag on the five affected clusters.

No behavior change for existing consumers (default `{}`).

## Test plan

- `terraform validate` passes; upstream input verified present in eks module 19.16.0.
- Consumer PR (argus-infra-stacks) will show a tags-only in-place update on `aws_eks_cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)