### PR TITLE
chore(aws-eks-cluster): correct v9.0.0 breaking-change notes to the shipped zero-drain behavior

### DIFF
--- a/aws-eks-cluster/CHANGELOG.md
+++ b/aws-eks-cluster/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* upgrading replaces the hash-named default NodePool with a stable "default" NodePool one time (every node on the old pool drains in parallel), and the default NodePool/EC2NodeClass become creation-time-only in Terraform; pre-enable the ArgoCD karpenter-default-nodepool app before upgrading so the new pool exists before the drain.
+* the default NodePool/EC2NodeClass become creation-time-only in Terraform and are owned by ArgoCD after creation; upgrading creates the stable "default" NodePool and freezes provisioning on the legacy hash-named pool in place (limits.cpu=0, no node drained) — capacity migrates via normal expireAfter rotation and consolidation, and the emptied legacy pool is removed by setting karpenter_legacy_nodepool = false.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Summary

The v9.0.0 changelog's BREAKING CHANGES entry describes the drain-based design from the first commit on #914 (release-please took that commit's footer), but the shipped code is the zero-drain revision: the legacy hash-named pool is kept and neutered in place (`limits.cpu=0`), no node drains at upgrade, and `karpenter_legacy_nodepool = false` removes the pool once empty. This rewrites the entry to match the code — validated in the nonprod soak (dev-cilium-test upgraded with `0 to destroy`; its legacy pool emptied via consolidation within 2 days).

Docs-only; `chore:` so release-please cuts nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)