### PR TITLE
chore: enable floating_tags for release-please-semvar

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,3 +19,4 @@ jobs:
         with:
             app_token: ${{ steps.generate_token.outputs.token }}
             include_component_in_tag: true
+            floating_tags: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
           app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
       - name: release please
-        uses: chanzuckerberg/github-actions/.github/actions/release-please-semvar@release-please-semvar-v0
+        uses: chanzuckerberg/github-actions/.github/actions/release-please-semvar@v6
         id: release
         with:
             app_token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,4 @@ jobs:
         id: release
         with:
             app_token: ${{ steps.generate_token.outputs.token }}
-            include_component_in_tag: true
             floating_tags: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "commit-search-depth": 1,
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "bump-minor-pre-major": true,
-  "monorepo-tags": true,
   "prerelease": false,
   "changelog-sections": [
     {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "include-component-in-tag": true,
   "commit-search-depth": 1,
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "bump-minor-pre-major": true,


### PR DESCRIPTION
Sets `floating_tags: true` on the release-please-semvar step so this repo continues to publish/advance its floating major/minor tag aliases.

The rewritten release-please-semvar action makes floating tags opt-in (default false). Without this flag, this repo would stop advancing its floating tags after adopting the new action, breaking any consumers that pin to those aliases.

Note: takes effect once chanzuckerberg/github-actions#635 is merged and the pinned action version advances to include the new input. Until then the extra input is ignored by the currently pinned action version.