### PR TITLE
feat: tag clusters GuardDutyManaged from enable_guardduty to control agent auto-management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
                 cache: true
                 cache-dependency-path: |
                     go.sum
-                go-version: '>=1.19.0'
                 go-version-file: go.mod
             - name: golangci-lint
               uses: golangci/golangci-lint-action@v9

--- a/aws-eks-cluster/main.tf
+++ b/aws-eks-cluster/main.tf
@@ -154,6 +154,8 @@ module "cluster" {
 
   tags = merge(var.tags, local.karpenter_discovery, local.karpenter_discovery_per_cluster)
 
+  cluster_tags = { GuardDutyManaged = var.addons.enable_guardduty ? "true" : "false" }
+
   cluster_name              = local.cluster_name
   cluster_version           = local.cluster_version
   vpc_id                    = var.vpc_id


### PR DESCRIPTION
## Problem

On 2026-08-20, GuardDuty EKS Runtime Monitoring with automated agent management was enabled at the account level for several CZI accounts. GuardDuty responded by installing its managed EKS add-on (`aws-guardduty-agent`, tagged `GuardDutyManaged=true`) into roughly 11 clusters. Every agent is crashlooping with `FailedToPingEndpoint https://guardduty-data.us-west-2.amazonaws.com/ping`, because those clusters' VPCs don't have the `guardduty-data` VPC endpoint. That endpoint is exactly the plumbing this module already provisions in `guardduty.tf`, but only when `addons.enable_guardduty = true`. The clusters GuardDuty auto-instrumented don't have that flag set, so they got an agent with nowhere to phone home — a degraded add-on and 45+ crashlooping pods per cluster, and the security feature not actually doing anything useful.

GuardDuty's automated agent management honors an AWS tag on the EKS cluster itself: clusters tagged `GuardDutyManaged=false` are excluded from agent install/management. This module already knows whether a cluster has the working GuardDuty plumbing — that's precisely `var.addons.enable_guardduty`. This PR derives the tag from that flag so the fleet becomes self-consistent: no plumbing means GuardDuty is told to stay out, and plumbing provisioned means GuardDuty is welcome.

## What changed

In `aws-eks-cluster/main.tf`, the inner `module "cluster"` call (terraform-aws-modules/eks v19.16.0) now passes:

```hcl
cluster_tags = { GuardDutyManaged = var.addons.enable_guardduty ? "true" : "false" }
```

I verified against the v19.16.0 module source (not assumed) that `cluster_tags` is a real input in that version, and that it's merged only onto the `aws_eks_cluster.this` resource's `tags` (alongside `var.tags`) — it does not touch node groups, IAM roles, or add-ons. The module didn't already pass `cluster_tags`, so this is a new argument rather than a merge into an existing one.

## Review focus

- `cluster_tags` is read in two places in terraform-aws-eks v19.16.0: it's merged into `aws_eks_cluster.this`'s `tags`, and it also feeds the `for_each` on `aws_ec2_tag.cluster_primary_security_group` (gated by `create_cluster_primary_security_group_tags`, which defaults to `true` and isn't overridden by this module), where it tags the cluster's EKS-managed primary security group. So every consumer's next plan should show two changes per cluster: an in-place `tags` update on `aws_eks_cluster.this`, and one new `aws_ec2_tag.cluster_primary_security_group["GuardDutyManaged"]` resource.
- Neither change is a destroy/replace — the `aws_eks_cluster` tags update is in place, and the `aws_ec2_tag` resource is purely additive.
- The ternary is exhaustive over both states of `enable_guardduty`, so there's no `null`/unset case to worry about — every cluster gets an explicit `true` or `false`.

## Rollout

This module is consumed via a floating version reference from other repos, so the tag rolls out on each consumer's next apply after this merges — there's no separate release step needed here.

Two things worth flagging:

1. This tag change does not remove add-ons GuardDuty already installed. The roughly 11 clusters that got `aws-guardduty-agent` installed before this fix will keep their crashlooping pods until someone runs `aws eks delete-addon --addon-name aws-guardduty-agent` against each affected cluster. That's a one-time manual follow-up, not something this PR automates.
2. This is a coordination point for whichever security team turned on Runtime Monitoring with automated agent management: if they want GuardDuty agents actually running on any of those clusters, the fix is to set `addons.enable_guardduty = true` for that cluster, which both flips this tag to `true` and provisions the VPC endpoint the agent needs to function.

No ticket is referenced here; one may be filed separately for the cleanup follow-up.

## Also included: CI lint fix

The lint job was failing repo-wide before this PR touched anything: setup-go was given both `go-version: '>=1.19.0'` and `go-version-file: go.mod`, and the former wins — resolving to Go 1.27 on the runners, which panics golangci-lint v2.11.3 (built with go1.26): `file requires newer Go version go1.27`. The second commit removes the floating range so the toolchain follows go.mod (go 1.26). This PR's own green lint check is the live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
