### PR TITLE
fix: pin lint Go toolchain to go.mod instead of floating latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
                 cache: true
                 cache-dependency-path: |
                     go.sum
-                go-version: '>=1.19.0'
                 go-version-file: go.mod
             - name: golangci-lint
               uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
## Problem

The `lint` job fails on every PR right now with golangci-lint panicking:

```
file requires newer Go version go1.27 (application built with go1.26)
```
exit code 2. This is repo-wide and unrelated to what the PR actually changes — for example #916, a one-line HCL change with no Go code, fails identically. Lint last passed on Aug 19, before Go 1.27 reached the GitHub-hosted runners.

## Root cause

The `actions/setup-go@v5` step in the `lint` job sets both:

```yaml
go-version: '>=1.19.0'
go-version-file: go.mod
```

Per `setup-go`'s documented precedence, an explicit `go-version` wins over `go-version-file`. The range `>=1.19.0` resolves to whatever the newest stable Go release is at the time the job runs — which recently became 1.27 on the runners. golangci-lint is pinned at v2.11.3, which is itself built with go1.26, and it panics when it encounters files that require a newer Go toolchain than it was built with.

## Fix

Delete the `go-version: '>=1.19.0'` line, leaving only `go-version-file: go.mod`. That pins the toolchain to this module's declared `go 1.26` directive instead of floating to "latest stable," so `setup-go` and golangci-lint stay in lockstep with what the repo actually declares.

This is the minimal durable fix: the toolchain now follows `go.mod`, which only moves when we deliberately bump it. Bumping golangci-lint to a version built with go1.27 would also unblock CI today, but it just chases the same race on the next Go release — this fixes the actual cause instead.

`ci.yml` has only one job with a `setup-go` step, so no other jobs needed the same fix.

## After merge

#916 and any other open PRs will need a rebase or a re-run of the lint job to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)